### PR TITLE
SOL-22: rendre la qualité mesurable et traçable

### DIFF
--- a/db/patches/20260814_sol22_quality_intelligence.sql
+++ b/db/patches/20260814_sol22_quality_intelligence.sql
@@ -1,0 +1,236 @@
+-- SOL-22 - Qualite, metrologie et tracabilite mesurables.
+-- Additif, rejouable. Aucun indicateur n'est pre-calcule ni simule.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.quality_cause_catalog (
+  code text PRIMARY KEY,
+  label text NOT NULL,
+  family text NOT NULL,
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT quality_cause_catalog_code_0450_ck CHECK (code ~ '^[A-Z][A-Z0-9_]{2,39}$'),
+  CONSTRAINT quality_cause_catalog_family_0450_ck CHECK (
+    family IN ('MATERIAL','METHOD','MACHINE','MEASUREMENT','MANPOWER','ENVIRONMENT','SUPPLIER','DESIGN','OTHER')
+  )
+);
+
+INSERT INTO public.quality_cause_catalog (code, label, family)
+VALUES
+  ('MATERIAL', 'Matiere', 'MATERIAL'),
+  ('METHOD', 'Methode ou gamme', 'METHOD'),
+  ('MACHINE', 'Machine ou outillage', 'MACHINE'),
+  ('MEASUREMENT', 'Mesure ou moyen de controle', 'MEASUREMENT'),
+  ('MANPOWER', 'Organisation ou competence', 'MANPOWER'),
+  ('ENVIRONMENT', 'Environnement', 'ENVIRONMENT'),
+  ('SUPPLIER', 'Fournisseur', 'SUPPLIER'),
+  ('DESIGN', 'Definition technique', 'DESIGN'),
+  ('OTHER', 'Autre cause documentee', 'OTHER')
+ON CONFLICT (code) DO NOTHING;
+
+ALTER TABLE public.non_conformity
+  ADD COLUMN IF NOT EXISTS cause_code text NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'non_conformity_cause_code_0450_fk'
+      AND conrelid = 'public.non_conformity'::regclass
+  ) THEN
+    ALTER TABLE public.non_conformity
+      ADD CONSTRAINT non_conformity_cause_code_0450_fk
+      FOREIGN KEY (cause_code) REFERENCES public.quality_cause_catalog(code)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS non_conformity_cause_period_0450_idx
+  ON public.non_conformity (cause_code, detection_date)
+  WHERE cause_code IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.quality_cost_entry (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  non_conformity_id uuid NOT NULL
+    REFERENCES public.non_conformity(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  category text NOT NULL,
+  amount numeric(18, 4) NOT NULL,
+  currency text NOT NULL,
+  occurred_on date NOT NULL,
+  source_type text NOT NULL,
+  source_id text NOT NULL,
+  evidence_document_id uuid NULL
+    REFERENCES public.quality_documents(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  note text NOT NULL,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  CONSTRAINT quality_cost_entry_category_0450_ck CHECK (
+    category IN ('SCRAP','REWORK','SORTING','CONTAINMENT','RETURN','OTHER')
+  ),
+  CONSTRAINT quality_cost_entry_amount_0450_ck CHECK (amount > 0),
+  CONSTRAINT quality_cost_entry_currency_0450_ck CHECK (currency ~ '^[A-Z]{3}$'),
+  CONSTRAINT quality_cost_entry_source_0450_ck CHECK (
+    source_type IN ('STOCK_MOVEMENT','TIME_ENTRY','SUPPLIER_DOCUMENT','MANUAL_EVIDENCE')
+    AND char_length(btrim(source_id)) BETWEEN 1 AND 160
+  ),
+  CONSTRAINT quality_cost_entry_note_0450_ck CHECK (char_length(btrim(note)) BETWEEN 5 AND 2000),
+  CONSTRAINT quality_cost_entry_hash_0450_ck CHECK (request_hash ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT quality_cost_entry_actor_key_0450_uq UNIQUE (created_by, idempotency_key),
+  CONSTRAINT quality_cost_entry_source_id_0450_uq UNIQUE (source_type, source_id, category)
+);
+
+CREATE INDEX IF NOT EXISTS quality_cost_entry_period_0450_idx
+  ON public.quality_cost_entry (occurred_on, category, currency);
+CREATE INDEX IF NOT EXISTS quality_cost_entry_nc_0450_idx
+  ON public.quality_cost_entry (non_conformity_id, occurred_on DESC);
+
+CREATE OR REPLACE FUNCTION public.quality_cost_entry_guard_0450()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  v_allowed boolean;
+BEGIN
+  IF TG_OP IN ('UPDATE', 'DELETE') THEN
+    RAISE EXCEPTION 'quality_cost_entry is append-only; record a compensating evidence instead';
+  END IF;
+  IF NEW.evidence_document_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.quality_documents d
+      WHERE d.id = NEW.evidence_document_id
+        AND d.removed_at IS NULL
+        AND (
+          (d.entity_type = 'NON_CONFORMITY' AND d.entity_id = NEW.non_conformity_id)
+          OR (
+            d.entity_type = 'ACTION'
+            AND EXISTS (
+              SELECT 1 FROM public.quality_action a
+              WHERE a.id = d.entity_id AND a.non_conformity_id = NEW.non_conformity_id
+            )
+          )
+        )
+    ) INTO v_allowed;
+    IF NOT v_allowed THEN
+      RAISE EXCEPTION 'quality cost evidence must belong to the same non-conformity';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_quality_cost_entry_guard_0450 ON public.quality_cost_entry;
+CREATE TRIGGER trg_quality_cost_entry_guard_0450
+  BEFORE INSERT OR UPDATE OR DELETE ON public.quality_cost_entry
+  FOR EACH ROW EXECUTE FUNCTION public.quality_cost_entry_guard_0450();
+
+-- Une politique SPC est versionnee et append-only. Sans ligne ACTIVE, le
+-- service declare l'indicateur indisponible au lieu d'inventer une carte.
+CREATE TABLE IF NOT EXISTS public.quality_spc_policy (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL,
+  version integer NOT NULL,
+  characteristic_key text NOT NULL,
+  expected_unit text NOT NULL,
+  sampling_rule text NOT NULL,
+  subgroup_size integer NOT NULL,
+  min_subgroups integer NOT NULL,
+  cadence_minutes integer NOT NULL,
+  effective_from timestamptz NOT NULL,
+  effective_to timestamptz NULL,
+  active boolean NOT NULL DEFAULT false,
+  justification text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  retired_at timestamptz NULL,
+  retired_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  retirement_reason text NULL,
+  CONSTRAINT quality_spc_policy_code_version_0450_uq UNIQUE (code, version),
+  CONSTRAINT quality_spc_policy_code_0450_ck CHECK (code ~ '^[A-Z][A-Z0-9_-]{2,39}$'),
+  CONSTRAINT quality_spc_policy_sampling_0450_ck CHECK (sampling_rule IN ('FIXED','PERCENT','LOT')),
+  CONSTRAINT quality_spc_policy_sizes_0450_ck CHECK (
+    subgroup_size >= 2 AND min_subgroups >= 2 AND cadence_minutes > 0
+  ),
+  CONSTRAINT quality_spc_policy_period_0450_ck CHECK (effective_to IS NULL OR effective_to >= effective_from),
+  CONSTRAINT quality_spc_policy_justification_0450_ck CHECK (char_length(btrim(justification)) >= 10),
+  CONSTRAINT quality_spc_policy_retirement_0450_ck CHECK (
+    (retired_at IS NULL AND retired_by IS NULL AND retirement_reason IS NULL)
+    OR (retired_at IS NOT NULL AND retired_by IS NOT NULL AND char_length(btrim(retirement_reason)) >= 10)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS quality_spc_policy_active_characteristic_0450_uq
+  ON public.quality_spc_policy (characteristic_key)
+  WHERE active;
+
+CREATE OR REPLACE FUNCTION public.quality_spc_policy_guard_0450()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'quality_spc_policy is immutable; retire it before creating a new version';
+  END IF;
+  IF OLD.active
+     AND NOT NEW.active
+     AND OLD.effective_to IS NULL
+     AND NEW.effective_to IS NOT NULL
+     AND NEW.retired_at IS NOT NULL
+     AND NEW.retired_by IS NOT NULL
+     AND char_length(btrim(NEW.retirement_reason)) >= 10
+     AND (to_jsonb(NEW) - ARRAY['active','effective_to','retired_at','retired_by','retirement_reason']::text[])
+       = (to_jsonb(OLD) - ARRAY['active','effective_to','retired_at','retired_by','retirement_reason']::text[])
+  THEN
+    RETURN NEW;
+  END IF;
+  RAISE EXCEPTION 'quality_spc_policy versions are immutable; only one-way retirement is allowed';
+END $$;
+
+DROP TRIGGER IF EXISTS trg_quality_spc_policy_guard_0450 ON public.quality_spc_policy;
+CREATE TRIGGER trg_quality_spc_policy_guard_0450
+  BEFORE UPDATE OR DELETE ON public.quality_spc_policy
+  FOR EACH ROW EXECUTE FUNCTION public.quality_spc_policy_guard_0450();
+
+-- La verification d'une CAPA exige une preuve explicite lorsque le plan la
+-- declare obligatoire. Le garde SQL couvre aussi les anciens endpoints.
+CREATE OR REPLACE FUNCTION public.quality_action_verification_guard_0450()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.status = 'VERIFIED' AND OLD.status IS DISTINCT FROM NEW.status THEN
+    IF NEW.verification_user_id IS NULL OR NEW.verification_date IS NULL THEN
+      RAISE EXCEPTION 'verified quality action requires verifier and verification date';
+    END IF;
+    IF NEW.effectiveness_comment IS NULL OR char_length(btrim(NEW.effectiveness_comment)) < 5 THEN
+      RAISE EXCEPTION 'verified quality action requires effectiveness evidence';
+    END IF;
+    IF NEW.evidence_required AND NOT EXISTS (
+      SELECT 1 FROM public.quality_documents d
+      WHERE d.entity_type = 'ACTION' AND d.entity_id = NEW.id AND d.removed_at IS NULL
+    ) THEN
+      RAISE EXCEPTION 'verified quality action requires an active evidence document';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_quality_action_verification_guard_0450 ON public.quality_action;
+CREATE TRIGGER trg_quality_action_verification_guard_0450
+  BEFORE UPDATE ON public.quality_action
+  FOR EACH ROW EXECUTE FUNCTION public.quality_action_verification_guard_0450();
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    ALTER TABLE public.quality_cause_catalog OWNER TO cerp_app;
+    ALTER TABLE public.quality_cost_entry OWNER TO cerp_app;
+    ALTER TABLE public.quality_spc_policy OWNER TO cerp_app;
+    GRANT SELECT ON public.quality_cause_catalog TO cerp_app;
+    GRANT SELECT, INSERT ON public.quality_cost_entry TO cerp_app;
+    GRANT SELECT, INSERT ON public.quality_spc_policy TO cerp_app;
+  END IF;
+END $$;
+
+COMMENT ON TABLE public.quality_cost_entry IS
+  'SOL-22: preuves de cout de non-qualite append-only; aucune absence ne vaut zero.';
+COMMENT ON TABLE public.quality_spc_policy IS
+  'SOL-22: prerequis SPC versionnes; aucune carte n est calculee sans politique active et observations fiables.';
+
+COMMIT;

--- a/db/patches/support/20260814_sol22_quality_intelligence.preflight.sql
+++ b/db/patches/support/20260814_sol22_quality_intelligence.preflight.sql
@@ -1,0 +1,32 @@
+\set ON_ERROR_STOP on
+
+DO $$
+DECLARE
+  missing text[] := ARRAY[]::text[];
+BEGIN
+  IF current_setting('server_version_num')::int < 140000 THEN
+    RAISE EXCEPTION 'PostgreSQL 14+ requis';
+  END IF;
+  IF to_regclass('public.quality_control') IS NULL THEN missing := array_append(missing, 'quality_control'); END IF;
+  IF to_regclass('public.quality_control_points') IS NULL THEN missing := array_append(missing, 'quality_control_points'); END IF;
+  IF to_regclass('public.non_conformity') IS NULL THEN missing := array_append(missing, 'non_conformity'); END IF;
+  IF to_regclass('public.quality_action') IS NULL THEN missing := array_append(missing, 'quality_action'); END IF;
+  IF to_regclass('public.quality_documents') IS NULL THEN missing := array_append(missing, 'quality_documents'); END IF;
+  IF to_regclass('public.metrologie_equipements') IS NULL THEN missing := array_append(missing, 'metrologie_equipements'); END IF;
+  IF array_length(missing, 1) IS NOT NULL THEN
+    RAISE EXCEPTION 'Prerequis SOL-22 manquants: %', array_to_string(missing, ', ');
+  END IF;
+END $$;
+
+SELECT current_database() AS database_name,
+       current_setting('server_version') AS postgres_version,
+       pg_size_pretty(pg_database_size(current_database())) AS database_size,
+       (SELECT COUNT(*) FROM public.quality_control) AS quality_controls,
+       (SELECT COUNT(*) FROM public.non_conformity) AS non_conformities,
+       (SELECT COUNT(*) FROM public.quality_action) AS quality_actions,
+       (SELECT COUNT(*) FROM public.metrologie_equipements) AS metrology_equipment;
+
+SELECT COUNT(*) AS verified_actions_without_comment
+FROM public.quality_action
+WHERE status = 'VERIFIED'
+  AND (effectiveness_comment IS NULL OR char_length(btrim(effectiveness_comment)) < 5);

--- a/db/patches/support/20260814_sol22_quality_intelligence.rollback.sql
+++ b/db/patches/support/20260814_sol22_quality_intelligence.rollback.sql
@@ -1,0 +1,34 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Rollback SOL-22 autorise uniquement sur cerp_test; restaurer la sauvegarde en production';
+  END IF;
+  IF to_regclass('public.quality_cost_entry') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM public.quality_cost_entry) THEN
+    RAISE EXCEPTION 'Rollback refuse: preuves de cout qualite presentes';
+  END IF;
+  IF to_regclass('public.quality_spc_policy') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM public.quality_spc_policy) THEN
+    RAISE EXCEPTION 'Rollback refuse: politiques SPC presentes';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.non_conformity WHERE cause_code IS NOT NULL) THEN
+    RAISE EXCEPTION 'Rollback refuse: causes structurees utilisees';
+  END IF;
+END $$;
+
+BEGIN;
+DROP TRIGGER IF EXISTS trg_quality_action_verification_guard_0450 ON public.quality_action;
+DROP FUNCTION IF EXISTS public.quality_action_verification_guard_0450();
+DROP TRIGGER IF EXISTS trg_quality_spc_policy_guard_0450 ON public.quality_spc_policy;
+DROP FUNCTION IF EXISTS public.quality_spc_policy_guard_0450();
+DROP TABLE IF EXISTS public.quality_spc_policy;
+DROP TRIGGER IF EXISTS trg_quality_cost_entry_guard_0450 ON public.quality_cost_entry;
+DROP FUNCTION IF EXISTS public.quality_cost_entry_guard_0450();
+DROP TABLE IF EXISTS public.quality_cost_entry;
+ALTER TABLE public.non_conformity DROP CONSTRAINT IF EXISTS non_conformity_cause_code_0450_fk;
+DROP INDEX IF EXISTS public.non_conformity_cause_period_0450_idx;
+ALTER TABLE public.non_conformity DROP COLUMN IF EXISTS cause_code;
+DROP TABLE IF EXISTS public.quality_cause_catalog;
+COMMIT;

--- a/db/patches/support/20260814_sol22_quality_intelligence.verify.sql
+++ b/db/patches/support/20260814_sol22_quality_intelligence.verify.sql
@@ -1,0 +1,44 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF to_regclass('public.quality_cause_catalog') IS NULL
+     OR to_regclass('public.quality_cost_entry') IS NULL
+     OR to_regclass('public.quality_spc_policy') IS NULL THEN
+    RAISE EXCEPTION 'Tables SOL-22 absentes';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'non_conformity' AND column_name = 'cause_code'
+  ) THEN
+    RAISE EXCEPTION 'Colonne non_conformity.cause_code absente';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_quality_cost_entry_guard_0450' AND NOT tgisinternal) THEN
+    RAISE EXCEPTION 'Garde append-only des couts absent';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_quality_spc_policy_guard_0450' AND NOT tgisinternal) THEN
+    RAISE EXCEPTION 'Garde de version SPC absent';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'quality_spc_policy_active_characteristic_0450_uq'
+      AND indexdef ILIKE 'CREATE UNIQUE INDEX%'
+  ) THEN
+    RAISE EXCEPTION 'Unicite de la politique SPC active absente';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_quality_action_verification_guard_0450' AND NOT tgisinternal) THEN
+    RAISE EXCEPTION 'Garde de preuve CAPA absent';
+  END IF;
+END $$;
+
+SELECT current_database() AS database_name,
+       (SELECT COUNT(*) FROM public.quality_cause_catalog) AS cause_codes,
+       (SELECT COUNT(*) FROM public.quality_cost_entry) AS cost_entries,
+       (SELECT COUNT(*) FROM public.quality_spc_policy WHERE active) AS active_spc_policies,
+       (SELECT COUNT(*) FROM public.non_conformity WHERE cause_code IS NOT NULL) AS structured_non_conformities;
+
+SELECT COUNT(*) AS orphan_cost_entries
+FROM public.quality_cost_entry c
+LEFT JOIN public.non_conformity nc ON nc.id = c.non_conformity_id
+WHERE nc.id IS NULL;

