### PR TITLE
SOL-22: enregistrer le patch dans le runner immuable

### DIFF
--- a/docs/execution-reports/SOL-22.md
+++ b/docs/execution-reports/SOL-22.md
@@ -79,6 +79,13 @@ délai de clôture, rebuts, retouches et COPQ ne deviennent jamais zéro en l'ab
 de preuve. Pareto et SPC restent explicitement indisponibles, et le drill-down du
 Centre Qualité ouvre la page de traçabilité canonique.
 
+Le preflight opérateur précédant l'application réelle a détecté que le patch
+SOL-22 n'était pas encore inscrit dans la liste immuable du runner `--only`. Le
+checksum LF canonique
+`adf2b97867ef23f9c40ecd5df7c271cd40cc4d4d67c04cc60e7444f2cf367264`
+est maintenant enregistré et couvert par le test du runner ; aucune base n'a été
+écrite avant cette correction.
+
 ## Risques, compatibilité et travail restant
 
 - les contrôles historiques sans source ou quantité rendent les ratios partiels ;

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -47,6 +47,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "7e1e026c8a16be2609f072434d1930afbd248a543d96e3b013e89426fdaa1336",
   "20260811_production_readiness_center.sql":
     "2657f0f1eeca1a708a32ec41ae4c2a9eb2755df074d0a7984ccebcfce6b2dde5",
+  "20260814_sol22_quality_intelligence.sql":
+    "adf2b97867ef23f9c40ecd5df7c271cd40cc4d4d67c04cc60e7444f2cf367264",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -76,6 +76,10 @@ const recentSolPatchChecksums = new Map([
     "20260811_base_unit_drift_repair.sql",
     "53e6d11928dcd329b80fd493932aa29d2f0f65874b20a2cd1daa4e9a8847eb66",
   ],
+  [
+    "20260814_sol22_quality_intelligence.sql",
+    "adf2b97867ef23f9c40ecd5df7c271cd40cc4d4d67c04cc60e7444f2cf367264",
+  ],
 ]);
 const wave9PatchChecksums = new Map([
   [


### PR DESCRIPTION
Le preflight opérateur a détecté avant toute écriture que le patch SOL-22 manquait dans la liste --only.\n\n- checksum LF canonique enregistré\n- test du runner ajouté\n- 24/24 tests ciblés PASS\n- typecheck PASS\n\nComplète #450.

## Summary by Sourcery

Register the SOL-22 database patch as an immutable entry in the runner and document its detection and coverage by tests.

Build:
- Add the SOL-22 patch filename and canonical checksum to the immutable-only patches configuration in the db patches script.

Documentation:
- Update SOL-22 execution report to describe the preflight detection and registration of the patch checksum in the immutable runner list.

Tests:
- Extend the db patches runner test to include the SOL-22 patch checksum.