--- a/docs/adr/ADR-0068-quality-intelligence-and-investigation.md
+++ b/docs/adr/ADR-0068-quality-intelligence-and-investigation.md
@@ -1,0 +1,74 @@
+# ADR-0068 — Mesure qualité, SPC et enquête de traçabilité
+
+- Statut : accepté
+- Date : 2026-08-14
+- Décideur technique : CERP+
+- Contrat : `CERP-QUALITY-INTELLIGENCE-1.0.0`
+- Issues : frontend #646, backend #450
+
+## Contexte
+
+Les contrôles, non-conformités, actions, instruments de mesure et liens de
+traçabilité existaient, mais sans contrat décisionnel commun. Une moyenne ou un
+coût pouvait donc être affiché sans dénominateur, une cause restait en texte libre
+et l'absence de preuve pouvait être confondue avec zéro. Le temps réel d'une
+enquête n'est par ailleurs pas historisé par des événements de début et de clôture.
+
+## Décision
+
+- Le FPY est la quantité conforme du premier contrôle validé d'une source divisée
+  par sa quantité contrôlée. Le premier passage est identifié par
+  `source_type + source_id`, puis par date de validation, création et identifiant.
+- Le PPM est `(quantité contrôlée - quantité conforme) / quantité contrôlée ×
+  1 000 000`. Le délai de clôture est la moyenne calendaire entre détection et
+  clôture des NC closes pendant la période.
+- Rebuts, retouches et autres coûts de non-qualité proviennent exclusivement du
+  ledger append-only `quality_cost_entry`. Une entrée porte devise, date,
+  catégorie, source, preuve éventuelle, acteur et clé d'idempotence. Plusieurs
+  devises sans politique de conversion rendent la consolidation indisponible.
+- Toute métrique expose formule, unité, période, source, fraîcheur, numérateur,
+  dénominateur, manquants et fiabilité `CONFIRMED`, `PARTIAL` ou `UNAVAILABLE`.
+  Une absence n'est jamais convertie en zéro. Un COPQ incomplet est une borne
+  inférieure `PARTIAL`, avec les catégories manquantes visibles.
+- Les causes sont choisies dans `quality_cause_catalog`. Leur affectation est
+  auditée, idempotente et protégée par verrou optimiste ; l'historique n'est pas
+  réécrit silencieusement.
+- Une action CAPA qui exige une preuve ne peut passer à `VERIFIED` sans
+  vérificateur, date, verdict d'efficacité et document actif lié.
+- Le SPC est fermé par défaut. Une politique versionnée doit préciser
+  caractéristique, unité, règle, taille de sous-groupe, nombre minimal et cadence.
+  Seuls des sous-groupes complets, dans la période d'effet de la version et avec
+  au moins 90 % de respect de cadence autorisent l'état `enabled`.
+- Le moteur métrologie existant reste l'autorité d'emploi : quarantaine et états
+  bloquants interdisent la mesure ; une échéance suit la stratégie versionnée
+  `BLOCK`, `WARN` ou `NONE`. Le centre existant fournit calendrier, instruments
+  critiques échus, quarantaine et échéances proches.
+- L'enquête réutilise le graphe de traçabilité canonique, de la matière à la
+  livraison. Elle mesure nœuds matière/livraison, arêtes prouvées, liens manquants
+  et couverture. La durée de génération technique est distincte du temps métier.
+  Faute d'événements `investigation_started_at` et `investigation_closed_at`, ce
+  dernier reste explicitement `UNAVAILABLE`.
+- `analytics_read`, `nc_manage` et `capa_manage` sont contrôlés côté API. Un accès
+  ordinaire au module n'élève pas le rôle ; seul un override de compte explicitement
+  élevé ou un rôle autorisé peut franchir le gate.
+
+## Conséquences
+
+Le cockpit fonctionnel peut présenter un Pareto, une tendance, les CAPA à traiter,
+le calendrier métrologique et le graphe d'enquête sans fabriquer de valeur. Les
+anciennes NC sans cause structurée et les anciens contrôles sans source restent
+visibles comme données partielles. Aucune politique SPC n'est créée par migration :
+la Qualité doit déclarer les règles réelles avant activation.
+
+## Migration et retour arrière
+
+La migration ajoute le catalogue de causes, le ledger de coûts et les politiques
+SPC, ainsi que les contraintes d'audit et de preuve CAPA. Elle amorce uniquement
+un vocabulaire de causes générique ; elle ne crée aucun coût, aucune observation
+ni politique SPC.
+
+L'ancien backend ignore ces objets additifs. Après utilisation réelle, le retour
+sûr consiste à redéployer le SHA précédent en conservant le schéma. Le rollback
+destructif est limité à `cerp_test` et refuse de supprimer une cause affectée, une
+écriture de coût ou une politique SPC. Une restauration se fait dans une nouvelle
+base à partir du dump vérifié, jamais en écrasant la base active.

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -677,3 +677,13 @@ treize clés obligatoires, résolution hors période rendant l'identité **sans*
 # 20260809 — Account invitation and administrative reset idempotency (SOL-02)
 
 `20260809_account_invitation_activation.sql` adds one-use administrative invitations and idempotency metadata for administrative password-reset creation. Run the matching support preflight, take a restorable backup, apply, then run verify. The rollback is intentionally refused once account-lifecycle evidence exists; disable application routes and preserve evidence instead.
+
+## 20260814 — Intelligence qualité, coûts, causes et SPC (SOL-22)
+
+`20260814_sol22_quality_intelligence.sql` ajoute le catalogue de causes, le ledger
+append-only des coûts qualité et les politiques SPC versionnées. Il renforce aussi
+la vérification des CAPA exigeant une preuve. Exécuter le preflight, produire et
+restaurer un dump vérifié, appliquer avec le runner de patches puis exécuter le
+verify. Le rollback support est limité à `cerp_test` et refuse toute suppression
+dès qu'une cause, un coût ou une politique SOL-22 est utilisé. La procédure complète
+est dans `docs/runbooks/quality-intelligence-sol22-migration.md`.

--- a/docs/execution-reports/SOL-22.md
+++ b/docs/execution-reports/SOL-22.md
@@ -1,0 +1,99 @@
+# SOL-22 — Qualité, métrologie et traçabilité (backend)
+
+- Date : 2026-08-14
+- Issue : https://github.com/BigFootLime/erp-crp-backend/issues/450
+- Branche : `feat/450-sol22-quality-intelligence`
+- Base initiale : `origin/main` (`0a5baa77`)
+- ADR : `docs/adr/ADR-0068-quality-intelligence-and-investigation.md`
+
+## Diagnostic et cause racine
+
+Les domaines Qualité, Métrologie et Traçabilité étaient solides séparément, mais
+aucun contrat unique ne qualifiait FPY, PPM, délai de clôture ou coût de
+non-qualité. Les causes restaient non structurées, les coûts n'avaient pas de
+ledger dédié et le SPC n'avait pas de politique de fiabilité versionnée. Le graphe
+de traçabilité existait, sans dataset d'enquête ni mesure explicite des liens
+manquants. Pendant la recette réelle, deux défauts transverses ont aussi été
+trouvés : double libération d'une connexion après transaction et élévation indue
+par simple accès au module Qualité.
+
+## Architecture et résultat
+
+- calculs purs et explicables pour FPY, PPM, clôture, rebut, retouche et COPQ ;
+- `null` et fiabilité visible lorsqu'un dénominateur, une catégorie de coût, une
+  devise ou une preuve manque ;
+- causes structurées, affectation optimiste/idempotente et audit immuable ;
+- ledger de coûts append-only avec source, acteur, preuve et idempotence ;
+- clôture CAPA bloquée quand une preuve obligatoire manque ;
+- politiques SPC datées/versionnées, sous-groupes complets et cadence contrôlée ;
+- centre métrologique existant réutilisé pour échéances et équipements bloquants ;
+- enquête fondée sur le graphe canonique matière → livraison, avec couverture et
+  liens manquants ; le temps métier reste indisponible faute d'événements source ;
+- RBAC serveur : accès analytique réservé, opérateur refusé, override élevé explicite.
+
+## Fichiers modifiés
+
+- domaine, repository, service, contrôleur, validation, routes et middleware
+  `src/module/qualite/` ;
+- migration et supports `db/patches/20260814_sol22_quality_intelligence.sql` ;
+- tests domaine, route, RBAC et gardes de migration dans `src/__tests__/` ;
+- ADR-0068, runbook, index des patches et présent rapport.
+
+## Migration et preuve de restauration
+
+La migration est additive et n'insère que neuf familles de causes génériques. Elle
+ne crée aucun coût ni politique SPC. Répétition PostgreSQL 16.14 jetable : 153
+patchs appliqués, 0 en attente, 0 checksum divergent ; dump de 2 114 969 octets,
+SHA-256 `13ace679cd197ccca0f86e7773c54f88d5edbf51f335b90a3648364450e67c89` ;
+rollback `cerp_test` réussi, restauration dans `cerp_restore` réussie, 0 coût
+orphelin et 0 cause invalide.
+
+La preuve SQL déterministe a produit FPY 90 %, PPM 100 000, clôture 2 jours,
+rebuts 100 EUR, retouches 50 EUR, COPQ 175 EUR, Pareto `MACHINE` et SPC v1 actif.
+La concurrence de deux politiques actives a été refusée ; v1 a été retirée avec
+acteur/motif, v2 activée, et toute réécriture de v1 a été rejetée. Le rejeu cause
+a conservé le même `updated_at`; le rejeu coût le même UUID.
+
+## Tests et vérification navigateur/E2E
+
+| Contrôle | Résultat réel |
+|---|---|
+| tests SOL-22 ciblés | PASS — 4 fichiers, 19/19 |
+| `pnpm typecheck` | PASS |
+| `pnpm build` | PASS |
+| audit dépendances production | PASS — 0 vulnérabilité connue |
+| parcours vente isolé après correctifs | PASS — 1/1, 35,7 s, 0 retry |
+| parcours ERP isolés complets | PASS — 3/3, 59,0 s, 0 retry |
+| suite backend complète | PASS — 298 fichiers, 4 588 réussis, 4 ignorés, 0 échec, 22,99 s |
+| vérification navigateur | PASS — Centre Qualité sur `cerp_test`, drill-down actif, 0 erreur console |
+
+Le parcours navigateur/API réel couvre vente → production → livraison → facture,
+puis NC, cause rejouée, coût rejoué, enquête lot → BL, métriques et refus opérateur.
+Les deux parcours achat complet et partiel passent aussi. Une première campagne
+groupée avait échoué avant le flux métier parce que l'état vide expose deux CTA
+« Nouvelle commande » : la recette cible maintenant l'unique CTA canonique déjà
+marqué par l'application et vérifie son unicité. La campagne suivante passe 3/3.
+
+La vérification manuelle instrumentée a confirmé dans le navigateur que FPY, PPM,
+délai de clôture, rebuts, retouches et COPQ ne deviennent jamais zéro en l'absence
+de preuve. Pareto et SPC restent explicitement indisponibles, et le drill-down du
+Centre Qualité ouvre la page de traçabilité canonique.
+
+## Risques, compatibilité et travail restant
+
+- les contrôles historiques sans source ou quantité rendent les ratios partiels ;
+- le COPQ reste une borne inférieure tant que toutes les catégories ne sont pas
+  alimentées ; aucune valeur manquante n'est interprétée comme zéro ;
+- aucune politique SPC n'est inventée : le responsable Qualité doit renseigner
+  échantillonnage, unité, cadence et volume réels ;
+- le temps métier d'enquête nécessite de futurs événements début/clôture ; la
+  durée technique de génération ne le remplace pas ;
+- la clé `(source_type, source_id, category)` suppose que `source_id` identifie la
+  preuve atomique du coût ; les intégrations futures doivent respecter ce contrat.
+
+## Rollback
+
+Redéployer d'abord l'ancien SHA en conservant les objets additifs. Le rollback SQL
+n'est autorisé que sur `cerp_test` et sans donnée SOL-22 ; sinon restaurer le dump
+pré-migration dans une nouvelle base après gel des écritures et vérifications. La
+procédure exacte est dans le runbook associé.

--- a/docs/runbooks/quality-intelligence-sol22-migration.md
+++ b/docs/runbooks/quality-intelligence-sol22-migration.md
@@ -1,0 +1,81 @@
+# Runbook opérateur — migration SOL-22 qualité et traçabilité
+
+- Propriétaire : exploitation CERP+
+- Version : 1.0
+- Dernière vérification : 2026-08-14
+- Patch : `20260814_sol22_quality_intelligence.sql`
+
+## Symptômes et impact
+
+Ce runbook couvre le déploiement, le refus ou le retour arrière du schéma SOL-22.
+Une migration absente rend les endpoints d'intelligence indisponibles et empêche
+l'affectation structurée des causes et l'enregistrement idempotent des coûts. Une
+métrique `UNAVAILABLE` ou un SPC désactivé par prérequis manquant n'est pas un
+incident de migration.
+
+## Préparation sûre
+
+1. Confirmer le SHA backend/frontend et le nom exact de la base ciblée.
+2. Geler brièvement les modifications de NC, CAPA et paramètres qualité.
+3. Exécuter le preflight en lecture seule :
+
+   ```powershell
+   psql $env:DATABASE_URL -v ON_ERROR_STOP=1 -f db/patches/support/20260814_sol22_quality_intelligence.preflight.sql
+   pnpm db:patches:status
+   ```
+
+4. Produire un dump PostgreSQL hors de la base active, calculer son SHA-256 et
+   démontrer sa restauration dans une base jetable. Ne pas continuer sans preuve.
+5. Vérifier l'espace disque, PostgreSQL >= 14, les relations Qualité/Métrologie/
+   Traçabilité et l'absence de migration en attente ou de checksum divergent.
+
+## Application et validation
+
+```powershell
+pnpm db:patches:up -- --dry-run --only 20260814_sol22_quality_intelligence.sql
+pnpm db:patches:up -- --only 20260814_sol22_quality_intelligence.sql
+psql $env:DATABASE_URL -v ON_ERROR_STOP=1 -f db/patches/support/20260814_sol22_quality_intelligence.verify.sql
+pnpm db:patches:status -- --check --only 20260814_sol22_quality_intelligence.sql
+```
+
+Valider ensuite :
+
+1. un responsable Qualité affecte une cause avec `expected_updated_at`, rejoue la
+   requête et retrouve le même état sans doublon ;
+2. il enregistre un coût avec `Idempotency-Key`, le rejoue et retrouve le même UUID ;
+3. un opérateur reçoit `403` en lecture des indicateurs et en création de coût ;
+4. une CAPA exigeant une preuve refuse `VERIFIED` sans document et l'accepte avec
+   vérificateur, date, efficacité et preuve active ;
+5. une politique SPC incomplète reste désactivée ; une politique complète ne
+   devient fiable qu'après les sous-groupes et la cadence requis ;
+6. un instrument en quarantaine reste bloqué, une échéance suit sa stratégie
+   `BLOCK`/`WARN`, et le centre liste les équipements bloquants ;
+7. l'enquête d'un lot livré contient les nœuds matière et livraison, expose ses
+   liens manquants et ne fabrique pas de temps métier d'enquête.
+
+Le service ne revient en production que si le verify, les contrôles d'idempotence,
+les refus RBAC et la recette navigateur passent.
+
+## Arbre de décision et rollback
+
+- Échec avant commit : conserver le log, corriger le prérequis puis rejouer ; ne
+  jamais éditer `cerp_schema_migrations`.
+- Échec applicatif sans corruption : redéployer l'ancien backend ; conserver les
+  objets additifs.
+- `cerp_test` sans donnée SOL-22 : exécuter le rollback support dans une session
+  contrôlée après export et snapshot.
+- Toute cause, coût ou politique déjà utilisée : le rollback destructif doit
+  refuser. Geler les écritures, restaurer le dump dans une nouvelle base, vérifier
+  contraintes/comptages puis promouvoir explicitement cette base.
+
+```powershell
+psql $env:DATABASE_URL -v ON_ERROR_STOP=1 -f db/patches/support/20260814_sol22_quality_intelligence.rollback.sql
+```
+
+## Actions interdites et communication
+
+Ne jamais supprimer une écriture de coût ou un audit, réécrire une politique SPC
+retirée, convertir un manque en zéro, contourner le gate métrologique/RBAC, ni
+exécuter le rollback sur `cerp_prod`. Informer les utilisateurs du gel, du SHA, de
+la base, du verdict de reprise et des NC/équipements touchés. Le post-mortem conserve
+logs corrélés, patch, checksum du dump, cause racine et validation métier.

--- a/src/__tests__/quality-intelligence-sol22.authorization.test.ts
+++ b/src/__tests__/quality-intelligence-sol22.authorization.test.ts
@@ -1,0 +1,54 @@
+import type { Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+
+import { HttpError } from "../utils/httpError";
+import { requireQualityCapability } from "../module/qualite/middlewares/quality-authorization.middleware";
+
+function qualityRequest(role: string, elevated: boolean): Request {
+  return {
+    user: { id: 42, role },
+    accountModuleAccess: {
+      userId: 42,
+      moduleKey: "qualite",
+      granted: true,
+      elevated,
+    },
+  } as Request;
+}
+
+describe("SOL-22 quality capability boundary", () => {
+  it("ne transforme pas l'accès ordinaire au module en privilège analytique", () => {
+    const next = vi.fn();
+    requireQualityCapability("analytics_read")(
+      qualityRequest("Employee | Opérateur atelier", false),
+      {} as Response,
+      next,
+    );
+
+    const error = next.mock.calls[0]?.[0];
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error).toMatchObject({ status: 403, code: "QUALITY_CAPABILITY_REQUIRED" });
+  });
+
+  it("autorise un rôle qualité avec un accès module ordinaire", () => {
+    const next = vi.fn();
+    requireQualityCapability("analytics_read")(
+      qualityRequest("Responsable Qualité", false),
+      {} as Response,
+      next,
+    );
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("honore une dérogation de compte explicitement élevée", () => {
+    const next = vi.fn();
+    requireQualityCapability("analytics_read")(
+      qualityRequest("Employee", true),
+      {} as Response,
+      next,
+    );
+
+    expect(next).toHaveBeenCalledWith();
+  });
+});

--- a/src/__tests__/quality-intelligence-sol22.domain.test.ts
+++ b/src/__tests__/quality-intelligence-sol22.domain.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assessSpcReadiness,
+  computeQualityDecisionMetrics,
+} from "../module/qualite/domain/quality-intelligence";
+import { roleHasQualityCapability } from "../module/qualite/domain/quality-policy";
+
+describe("SOL-22 quality decision metrics", () => {
+  it("calcule FPY, PPM et délai sans fausse précision", () => {
+    const metrics = computeQualityDecisionMetrics({
+      firstPassConformingQty: 8,
+      firstPassControlledQty: 10,
+      firstPassMissingData: 0,
+      defectQty: 25,
+      controlledQty: 100_000,
+      controlsMissingQuantities: 0,
+      closureDurationsDays: [1, 2, 6],
+      scrapCost: 125.555,
+      reworkCost: 74.445,
+      otherPoorQualityCost: 25,
+      costCurrency: "EUR",
+      costCurrencyCount: 1,
+    });
+
+    expect(metrics.find((metric) => metric.code === "FPY")).toMatchObject({
+      value: 80,
+      numerator: 8,
+      denominator: 10,
+      reliability: "CONFIRMED",
+    });
+    expect(metrics.find((metric) => metric.code === "PPM")).toMatchObject({
+      value: 250,
+      numerator: 25,
+      denominator: 100_000,
+      reliability: "CONFIRMED",
+    });
+    expect(metrics.find((metric) => metric.code === "CLOSURE_DELAY")).toMatchObject({
+      value: 3,
+      unit: "days",
+    });
+    expect(metrics.find((metric) => metric.code === "COPQ")).toMatchObject({
+      value: 225,
+      currency: "EUR",
+    });
+  });
+
+  it("renvoie null, jamais zéro, quand le dénominateur ou le coût manque", () => {
+    const metrics = computeQualityDecisionMetrics({
+      firstPassConformingQty: 0,
+      firstPassControlledQty: 0,
+      firstPassMissingData: 0,
+      defectQty: 0,
+      controlledQty: 0,
+      controlsMissingQuantities: 0,
+      closureDurationsDays: [],
+      scrapCost: null,
+      reworkCost: null,
+      otherPoorQualityCost: null,
+      costCurrency: null,
+      costCurrencyCount: 0,
+    });
+
+    for (const metric of metrics) {
+      expect(metric.value).toBeNull();
+      expect(metric.reliability).toBe("UNAVAILABLE");
+      expect(metric.missing.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("marque partiel un ratio contenant des sources historiques incomplètes", () => {
+    const metrics = computeQualityDecisionMetrics({
+      firstPassConformingQty: 9,
+      firstPassControlledQty: 10,
+      firstPassMissingData: 2,
+      defectQty: 1,
+      controlledQty: 10,
+      controlsMissingQuantities: 1,
+      closureDurationsDays: [1],
+      scrapCost: 1,
+      reworkCost: 1,
+      otherPoorQualityCost: null,
+      costCurrency: "EUR",
+      costCurrencyCount: 1,
+    });
+    expect(metrics.find((metric) => metric.code === "FPY")?.reliability).toBe("PARTIAL");
+    expect(metrics.find((metric) => metric.code === "PPM")?.reliability).toBe("PARTIAL");
+    expect(metrics.find((metric) => metric.code === "COPQ")).toMatchObject({
+      value: 2,
+      reliability: "PARTIAL",
+      missing: ["other_quality_cost_entries"],
+    });
+  });
+
+  it("refuse d'additionner silencieusement plusieurs devises", () => {
+    const copq = computeQualityDecisionMetrics({
+      firstPassConformingQty: 1,
+      firstPassControlledQty: 1,
+      firstPassMissingData: 0,
+      defectQty: 0,
+      controlledQty: 1,
+      controlsMissingQuantities: 0,
+      closureDurationsDays: [1],
+      scrapCost: 10,
+      reworkCost: 5,
+      otherPoorQualityCost: null,
+      costCurrency: null,
+      costCurrencyCount: 2,
+    }).find((metric) => metric.code === "COPQ");
+    expect(copq).toMatchObject({ value: null, reliability: "UNAVAILABLE" });
+    expect(copq?.missing).toContain("currency_conversion_policy");
+  });
+});
+
+describe("SOL-22 SPC readiness gate", () => {
+  it("active SPC uniquement si politique, unité, volume et cadence sont prouvés", () => {
+    expect(
+      assessSpcReadiness({
+        policyActive: true,
+        samplingRule: "FIXED",
+        expectedUnit: "mm",
+        cadenceMinutes: 60,
+        subgroupSize: 5,
+        minSubgroups: 3,
+        observedSubgroups: 4,
+        observedUnits: ["mm"],
+        cadenceCoverageRatio: 1,
+      })
+    ).toEqual({ enabled: true, reliability: "CONFIRMED", missing: [] });
+  });
+
+  it("reste désactivé si unité ou fréquence n'est pas fiable", () => {
+    const result = assessSpcReadiness({
+      policyActive: true,
+      samplingRule: "FIXED",
+      expectedUnit: "mm",
+      cadenceMinutes: 60,
+      subgroupSize: 5,
+      minSubgroups: 3,
+      observedSubgroups: 4,
+      observedUnits: ["mm", "inch"],
+      cadenceCoverageRatio: 0.5,
+    });
+    expect(result.enabled).toBe(false);
+    expect(result.reliability).toBe("PARTIAL");
+    expect(result.missing).toEqual(expect.arrayContaining(["consistent_observed_unit", "sampling_cadence_coverage"]));
+  });
+});
+
+describe("SOL-22 analytics RBAC", () => {
+  it("autorise qualité et direction, refuse atelier et comptabilité", () => {
+    expect(roleHasQualityCapability("Responsable Qualite", "analytics_read")).toBe(true);
+    expect(roleHasQualityCapability("Direction", "analytics_read")).toBe(true);
+    expect(roleHasQualityCapability("Chef d'atelier", "analytics_read")).toBe(false);
+    expect(roleHasQualityCapability("Comptabilite", "analytics_read")).toBe(false);
+  });
+});

--- a/src/__tests__/quality-intelligence-sol22.migration-guards.test.ts
+++ b/src/__tests__/quality-intelligence-sol22.migration-guards.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(__dirname, "../..");
+const patch = readFileSync(resolve(root, "db/patches/20260814_sol22_quality_intelligence.sql"), "utf8");
+const preflight = readFileSync(resolve(root, "db/patches/support/20260814_sol22_quality_intelligence.preflight.sql"), "utf8");
+const verify = readFileSync(resolve(root, "db/patches/support/20260814_sol22_quality_intelligence.verify.sql"), "utf8");
+const rollback = readFileSync(resolve(root, "db/patches/support/20260814_sol22_quality_intelligence.rollback.sql"), "utf8");
+
+describe("SOL-22 migration safety", () => {
+  it("crée des coûts immuables et des politiques SPC versionnées", () => {
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.quality_cost_entry");
+    expect(patch).toContain("trg_quality_cost_entry_guard_0450");
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.quality_spc_policy");
+    expect(patch).toContain("trg_quality_spc_policy_guard_0450");
+    expect(patch).toContain("CREATE UNIQUE INDEX IF NOT EXISTS quality_spc_policy_active_characteristic_0450_uq");
+    expect(patch).toContain("only one-way retirement is allowed");
+    expect(patch).toContain("quality_action_verification_guard_0450");
+  });
+
+  it("fournit preflight, vérification et rollback explicitement gardé", () => {
+    expect(preflight).toContain("PostgreSQL 14+ requis");
+    expect(verify).toContain("Tables SOL-22 absentes");
+    expect(rollback).toContain("current_database() <> 'cerp_test'");
+    expect(rollback).toContain("Rollback refuse: preuves de cout qualite presentes");
+  });
+
+  it("ne transforme aucune absence de coût en zéro", () => {
+    expect(patch).not.toMatch(/quality_cost_entry[\s\S]{0,500}DEFAULT\s+0/i);
+  });
+});

--- a/src/__tests__/quality-intelligence-sol22.routes.test.ts
+++ b/src/__tests__/quality-intelligence-sol22.routes.test.ts
@@ -1,0 +1,102 @@
+import { EventEmitter } from "node:events";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = { on: emitter.on.bind(emitter), query: mocks.poolQuery, connect: mocks.poolConnect };
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({ checkNetworkDrive: vi.fn(() => Promise.resolve()) }));
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; role: string }; headers?: Record<string, string | string[] | undefined> },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void
+  ) => {
+    if (req.headers?.["x-test-anonymous"] === "1") {
+      res.status(401).json({ success: false, code: "UNAUTHORIZED" });
+      return;
+    }
+    const role = req.headers?.["x-test-role"];
+    req.user = { id: 1, role: typeof role === "string" ? role : "Responsable Qualite" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import app from "../config/app";
+
+const BASE = "/api/v1/qualite/v2";
+
+beforeEach(() => {
+  mocks.poolQuery.mockReset();
+  mocks.poolConnect.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.clientRelease.mockReset();
+});
+
+describe("SOL-22 intelligence routes", () => {
+  it("refuse l'anonyme avant toute lecture DB", async () => {
+    const response = await request(app)
+      .get(`${BASE}/intelligence?from=2026-08-01&to=2026-08-14`)
+      .set("x-test-anonymous", "1");
+    expect(response.status).toBe(401);
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+
+  it.each(["Chef d'atelier", "Comptabilite"])("refuse le rôle sans analytics_read: %s", async (role) => {
+    const response = await request(app)
+      .get(`${BASE}/intelligence?from=2026-08-01&to=2026-08-14`)
+      .set("x-test-role", role);
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe("QUALITY_CAPABILITY_REQUIRED");
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+
+  it("valide strictement la période avant les requêtes", async () => {
+    const response = await request(app)
+      .get(`${BASE}/intelligence?from=2026-08-14&to=2026-08-01`)
+      .set("x-test-role", "Responsable Qualite");
+    expect(response.status).toBe(422);
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+
+  it("refuse une enquête avec un type de nœud inconnu", async () => {
+    const response = await request(app)
+      .get(`${BASE}/intelligence/investigation?type=secret&id=42`)
+      .set("x-test-role", "Responsable Qualite");
+    expect(response.status).toBe(422);
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+
+  it("exige une clé d'idempotence pour enregistrer un coût", async () => {
+    const response = await request(app)
+      .post(`${BASE}/intelligence/costs`)
+      .set("x-test-role", "Responsable Qualite")
+      .send({
+        non_conformity_id: "11111111-1111-1111-1111-111111111111",
+        category: "SCRAP",
+        amount: 12.5,
+        currency: "EUR",
+        occurred_on: "2026-08-14",
+        source_type: "MANUAL_EVIDENCE",
+        source_id: "NC-2026-1-SCRAP",
+        note: "Constat de rebut signé",
+      });
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe("IDEMPOTENCY_KEY_INVALID");
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+});

--- a/src/module/qualite/controllers/quality-360.controller.ts
+++ b/src/module/qualite/controllers/quality-360.controller.ts
@@ -10,10 +10,13 @@ import { ZodError, type ZodTypeAny, type z } from "zod";
 import { asyncHandler } from "../../../utils/asyncHandler";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 
 import type { QualityActor } from "../repository/quality-360.repository";
 import {
   consumeDerogationSchema,
+  assignQualityCauseSchema,
+  createQualityCostSchema,
   createDeliveryPolicySchema,
   createDerogationSchema,
   createExecutionSchema,
@@ -31,6 +34,8 @@ import {
   planApplicabilityQuerySchema,
   planTransitionSchema,
   qualityCenterQuerySchema,
+  qualityIntelligenceQuerySchema,
+  qualityInvestigationQuerySchema,
   recordMeasurementsSchema,
   reviseDeliveryPolicySchema,
   revisePlanSchema,
@@ -40,6 +45,8 @@ import {
 } from "../validators/quality-360.validators";
 import {
   svcConsumeDerogation,
+  svcAssignQualityCause,
+  svcCreateQualityCost,
   svcCreateDeliveryPolicy,
   svcCreateDerogation,
   svcCreateExecution,
@@ -59,6 +66,8 @@ import {
   svcPreviewExecution,
   svcPreviewVerdict,
   svcQualityCenter,
+  svcQualityIntelligence,
+  svcQualityInvestigation,
   svcRecordMeasurements,
   svcReviseDeliveryPolicy,
   svcRevisePlan,
@@ -388,4 +397,55 @@ export const evaluateEligibility: RequestHandler = asyncHandler(async (req, res)
 export const qualityCenter: RequestHandler = asyncHandler(async (req, res) => {
   const query = parseOrThrow(qualityCenterQuerySchema, req.query);
   res.json(await svcQualityCenter({ horizonDays: query.horizon_days }));
+});
+
+export const qualityIntelligence: RequestHandler = asyncHandler(async (req, res) => {
+  const query = parseOrThrow(qualityIntelligenceQuerySchema, req.query);
+  res.json(await svcQualityIntelligence(query));
+});
+
+export const qualityInvestigation: RequestHandler = asyncHandler(async (req, res) => {
+  const query = parseOrThrow(qualityInvestigationQuerySchema, req.query);
+  const actor = buildActor(req);
+  const out = await svcQualityInvestigation({ query, role: actor.role });
+  await repoInsertAuditLog({
+    user_id: actor.user_id,
+    body: {
+      event_type: "ACTION",
+      action: "qualite.investigation.read",
+      page_key: actor.page_key,
+      entity_type: query.type,
+      entity_id: query.id,
+      path: actor.path,
+      client_session_id: actor.client_session_id,
+      details: {
+        coverage: out.coverage.state,
+        nodes: out.graph.summary.node_count,
+        edges: out.graph.summary.edge_count,
+        missing_link_count: out.coverage.missing_link_count,
+      },
+    },
+    ip: actor.ip,
+    user_agent: actor.user_agent,
+    device_type: actor.device_type,
+    os: actor.os,
+    browser: actor.browser,
+  });
+  res.json(out);
+});
+
+export const createQualityCost: RequestHandler = asyncHandler(async (req, res) => {
+  const { body } = parseOrThrow(createQualityCostSchema, { body: req.body });
+  res.status(201).json(
+    await svcCreateQualityCost({
+      body,
+      actor: buildActor(req),
+      idempotencyKey: idempotencyKey(req),
+    })
+  );
+});
+
+export const assignQualityCause: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(assignQualityCauseSchema, { params: req.params, body: req.body });
+  res.json(await svcAssignQualityCause({ id: parsed.params.id, body: parsed.body, actor: buildActor(req) }));
 });

--- a/src/module/qualite/domain/quality-intelligence.ts
+++ b/src/module/qualite/domain/quality-intelligence.ts
@@ -1,0 +1,214 @@
+export const QUALITY_METRIC_RELIABILITIES = ["CONFIRMED", "PARTIAL", "UNAVAILABLE"] as const;
+export type QualityMetricReliability = (typeof QUALITY_METRIC_RELIABILITIES)[number];
+
+export type QualityDecisionMetric = {
+  code: "FPY" | "PPM" | "CLOSURE_DELAY" | "SCRAP_COST" | "REWORK_COST" | "COPQ";
+  label: string;
+  value: number | null;
+  unit: "%" | "ppm" | "days" | "currency";
+  currency: string | null;
+  numerator: number | null;
+  denominator: number | null;
+  reliability: QualityMetricReliability;
+  missing: string[];
+  formula: string;
+  source: string[];
+};
+
+export type QualityMetricInputs = {
+  firstPassConformingQty: number;
+  firstPassControlledQty: number;
+  firstPassMissingData: number;
+  defectQty: number;
+  controlledQty: number;
+  controlsMissingQuantities: number;
+  closureDurationsDays: number[];
+  scrapCost: number | null;
+  reworkCost: number | null;
+  otherPoorQualityCost: number | null;
+  costCurrency: string | null;
+  costCurrencyCount: number;
+};
+
+function round(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+function ratioReliability(denominator: number, missing: number): QualityMetricReliability {
+  if (denominator <= 0) return "UNAVAILABLE";
+  return missing > 0 ? "PARTIAL" : "CONFIRMED";
+}
+
+function costMetric(params: {
+  code: "SCRAP_COST" | "REWORK_COST" | "COPQ";
+  label: string;
+  amount: number | null;
+  currency: string | null;
+  currencyCount: number;
+  source: string[];
+  additionalMissing?: string[];
+}): QualityDecisionMetric {
+  const missing: string[] = [...(params.additionalMissing ?? [])];
+  if (params.amount === null) missing.push("cost_entries");
+  if (!params.currency) missing.push("currency");
+  if (params.currencyCount > 1) missing.push("currency_conversion_policy");
+  const available = params.amount !== null && Boolean(params.currency) && params.currencyCount <= 1;
+  const reliability: QualityMetricReliability = !available
+    ? "UNAVAILABLE"
+    : missing.length > 0
+      ? "PARTIAL"
+      : "CONFIRMED";
+  return {
+    code: params.code,
+    label: params.label,
+    value: available ? round(params.amount!, 2) : null,
+    unit: "currency",
+    currency: available ? params.currency : null,
+    numerator: available ? params.amount : null,
+    denominator: null,
+    reliability,
+    missing,
+    formula: "Somme des écritures de coût qualité immuables de la catégorie sur la période.",
+    source: params.source,
+  };
+}
+
+/**
+ * Calculs purs des indicateurs SOL-22. Une absence de dénominateur ou de coût
+ * reste `null`; elle n'est jamais maquillée en zéro.
+ */
+export function computeQualityDecisionMetrics(input: QualityMetricInputs): QualityDecisionMetric[] {
+  const fpyReliability = ratioReliability(input.firstPassControlledQty, input.firstPassMissingData);
+  const ppmReliability = ratioReliability(input.controlledQty, input.controlsMissingQuantities);
+  const closureCount = input.closureDurationsDays.length;
+  const closureSum = input.closureDurationsDays.reduce((sum, value) => sum + value, 0);
+
+  const scrap = costMetric({
+    code: "SCRAP_COST",
+    label: "Coût des rebuts",
+    amount: input.scrapCost,
+    currency: input.costCurrency,
+    currencyCount: input.costCurrencyCount,
+    source: ["quality_cost_entry(category=SCRAP)"],
+  });
+  const rework = costMetric({
+    code: "REWORK_COST",
+    label: "Coût des retouches",
+    amount: input.reworkCost,
+    currency: input.costCurrency,
+    currencyCount: input.costCurrencyCount,
+    source: ["quality_cost_entry(category=REWORK)"],
+  });
+  const allCosts = [input.scrapCost, input.reworkCost, input.otherPoorQualityCost];
+  const missingCopqCategories = [
+    input.scrapCost === null ? "scrap_cost_entries" : null,
+    input.reworkCost === null ? "rework_cost_entries" : null,
+    input.otherPoorQualityCost === null ? "other_quality_cost_entries" : null,
+  ].filter((value): value is string => value !== null);
+  const copqAmount = allCosts.every((value) => value === null)
+    ? null
+    : allCosts.reduce<number>((sum, value) => sum + (value ?? 0), 0);
+
+  return [
+    {
+      code: "FPY",
+      label: "Rendement au premier passage",
+      value: fpyReliability === "UNAVAILABLE"
+        ? null
+        : round((input.firstPassConformingQty / input.firstPassControlledQty) * 100, 2),
+      unit: "%",
+      currency: null,
+      numerator: fpyReliability === "UNAVAILABLE" ? null : input.firstPassConformingQty,
+      denominator: fpyReliability === "UNAVAILABLE" ? null : input.firstPassControlledQty,
+      reliability: fpyReliability,
+      missing: input.firstPassControlledQty <= 0
+        ? ["first_pass_quantities"]
+        : input.firstPassMissingData > 0
+          ? ["first_pass_source_or_quantity"]
+          : [],
+      formula: "Quantité conforme au premier passage / quantité contrôlée au premier passage × 100.",
+      source: ["quality_control.qty_conforming", "quality_control.qty_controlled", "quality_control.source_type", "quality_control.source_id", "quality_control.validation_date"],
+    },
+    {
+      code: "PPM",
+      label: "Pièces non conformes par million contrôlé",
+      value: ppmReliability === "UNAVAILABLE" ? null : round((input.defectQty / input.controlledQty) * 1_000_000, 0),
+      unit: "ppm",
+      currency: null,
+      numerator: ppmReliability === "UNAVAILABLE" ? null : input.defectQty,
+      denominator: ppmReliability === "UNAVAILABLE" ? null : input.controlledQty,
+      reliability: ppmReliability,
+      missing: input.controlledQty <= 0
+        ? ["controlled_quantity"]
+        : input.controlsMissingQuantities > 0
+          ? ["controlled_or_conforming_quantity"]
+          : [],
+      formula: "(Quantité contrôlée − quantité conforme) / quantité contrôlée × 1 000 000.",
+      source: ["quality_control.qty_controlled", "quality_control.qty_conforming", "quality_control.validation_date"],
+    },
+    {
+      code: "CLOSURE_DELAY",
+      label: "Délai moyen de clôture des non-conformités",
+      value: closureCount > 0 ? round(closureSum / closureCount, 2) : null,
+      unit: "days",
+      currency: null,
+      numerator: closureCount > 0 ? round(closureSum, 4) : null,
+      denominator: closureCount > 0 ? closureCount : null,
+      reliability: closureCount > 0 ? "CONFIRMED" : "UNAVAILABLE",
+      missing: closureCount > 0 ? [] : ["closed_non_conformities"],
+      formula: "Moyenne de (date de clôture − date de détection) en jours calendaires.",
+      source: ["non_conformity.detection_date", "non_conformity.closed_at"],
+    },
+    scrap,
+    rework,
+    costMetric({
+      code: "COPQ",
+      label: "Coût de non-qualité",
+      amount: copqAmount,
+      currency: input.costCurrency,
+      currencyCount: input.costCurrencyCount,
+      source: ["quality_cost_entry"],
+      additionalMissing: missingCopqCategories,
+    }),
+  ];
+}
+
+export type SpcReadinessInput = {
+  policyActive: boolean;
+  samplingRule: string | null;
+  expectedUnit: string | null;
+  cadenceMinutes: number | null;
+  subgroupSize: number | null;
+  minSubgroups: number | null;
+  observedSubgroups: number;
+  observedUnits: string[];
+  cadenceCoverageRatio: number | null;
+};
+
+export type SpcReadiness = {
+  enabled: boolean;
+  reliability: QualityMetricReliability;
+  missing: string[];
+};
+
+/** SPC est refusé par défaut tant que plan, unité, cadence et volume ne sont pas prouvés. */
+export function assessSpcReadiness(input: SpcReadinessInput): SpcReadiness {
+  const missing: string[] = [];
+  if (!input.policyActive) missing.push("active_spc_policy");
+  if (!input.samplingRule) missing.push("sampling_rule");
+  if (!input.expectedUnit) missing.push("expected_unit");
+  if (!input.cadenceMinutes || input.cadenceMinutes <= 0) missing.push("sampling_frequency");
+  if (!input.subgroupSize || input.subgroupSize < 2) missing.push("subgroup_size");
+  if (!input.minSubgroups || input.minSubgroups < 2) missing.push("minimum_subgroups");
+  if (input.expectedUnit && (input.observedUnits.length !== 1 || input.observedUnits[0] !== input.expectedUnit)) {
+    missing.push("consistent_observed_unit");
+  }
+  if (input.minSubgroups && input.observedSubgroups < input.minSubgroups) missing.push("observed_subgroups");
+  if (input.cadenceCoverageRatio === null || input.cadenceCoverageRatio < 0.9) missing.push("sampling_cadence_coverage");
+  return {
+    enabled: missing.length === 0,
+    reliability: missing.length === 0 ? "CONFIRMED" : input.observedSubgroups > 0 ? "PARTIAL" : "UNAVAILABLE",
+    missing,
+  };
+}

--- a/src/module/qualite/domain/quality-policy.ts
+++ b/src/module/qualite/domain/quality-policy.ts
@@ -31,6 +31,7 @@ export const QUALITY_CAPABILITIES = [
   "closure_verify",
   "documents_read",
   "audit_read",
+  "analytics_read",
   "settings_manage",
 ] as const;
 
@@ -67,6 +68,7 @@ const CAPABILITY_NEEDLES: Record<QualityCapability, readonly string[]> = {
   closure_verify: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
   documents_read: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "production", "atelier", "method"],
   audit_read: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  analytics_read: ["admin", "administrateur", "directeur", "direction", "qualit", "quality", "qse"],
   settings_manage: ["admin", "administrateur", "directeur"],
 };
 
@@ -74,7 +76,6 @@ export function roleHasQualityCapability(
   role: string | null | undefined,
   capability: QualityCapability
 ): boolean {
-  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   const needles = CAPABILITY_NEEDLES[capability];
@@ -580,4 +581,3 @@ export function assertOptimisticVersion(params: {
     );
   }
 }
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/qualite/middlewares/quality-authorization.middleware.ts
+++ b/src/module/qualite/middlewares/quality-authorization.middleware.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
-import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import { requestHasElevatedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { roleHasQualityCapability, type QualityCapability } from "../domain/quality-policy";
 
 /**
@@ -16,7 +16,7 @@ export function requireQualityCapability(capability: QualityCapability): Request
       return;
     }
     if (
-      !requestHasGrantedAccountModuleAccess(req) &&
+      !requestHasElevatedAccountModuleAccess(req) &&
       !roleHasQualityCapability(req.user.role, capability)
     ) {
       next(

--- a/src/module/qualite/repository/quality-intelligence.repository.ts
+++ b/src/module/qualite/repository/quality-intelligence.repository.ts
@@ -1,0 +1,563 @@
+import pool from "../../../config/database";
+import { withRealtimeOutboxTransaction } from "../../../shared/realtime/realtime-outbox-transaction";
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import { repoCenter as repoMetrologyCenter } from "../../metrologie/repository/metrology-registry.repository";
+import {
+  assessSpcReadiness,
+  computeQualityDecisionMetrics,
+  type QualityDecisionMetric,
+  type QualityMetricReliability,
+} from "../domain/quality-intelligence";
+import {
+  decideQualityReceipt,
+  assertOptimisticVersion,
+  normalizeQualityIdempotencyKey,
+  qualityRequestHash,
+} from "../domain/quality-policy";
+import type {
+  CreateQualityCostBodyDTO,
+  AssignQualityCauseBodyDTO,
+  QualityIntelligenceQueryDTO,
+} from "../validators/quality-360.validators";
+import type { QualityActor } from "./quality-360.repository";
+
+type AggregateRow = {
+  first_pass_conforming_qty: string | null;
+  first_pass_controlled_qty: string | null;
+  first_pass_missing_data: string;
+  defect_qty: string | null;
+  controlled_qty: string | null;
+  controls_missing_quantities: string;
+  freshest_control_at: string | null;
+};
+
+type ClosureRow = { duration_days: string; closed_at: string };
+type CostRow = { category: string; amount: string; currency: string; freshest_cost_at: string };
+type ParetoRow = { cause_code: string; label: string; count: string; defect_qty: string | null };
+type TrendRow = {
+  week_start: string;
+  controlled_qty: string;
+  conforming_qty: string;
+  missing_qty: string;
+};
+type CapaRow = {
+  id: string;
+  non_conformity_id: string;
+  non_conformity_reference: string;
+  description: string;
+  responsible_user_id: number;
+  due_date: string | null;
+  status: string;
+  priority: string;
+  mandatory: boolean;
+  evidence_required: boolean;
+  evidence_count: string;
+};
+type SpcPolicyRow = {
+  id: string;
+  code: string;
+  version: number;
+  characteristic_key: string;
+  expected_unit: string;
+  sampling_rule: string;
+  subgroup_size: number;
+  min_subgroups: number;
+  cadence_minutes: number;
+  observed_subgroups: string;
+  observed_units: string[] | null;
+  control_times: string[] | null;
+};
+
+function numberOf(value: string | number | null | undefined): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function nullableAmount(rows: CostRow[], categories: string[]): number | null {
+  const selected = rows.filter((row) => categories.includes(row.category));
+  return selected.length > 0 ? selected.reduce((sum, row) => sum + numberOf(row.amount), 0) : null;
+}
+
+function cadenceCoverage(times: string[], cadenceMinutes: number): number | null {
+  if (times.length < 2 || cadenceMinutes <= 0) return null;
+  const expectedMs = cadenceMinutes * 60_000;
+  let valid = 0;
+  let total = 0;
+  for (let index = 1; index < times.length; index += 1) {
+    const previous = Date.parse(times[index - 1]!);
+    const current = Date.parse(times[index]!);
+    if (!Number.isFinite(previous) || !Number.isFinite(current) || current <= previous) continue;
+    total += 1;
+    const ratio = (current - previous) / expectedMs;
+    if (ratio >= 0.5 && ratio <= 1.5) valid += 1;
+  }
+  return total > 0 ? valid / total : null;
+}
+
+export type QualityIntelligenceDTO = {
+  period: { from: string; to: string; timezone: "UTC" };
+  generated_at: string;
+  freshness: { latest_source_at: string | null; age_seconds: number | null };
+  source: string[];
+  reliability: QualityMetricReliability;
+  metrics: QualityDecisionMetric[];
+  pareto: Array<{ cause_code: string; label: string; count: number; defect_qty: number | null }>;
+  trend: Array<{
+    week_start: string;
+    controlled_qty: number | null;
+    conforming_qty: number | null;
+    fpy_percent: number | null;
+    reliability: QualityMetricReliability;
+  }>;
+  capa_queue: Array<{
+    id: string;
+    non_conformity_id: string;
+    non_conformity_reference: string;
+    description: string;
+    responsible_user_id: number;
+    due_date: string | null;
+    status: string;
+    priority: string;
+    mandatory: boolean;
+    closure_evidence: "NOT_REQUIRED" | "MISSING" | "AVAILABLE";
+  }>;
+  spc: Array<{
+    policy_id: string;
+    code: string;
+    version: number;
+    characteristic_key: string;
+    enabled: boolean;
+    reliability: QualityMetricReliability;
+    missing: string[];
+  }>;
+  metrology: Awaited<ReturnType<typeof repoMetrologyCenter>>;
+};
+
+export async function repoQualityIntelligence(
+  query: QualityIntelligenceQueryDTO
+): Promise<QualityIntelligenceDTO> {
+  const from = `${query.from}T00:00:00.000Z`;
+  const toExclusiveDate = new Date(`${query.to}T00:00:00.000Z`);
+  toExclusiveDate.setUTCDate(toExclusiveDate.getUTCDate() + 1);
+  const toExclusive = toExclusiveDate.toISOString();
+  const range = [from, toExclusive];
+
+  const [aggregateRes, closureRes, costRes, paretoRes, trendRes, capaRes, spcRes, metrology] = await Promise.all([
+    pool.query<AggregateRow>(
+      `
+        WITH finalized AS (
+          SELECT qc.*,
+                 row_number() OVER (
+                   PARTITION BY COALESCE(qc.source_type || ':' || qc.source_id, 'LEGACY:' || qc.id::text)
+                   ORDER BY qc.validation_date ASC, qc.created_at ASC, qc.id ASC
+                 ) AS pass_no
+          FROM public.quality_control qc
+          WHERE qc.validation_date >= $1::timestamptz
+            AND qc.validation_date < $2::timestamptz
+        ), first_pass AS (
+          SELECT * FROM finalized WHERE pass_no = 1
+        )
+        SELECT
+          SUM(qty_conforming) FILTER (WHERE qty_controlled > 0)::text AS first_pass_conforming_qty,
+          SUM(qty_controlled) FILTER (WHERE qty_controlled > 0)::text AS first_pass_controlled_qty,
+          COUNT(*) FILTER (
+            WHERE source_type IS NULL OR source_id IS NULL OR qty_controlled <= 0 OR qty_conforming IS NULL
+          )::text AS first_pass_missing_data,
+          SUM(GREATEST(qty_controlled - qty_conforming, 0)) FILTER (WHERE qty_controlled > 0)::text AS defect_qty,
+          SUM(qty_controlled) FILTER (WHERE qty_controlled > 0)::text AS controlled_qty,
+          COUNT(*) FILTER (WHERE qty_controlled <= 0 OR qty_conforming IS NULL)::text AS controls_missing_quantities,
+          MAX(validation_date)::text AS freshest_control_at
+        FROM first_pass
+      `,
+      range
+    ),
+    pool.query<ClosureRow>(
+      `
+        SELECT (EXTRACT(EPOCH FROM (closed_at - detection_date)) / 86400.0)::text AS duration_days,
+               closed_at::text AS closed_at
+        FROM public.non_conformity
+        WHERE closed_at >= $1::timestamptz AND closed_at < $2::timestamptz
+          AND closed_at >= detection_date
+      `,
+      range
+    ),
+    pool.query<CostRow>(
+      `
+        SELECT category, SUM(amount)::text AS amount, currency, MAX(created_at)::text AS freshest_cost_at
+        FROM public.quality_cost_entry
+        WHERE occurred_on >= $1::date AND occurred_on < $2::date
+        GROUP BY category, currency
+      `,
+      [query.from, toExclusive.slice(0, 10)]
+    ),
+    pool.query<ParetoRow>(
+      `
+        SELECT nc.cause_code, cc.label, COUNT(*)::text AS count, SUM(nc.qty)::text AS defect_qty
+        FROM public.non_conformity nc
+        JOIN public.quality_cause_catalog cc ON cc.code = nc.cause_code
+        WHERE nc.detection_date >= $1::timestamptz AND nc.detection_date < $2::timestamptz
+          AND nc.cause_code IS NOT NULL
+        GROUP BY nc.cause_code, cc.label
+        ORDER BY COUNT(*) DESC, nc.cause_code ASC
+        LIMIT 20
+      `,
+      range
+    ),
+    pool.query<TrendRow>(
+      `
+        WITH finalized AS (
+          SELECT qc.*,
+                 row_number() OVER (
+                   PARTITION BY COALESCE(qc.source_type || ':' || qc.source_id, 'LEGACY:' || qc.id::text)
+                   ORDER BY qc.validation_date ASC, qc.created_at ASC, qc.id ASC
+                 ) AS pass_no
+          FROM public.quality_control qc
+          WHERE qc.validation_date >= $1::timestamptz AND qc.validation_date < $2::timestamptz
+        ), first_pass AS (
+          SELECT * FROM finalized WHERE pass_no = 1
+        )
+        SELECT date_trunc('week', validation_date AT TIME ZONE 'UTC')::date::text AS week_start,
+               SUM(qty_controlled) FILTER (WHERE qty_controlled > 0)::text AS controlled_qty,
+               SUM(qty_conforming) FILTER (WHERE qty_controlled > 0)::text AS conforming_qty,
+               COUNT(*) FILTER (WHERE qty_controlled <= 0 OR qty_conforming IS NULL)::text AS missing_qty
+        FROM first_pass
+        GROUP BY 1 ORDER BY 1
+      `,
+      range
+    ),
+    pool.query<CapaRow>(
+      `
+        SELECT a.id::text, a.non_conformity_id::text, nc.reference AS non_conformity_reference,
+               a.description, a.responsible_user_id, a.due_date::text, a.status::text,
+               a.priority, a.mandatory, a.evidence_required,
+               COUNT(d.id)::text AS evidence_count
+        FROM public.quality_action a
+        JOIN public.non_conformity nc ON nc.id = a.non_conformity_id
+        LEFT JOIN public.quality_documents d
+          ON d.entity_type = 'ACTION' AND d.entity_id = a.id AND d.removed_at IS NULL
+        WHERE a.status <> 'VERIFIED'
+        GROUP BY a.id, nc.reference
+        ORDER BY
+          CASE a.priority WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1 WHEN 'NORMAL' THEN 2 ELSE 3 END,
+          a.due_date ASC NULLS LAST, a.created_at ASC
+        LIMIT 100
+      `
+    ),
+    pool.query<SpcPolicyRow>(
+      `
+        WITH observed AS (
+          SELECT p.id AS policy_id,
+                 CASE WHEN COUNT(qcp.id) >= p.subgroup_size THEN qc.id ELSE NULL END AS control_id,
+                 CASE WHEN COUNT(qcp.id) >= p.subgroup_size THEN MIN(qcp.measured_at) ELSE NULL END AS measured_at,
+                 array_remove(array_agg(DISTINCT qcp.unit), NULL) AS units
+          FROM public.quality_spc_policy p
+          LEFT JOIN public.quality_control qc
+            ON qc.validation_date >= $1::timestamptz
+           AND qc.validation_date < $2::timestamptz
+           AND qc.validation_date >= p.effective_from
+           AND (p.effective_to IS NULL OR qc.validation_date <= p.effective_to)
+          LEFT JOIN public.quality_control_points qcp
+            ON qcp.quality_control_id = qc.id AND qcp.characteristic_key = p.characteristic_key
+          WHERE (p.active OR p.retired_at IS NOT NULL) AND p.effective_from < $2::timestamptz
+            AND (p.effective_to IS NULL OR p.effective_to >= $1::timestamptz)
+          GROUP BY p.id, qc.id
+        )
+        SELECT p.id::text, p.code, p.version, p.characteristic_key, p.expected_unit,
+               p.sampling_rule, p.subgroup_size, p.min_subgroups, p.cadence_minutes,
+               COUNT(DISTINCT o.control_id)::text AS observed_subgroups,
+               COALESCE(array_agg(DISTINCT unit_value) FILTER (WHERE unit_value IS NOT NULL), ARRAY[]::text[]) AS observed_units,
+               COALESCE(array_agg(o.measured_at::text ORDER BY o.measured_at) FILTER (WHERE o.measured_at IS NOT NULL), ARRAY[]::text[]) AS control_times
+        FROM public.quality_spc_policy p
+        LEFT JOIN observed o ON o.policy_id = p.id
+        LEFT JOIN LATERAL unnest(COALESCE(o.units, ARRAY[]::text[])) unit_value ON TRUE
+        WHERE (p.active OR p.retired_at IS NOT NULL) AND p.effective_from < $2::timestamptz
+          AND (p.effective_to IS NULL OR p.effective_to >= $1::timestamptz)
+        GROUP BY p.id
+        ORDER BY p.code, p.version DESC
+        LIMIT 50
+      `,
+      range
+    ),
+    repoMetrologyCenter({ site: null, categorieCode: null, horizonDays: query.horizon_days }),
+  ]);
+
+  const aggregate = aggregateRes.rows[0] ?? {
+    first_pass_conforming_qty: null,
+    first_pass_controlled_qty: null,
+    first_pass_missing_data: "0",
+    defect_qty: null,
+    controlled_qty: null,
+    controls_missing_quantities: "0",
+    freshest_control_at: null,
+  };
+  const currencies = [...new Set(costRes.rows.map((row) => row.currency))];
+  const costCurrency = currencies.length === 1 ? currencies[0]! : null;
+  const metrics = computeQualityDecisionMetrics({
+    firstPassConformingQty: numberOf(aggregate.first_pass_conforming_qty),
+    firstPassControlledQty: numberOf(aggregate.first_pass_controlled_qty),
+    firstPassMissingData: numberOf(aggregate.first_pass_missing_data),
+    defectQty: numberOf(aggregate.defect_qty),
+    controlledQty: numberOf(aggregate.controlled_qty),
+    controlsMissingQuantities: numberOf(aggregate.controls_missing_quantities),
+    closureDurationsDays: closureRes.rows.map((row) => numberOf(row.duration_days)),
+    scrapCost: nullableAmount(costRes.rows, ["SCRAP"]),
+    reworkCost: nullableAmount(costRes.rows, ["REWORK"]),
+    otherPoorQualityCost: nullableAmount(costRes.rows, ["SORTING", "CONTAINMENT", "RETURN", "OTHER"]),
+    costCurrency,
+    costCurrencyCount: currencies.length,
+  });
+
+  const freshnessCandidates = [
+    aggregate.freshest_control_at,
+    ...closureRes.rows.map((row) => row.closed_at),
+    ...costRes.rows.map((row) => row.freshest_cost_at),
+  ].filter((value): value is string => Boolean(value));
+  const latestSourceMs = freshnessCandidates.reduce((latest, value) => Math.max(latest, Date.parse(value)), 0);
+  const generatedAt = new Date();
+
+  const reliability: QualityMetricReliability = metrics.every((metric) => metric.reliability === "CONFIRMED")
+    ? "CONFIRMED"
+    : metrics.some((metric) => metric.reliability !== "UNAVAILABLE")
+      ? "PARTIAL"
+      : "UNAVAILABLE";
+
+  return {
+    period: { from: query.from, to: query.to, timezone: "UTC" },
+    generated_at: generatedAt.toISOString(),
+    freshness: {
+      latest_source_at: latestSourceMs > 0 ? new Date(latestSourceMs).toISOString() : null,
+      age_seconds: latestSourceMs > 0 ? Math.max(0, Math.round((generatedAt.getTime() - latestSourceMs) / 1000)) : null,
+    },
+    source: [
+      "quality_control",
+      "non_conformity",
+      "quality_action",
+      "quality_documents",
+      "quality_cost_entry",
+      "quality_spc_policy",
+      "metrologie_equipements",
+      "metrologie_plan_version",
+    ],
+    reliability,
+    metrics,
+    pareto: paretoRes.rows.map((row) => ({
+      cause_code: row.cause_code,
+      label: row.label,
+      count: numberOf(row.count),
+      defect_qty: row.defect_qty === null ? null : numberOf(row.defect_qty),
+    })),
+    trend: trendRes.rows.map((row) => {
+      const controlled = numberOf(row.controlled_qty);
+      const conforming = numberOf(row.conforming_qty);
+      const missing = numberOf(row.missing_qty);
+      return {
+        week_start: row.week_start,
+        controlled_qty: controlled > 0 ? controlled : null,
+        conforming_qty: controlled > 0 ? conforming : null,
+        fpy_percent: controlled > 0 ? Math.round((conforming / controlled) * 10_000) / 100 : null,
+        reliability: controlled <= 0 ? "UNAVAILABLE" : missing > 0 ? "PARTIAL" : "CONFIRMED",
+      };
+    }),
+    capa_queue: capaRes.rows.map((row) => ({
+      id: row.id,
+      non_conformity_id: row.non_conformity_id,
+      non_conformity_reference: row.non_conformity_reference,
+      description: row.description,
+      responsible_user_id: row.responsible_user_id,
+      due_date: row.due_date,
+      status: row.status,
+      priority: row.priority,
+      mandatory: row.mandatory,
+      closure_evidence: !row.evidence_required
+        ? "NOT_REQUIRED"
+        : numberOf(row.evidence_count) > 0
+          ? "AVAILABLE"
+          : "MISSING",
+    })),
+    spc: spcRes.rows.map((row) => {
+      const readiness = assessSpcReadiness({
+        policyActive: true,
+        samplingRule: row.sampling_rule,
+        expectedUnit: row.expected_unit,
+        cadenceMinutes: row.cadence_minutes,
+        subgroupSize: row.subgroup_size,
+        minSubgroups: row.min_subgroups,
+        observedSubgroups: numberOf(row.observed_subgroups),
+        observedUnits: row.observed_units ?? [],
+        cadenceCoverageRatio: cadenceCoverage(row.control_times ?? [], row.cadence_minutes),
+      });
+      return {
+        policy_id: row.id,
+        code: row.code,
+        version: row.version,
+        characteristic_key: row.characteristic_key,
+        ...readiness,
+      };
+    }),
+    metrology,
+  };
+}
+
+export type QualityCostEntryDTO = CreateQualityCostBodyDTO & {
+  id: string;
+  created_at: string;
+  created_by: number;
+};
+
+export async function repoCreateQualityCost(params: {
+  body: CreateQualityCostBodyDTO;
+  actor: QualityActor;
+  idempotencyKey: string | null;
+}): Promise<QualityCostEntryDTO> {
+  const key = normalizeQualityIdempotencyKey(params.idempotencyKey);
+  const requestHash = qualityRequestHash("QUALITY_COST_CREATE", params.body);
+  const client = await pool.connect();
+  return withRealtimeOutboxTransaction(client, async (tx) => {
+      const existing = await tx.query<{ id: string; request_hash: string }>(
+        `SELECT id::text, request_hash FROM public.quality_cost_entry
+         WHERE created_by = $1 AND idempotency_key = $2 FOR UPDATE`,
+        [params.actor.user_id, key]
+      );
+      const receipt = decideQualityReceipt(existing.rows[0]?.request_hash, requestHash);
+      if (receipt === "CONFLICT") {
+        throw new HttpError(409, "QUALITY_COST_IDEMPOTENCY_CONFLICT", "Cette clé a déjà servi pour un autre coût qualité.");
+      }
+      if (receipt === "REPLAY") {
+        const replay = await tx.query<QualityCostEntryDTO>(
+          `SELECT id::text, non_conformity_id::text, category, amount::float8 AS amount,
+                  currency, occurred_on::text, source_type, source_id,
+                  evidence_document_id::text, note, created_at::text, created_by
+           FROM public.quality_cost_entry WHERE id = $1::uuid`,
+          [existing.rows[0]!.id]
+        );
+        return replay.rows[0]!;
+      }
+
+      const inserted = await tx.query<QualityCostEntryDTO>(
+        `
+          INSERT INTO public.quality_cost_entry (
+            non_conformity_id, category, amount, currency, occurred_on,
+            source_type, source_id, evidence_document_id, note,
+            idempotency_key, request_hash, created_by
+          ) VALUES ($1::uuid,$2,$3,$4,$5::date,$6,$7,$8::uuid,$9,$10,$11,$12)
+          RETURNING id::text, non_conformity_id::text, category, amount::float8 AS amount,
+                    currency, occurred_on::text, source_type, source_id,
+                    evidence_document_id::text, note, created_at::text, created_by
+        `,
+        [
+          params.body.non_conformity_id,
+          params.body.category,
+          params.body.amount,
+          params.body.currency,
+          params.body.occurred_on,
+          params.body.source_type,
+          params.body.source_id,
+          params.body.evidence_document_id ?? null,
+          params.body.note,
+          key,
+          requestHash,
+          params.actor.user_id,
+        ]
+      );
+      const result = inserted.rows[0];
+      if (!result) throw new Error("QUALITY_COST_INSERT_FAILED");
+      await repoInsertAuditLog({
+        user_id: params.actor.user_id,
+        body: {
+          event_type: "ACTION",
+          action: "qualite.cost.create",
+          page_key: params.actor.page_key,
+          entity_type: "quality_cost_entry",
+          entity_id: result.id,
+          path: params.actor.path,
+          client_session_id: params.actor.client_session_id,
+          details: {
+            non_conformity_id: params.body.non_conformity_id,
+            category: params.body.category,
+            currency: params.body.currency,
+            source_type: params.body.source_type,
+          },
+        },
+        ip: params.actor.ip,
+        user_agent: params.actor.user_agent,
+        device_type: params.actor.device_type,
+        os: params.actor.os,
+        browser: params.actor.browser,
+        tx,
+      });
+      return result;
+  });
+}
+
+export async function repoAssignQualityCause(params: {
+  id: string;
+  body: AssignQualityCauseBodyDTO;
+  actor: QualityActor;
+}): Promise<{ id: string; cause_code: string; updated_at: string }> {
+  const client = await pool.connect();
+  return withRealtimeOutboxTransaction(client, async (tx) => {
+      const currentRes = await tx.query<{ id: string; cause_code: string | null; updated_at: string }>(
+        `SELECT id::text, cause_code, updated_at::text FROM public.non_conformity
+         WHERE id = $1::uuid FOR UPDATE`,
+        [params.id]
+      );
+      const current = currentRes.rows[0];
+      if (!current) throw new HttpError(404, "NOT_FOUND", "Non-conformité introuvable.");
+      if (current.cause_code === params.body.cause_code) {
+        return { id: current.id, cause_code: current.cause_code, updated_at: current.updated_at };
+      }
+      assertOptimisticVersion({ expectedUpdatedAt: params.body.expected_updated_at, currentUpdatedAt: current.updated_at });
+      const cause = await tx.query<{ code: string }>(
+        `SELECT code FROM public.quality_cause_catalog WHERE code = $1 AND active`,
+        [params.body.cause_code]
+      );
+      if (!cause.rows[0]) {
+        throw new HttpError(422, "QUALITY_CAUSE_UNKNOWN", "La cause structurée est inconnue ou inactive.");
+      }
+      const updated = await tx.query<{ id: string; cause_code: string; updated_at: string }>(
+        `UPDATE public.non_conformity
+         SET cause_code = $2, updated_at = now(), updated_by = $3
+         WHERE id = $1::uuid
+         RETURNING id::text, cause_code, updated_at::text`,
+        [params.id, params.body.cause_code, params.actor.user_id]
+      );
+      const result = updated.rows[0]!;
+      await tx.query(
+        `INSERT INTO public.quality_event_log (
+           entity_type, entity_id, event_type, old_values, new_values, user_id,
+           correlation_id, rule_code, reason, request_id, source
+         )
+         VALUES ('NON_CONFORMITY', $1::uuid, 'CAUSE_ASSIGNED', $2::jsonb, $3::jsonb, $4,
+                 $1::uuid, 'QUALITY_STRUCTURED_CAUSE_SOL22', $5, $6, 'api')`,
+        [
+          params.id,
+          JSON.stringify({ cause_code: current.cause_code }),
+          JSON.stringify({ cause_code: result.cause_code }),
+          params.actor.user_id,
+          params.body.reason,
+          params.actor.request_id,
+        ]
+      );
+      await repoInsertAuditLog({
+        user_id: params.actor.user_id,
+        body: {
+          event_type: "ACTION",
+          action: "qualite.nc.cause.assign",
+          page_key: params.actor.page_key,
+          entity_type: "non_conformity",
+          entity_id: params.id,
+          path: params.actor.path,
+          client_session_id: params.actor.client_session_id,
+          details: { from: current.cause_code, to: result.cause_code, reason: params.body.reason },
+        },
+        ip: params.actor.ip,
+        user_agent: params.actor.user_agent,
+        device_type: params.actor.device_type,
+        os: params.actor.os,
+        browser: params.actor.browser,
+        tx,
+      });
+      return result;
+  });
+}

--- a/src/module/qualite/routes/quality-360.routes.ts
+++ b/src/module/qualite/routes/quality-360.routes.ts
@@ -4,6 +4,8 @@ import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { requireQualityCapability } from "../middlewares/quality-authorization.middleware";
 import {
   consumeDerogation,
+  assignQualityCause,
+  createQualityCost,
   createDeliveryPolicy,
   createDerogation,
   createExecution,
@@ -23,6 +25,8 @@ import {
   previewExecution,
   previewVerdict,
   qualityCenter,
+  qualityIntelligence,
+  qualityInvestigation,
   recordMeasurements,
   reviseDeliveryPolicy,
   revisePlan,
@@ -60,6 +64,9 @@ const requireDerogationTransitionCapability: RequestHandler = (req, res, next) =
 // Centre Qualité et éligibilité (lecture).
 router.get("/center", requireQualityCapability("read"), qualityCenter);
 router.get("/eligibility", requireQualityCapability("read"), evaluateEligibility);
+router.get("/intelligence", requireQualityCapability("analytics_read"), qualityIntelligence);
+router.get("/intelligence/investigation", requireQualityCapability("analytics_read"), qualityInvestigation);
+router.post("/intelligence/costs", requireQualityCapability("capa_manage"), createQualityCost);
 
 // Politique globale de liberation des BL : aucune valeur par defaut n'est creee.
 router.get("/delivery-release-policies", requireQualityCapability("read"), listDeliveryPolicies);
@@ -113,5 +120,6 @@ router.post(
 router.get("/non-conformities/:id/analysis", requireQualityCapability("read"), getNcAnalysis);
 router.put("/non-conformities/:id/analysis", requireQualityCapability("nc_manage"), upsertNcAnalysis);
 router.post("/non-conformities/:id/transitions", requireQualityCapability("nc_manage"), transitionNc);
+router.put("/non-conformities/:id/cause", requireQualityCapability("nc_manage"), assignQualityCause);
 
 export default router;

--- a/src/module/qualite/services/quality-360.service.ts
+++ b/src/module/qualite/services/quality-360.service.ts
@@ -35,6 +35,13 @@ import {
   repoTransitionDeliveryPolicy,
   repoUpdateDeliveryPolicy,
 } from "../repository/quality-delivery-policy.repository";
+import {
+  repoCreateQualityCost,
+  repoAssignQualityCause,
+  repoQualityIntelligence,
+} from "../repository/quality-intelligence.repository";
+import { svcGetTraceabilityChain } from "../../traceability/services/traceability-360.service";
+import type { QualityInvestigationQueryDTO } from "../validators/quality-360.validators";
 
 export const svcListDeliveryPolicies = repoListDeliveryPolicies;
 export const svcGetDeliveryPolicy = repoGetDeliveryPolicy;
@@ -71,3 +78,58 @@ export const svcTransitionNc = repoTransitionNc;
 
 export const svcEvaluateEligibility = repoEvaluateEligibility;
 export const svcQualityCenter = repoQualityCenter;
+export const svcQualityIntelligence = repoQualityIntelligence;
+export const svcCreateQualityCost = repoCreateQualityCost;
+export const svcAssignQualityCause = repoAssignQualityCause;
+
+export async function svcQualityInvestigation(params: {
+  query: QualityInvestigationQueryDTO;
+  role: string | null;
+}) {
+  const startedAt = performance.now();
+  const graph = await svcGetTraceabilityChain({
+    seed: { type: params.query.type, id: params.query.id },
+    role: params.role,
+    direction: "both",
+    asOf: params.query.as_of ?? null,
+    maxDepth: params.query.max_depth,
+    maxNodes: 600,
+    maxEdges: 2400,
+    periodFrom: params.query.period_from ?? null,
+    periodTo: params.query.period_to ?? null,
+    withQualityAudit: true,
+  });
+  const materialTypes = new Set(["lot", "material_consumption", "reception_ligne", "stock_movement_line"]);
+  const deliveryTypes = new Set(["bon_livraison", "bon_livraison_ligne", "delivery_proof"]);
+  const materialNodes = graph.nodes.filter((node) => materialTypes.has(node.type));
+  const deliveryNodes = graph.nodes.filter((node) => deliveryTypes.has(node.type));
+  const provenEdges = graph.edges.filter((edge) => edge.proof_level === "proven").length;
+  return {
+    generated_at: new Date().toISOString(),
+    generation_duration_ms: Math.max(0, Math.round((performance.now() - startedAt) * 100) / 100),
+    definition: {
+      label: "Dossier d'enquête matière → livraison",
+      unit: "graphe de preuves",
+      source: graph.sources,
+      freshness: graph.as_of,
+      reliability: graph.coverage.state,
+    },
+    coverage: {
+      ...graph.coverage,
+      material_node_count: materialNodes.length,
+      delivery_node_count: deliveryNodes.length,
+      material_to_delivery_available: materialNodes.length > 0 && deliveryNodes.length > 0,
+      proven_edge_count: provenEdges,
+      proven_edge_ratio: graph.edges.length > 0 ? Math.round((provenEdges / graph.edges.length) * 10_000) / 100 : null,
+      missing_link_count: graph.data_quality_issues.length,
+    },
+    investigation_time: {
+      value: null,
+      unit: "minutes" as const,
+      reliability: "UNAVAILABLE" as const,
+      missing: ["investigation_started_at", "investigation_closed_at"] as const,
+      source: [] as const,
+    },
+    graph,
+  };
+}

--- a/src/module/qualite/validators/quality-360.validators.ts
+++ b/src/module/qualite/validators/quality-360.validators.ts
@@ -4,6 +4,8 @@
 
 import { z } from "zod";
 
+import { TRACEABILITY_NODE_TYPES } from "../../traceability/domain/traceability-model";
+
 import {
   QUALITY_CHARACTERISTIC_TYPES,
   QUALITY_CRITICALITIES,
@@ -574,3 +576,58 @@ export const qualityCenterQuerySchema = z
   })
   .strict();
 export type QualityCenterQueryDTO = z.infer<typeof qualityCenterQuerySchema>;
+
+export const qualityIntelligenceQuerySchema = z
+  .object({
+    from: z.string().date(),
+    to: z.string().date(),
+    horizon_days: z.coerce.number().int().min(1).max(365).default(30),
+  })
+  .strict()
+  .refine((value) => value.from <= value.to, { path: ["to"], message: "La fin doit suivre le début" });
+export type QualityIntelligenceQueryDTO = z.infer<typeof qualityIntelligenceQuerySchema>;
+
+export const qualityInvestigationQuerySchema = z
+  .object({
+    type: z.enum(TRACEABILITY_NODE_TYPES),
+    id: shortText(160),
+    as_of: z.string().datetime({ offset: true }).optional(),
+    period_from: z.string().datetime({ offset: true }).optional(),
+    period_to: z.string().datetime({ offset: true }).optional(),
+    max_depth: z.coerce.number().int().min(1).max(8).default(8),
+  })
+  .strict();
+export type QualityInvestigationQueryDTO = z.infer<typeof qualityInvestigationQuerySchema>;
+
+export const createQualityCostSchema = z
+  .object({
+    body: z
+      .object({
+        non_conformity_id: uuid,
+        category: z.enum(["SCRAP", "REWORK", "SORTING", "CONTAINMENT", "RETURN", "OTHER"]),
+        amount: z.number().finite().positive().max(1_000_000_000),
+        currency: z.string().trim().regex(/^[A-Z]{3}$/),
+        occurred_on: z.string().date(),
+        source_type: z.enum(["STOCK_MOVEMENT", "TIME_ENTRY", "SUPPLIER_DOCUMENT", "MANUAL_EVIDENCE"]),
+        source_id: shortText(160),
+        evidence_document_id: uuid.optional().nullable(),
+        note: z.string().trim().min(5).max(2000),
+      })
+      .strict(),
+  })
+  .strict();
+export type CreateQualityCostBodyDTO = z.infer<typeof createQualityCostSchema>["body"];
+
+export const assignQualityCauseSchema = z
+  .object({
+    params: idParamSchema.shape.params,
+    body: z
+      .object({
+        cause_code: z.string().trim().regex(/^[A-Z][A-Z0-9_]{2,39}$/),
+        expected_updated_at: isoDateTime,
+        reason: z.string().trim().min(5).max(2000),
+      })
+      .strict(),
+  })
+  .strict();
+export type AssignQualityCauseBodyDTO = z.infer<typeof assignQualityCauseSchema>["body"];


### PR DESCRIPTION
## Résultat\n- calcule FPY, PPM, clôture et COPQ avec fiabilité et données manquantes explicites\n- ajoute causes structurées, ledger de coûts idempotent et politiques SPC versionnées\n- réutilise le graphe canonique matière vers livraison\n- renforce le RBAC et l'audit\n\n## Vérifications\n- typecheck, build et audit production : PASS\n- tests SOL-22 : 19/19 PASS\n- suite complète : 298 fichiers / 4 588 tests PASS\n- E2E isolés : 3/3 PASS, 0 retry\n- migration PostgreSQL 16.14, rollback et restauration : PASS\n\nCloses #450

## Summary by Sourcery

Introduce measurable quality intelligence and investigation capabilities, including structured causes, cost ledger, SPC policies, and tightened RBAC for analytics access.

New Features:
- Expose quality intelligence analytics and investigation endpoints backed by traceability graphs and metrology data.
- Add structured quality causes, append-only quality cost ledger with idempotency, and versioned SPC policy management.
- Provide computation of FPY, PPM, closure delay, scrap/rework costs, and COPQ with explicit reliability and missing-data reporting.

Enhancements:
- Strengthen quality module RBAC by adding an analytics_read capability and removing blanket module-access elevation.
- Augment audit logging for quality investigations, cause assignment, and cost creation to improve traceability.
- Reuse the canonical material-to-delivery traceability graph to power investigation responses with coverage and missing-link metrics.

Deployment:
- Add PostgreSQL migration scripts and safety guards (preflight, verify, rollback) for SOL-22 quality intelligence tables, triggers, and constraints.

Documentation:
- Document the SOL-22 quality intelligence migration, including runbook, ADR, execution report, and database patch notes.

Tests:
- Add domain, route, authorization, migration-guard, and SQL-support tests to validate quality intelligence metrics, RBAC boundaries, and migration safety.