### PR TITLE
Release SOL-23 : promouvoir ADV fiable

### DIFF
--- a/db/patches/20260814_adv_reliability_sol23.sql
+++ b/db/patches/20260814_adv_reliability_sol23.sql
@@ -1,0 +1,211 @@
+-- SOL-23 - ADV, OTIF, cash, blocages et litiges traçables.
+-- Additif et rejouable. Aucun statut de connecteur de facturation électronique n'est simulé.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.adv_delivery_blocks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  delivery_id uuid NOT NULL REFERENCES public.bon_livraison(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  order_id bigint NOT NULL REFERENCES public.commande_client(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  category text NOT NULL CHECK (category IN ('QUALITY','DOCUMENT','STOCK','TRANSPORT')),
+  status text NOT NULL DEFAULT 'OPEN' CHECK (status IN ('OPEN','RESOLVED')),
+  detail text NOT NULL CHECK (char_length(btrim(detail)) BETWEEN 3 AND 1000),
+  owner_user_id integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  next_action text NOT NULL CHECK (char_length(btrim(next_action)) BETWEEN 3 AND 500),
+  due_date date NOT NULL,
+  resolution_note text NULL,
+  resolved_at timestamptz NULL,
+  resolved_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  version integer NOT NULL DEFAULT 1 CHECK (version > 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  updated_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  CONSTRAINT adv_delivery_blocks_resolution_0455_ck CHECK (
+    (status='OPEN' AND resolution_note IS NULL AND resolved_at IS NULL AND resolved_by IS NULL)
+    OR (status='RESOLVED' AND char_length(btrim(resolution_note))>=3 AND resolved_at IS NOT NULL AND resolved_by IS NOT NULL)
+  )
+);
+CREATE UNIQUE INDEX IF NOT EXISTS adv_delivery_blocks_active_0455_uq
+  ON public.adv_delivery_blocks(delivery_id,category) WHERE status='OPEN';
+CREATE INDEX IF NOT EXISTS adv_delivery_blocks_queue_0455_idx
+  ON public.adv_delivery_blocks(status,due_date,order_id);
+
+CREATE TABLE IF NOT EXISTS public.adv_payment_promises (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  facture_id bigint NOT NULL REFERENCES public.facture(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  client_id varchar NOT NULL REFERENCES public.clients(client_id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  amount_ttc numeric(18,2) NOT NULL CHECK (amount_ttc>0),
+  currency text NOT NULL CHECK (currency ~ '^[A-Z]{3}$'),
+  promised_date date NOT NULL,
+  status text NOT NULL DEFAULT 'OPEN' CHECK (status IN ('OPEN','KEPT','BROKEN','CANCELLED')),
+  owner_user_id integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  next_action text NOT NULL CHECK (char_length(btrim(next_action)) BETWEEN 3 AND 500),
+  due_date date NOT NULL,
+  note text NULL,
+  resolution_note text NULL,
+  resolved_at timestamptz NULL,
+  resolved_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  version integer NOT NULL DEFAULT 1 CHECK (version>0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  updated_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  CONSTRAINT adv_payment_promises_resolution_0455_ck CHECK (
+    (status='OPEN' AND resolution_note IS NULL AND resolved_at IS NULL AND resolved_by IS NULL)
+    OR (status<>'OPEN' AND char_length(btrim(resolution_note))>=3 AND resolved_at IS NOT NULL AND resolved_by IS NOT NULL)
+  )
+);
+CREATE INDEX IF NOT EXISTS adv_payment_promises_forecast_0455_idx
+  ON public.adv_payment_promises(status,promised_date,facture_id);
+
+CREATE TABLE IF NOT EXISTS public.adv_invoice_disputes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  facture_id bigint NOT NULL REFERENCES public.facture(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  category text NOT NULL CHECK (category IN ('QUALITY','DOCUMENT','PRICE','QUANTITY','DELIVERY','TAX','OTHER')),
+  status text NOT NULL DEFAULT 'OPEN' CHECK (status IN ('OPEN','RESOLVED','CANCELLED')),
+  disputed_amount_ttc numeric(18,2) NULL CHECK (disputed_amount_ttc>0),
+  detail text NOT NULL CHECK (char_length(btrim(detail)) BETWEEN 3 AND 1000),
+  owner_user_id integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  next_action text NOT NULL CHECK (char_length(btrim(next_action)) BETWEEN 3 AND 500),
+  due_date date NOT NULL,
+  resolution_note text NULL,
+  resolved_at timestamptz NULL,
+  resolved_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  version integer NOT NULL DEFAULT 1 CHECK (version>0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  updated_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  CONSTRAINT adv_invoice_disputes_resolution_0455_ck CHECK (
+    (status='OPEN' AND resolution_note IS NULL AND resolved_at IS NULL AND resolved_by IS NULL)
+    OR (status<>'OPEN' AND char_length(btrim(resolution_note))>=3 AND resolved_at IS NOT NULL AND resolved_by IS NOT NULL)
+  )
+);
+CREATE INDEX IF NOT EXISTS adv_invoice_disputes_queue_0455_idx
+  ON public.adv_invoice_disputes(status,due_date,facture_id);
+
+CREATE TABLE IF NOT EXISTS public.adv_case_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_type text NOT NULL CHECK (case_type IN ('DELIVERY_BLOCK','PAYMENT_PROMISE','INVOICE_DISPUTE')),
+  case_id uuid NOT NULL,
+  event_type text NOT NULL CHECK (char_length(btrim(event_type)) BETWEEN 2 AND 40),
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  snapshot jsonb NOT NULL CHECK (jsonb_typeof(snapshot)='object'),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS adv_case_events_lookup_0455_idx ON public.adv_case_events(case_type,case_id,created_at,id);
+
+CREATE TABLE IF NOT EXISTS public.adv_otif_assessments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id bigint NOT NULL UNIQUE REFERENCES public.commande_client(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  promised_date date NOT NULL,
+  completion_date date NOT NULL,
+  on_time_in_full boolean NOT NULL,
+  source text NOT NULL DEFAULT 'FULFILMENT_TRIGGER' CHECK (source='FULFILMENT_TRIGGER'),
+  line_snapshot jsonb NOT NULL CHECK (jsonb_typeof(line_snapshot)='array'),
+  frozen_at timestamptz NOT NULL DEFAULT now(),
+  frozen_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS adv_otif_assessments_period_0455_idx ON public.adv_otif_assessments(promised_date,on_time_in_full);
+
+CREATE TABLE IF NOT EXISTS public.adv_command_receipts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  action text NOT NULL CHECK (action IN ('DELIVERY_BLOCK_CREATE','DELIVERY_BLOCK_RESOLVE','PAYMENT_PROMISE_CREATE','PAYMENT_PROMISE_STATUS','INVOICE_DISPUTE_CREATE','INVOICE_DISPUTE_STATUS')),
+  idempotency_key text NOT NULL CHECK (char_length(idempotency_key) BETWEEN 8 AND 120),
+  request_hash char(64) NOT NULL CHECK (request_hash ~ '^[a-f0-9]{64}$'),
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  response_snapshot jsonb NOT NULL CHECK (jsonb_typeof(response_snapshot)='object'),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT adv_command_receipts_action_key_0455_uq UNIQUE(action,idempotency_key)
+);
+
+CREATE OR REPLACE FUNCTION public.adv_case_transition_guard_0455()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP='DELETE' THEN RAISE EXCEPTION '% cases cannot be deleted',TG_TABLE_NAME; END IF;
+  IF OLD.status<>'OPEN' THEN RAISE EXCEPTION '% is already closed',TG_TABLE_NAME; END IF;
+  IF NEW.status='OPEN' THEN RAISE EXCEPTION '% updates must close the case',TG_TABLE_NAME; END IF;
+  IF (to_jsonb(NEW)-ARRAY['status','resolution_note','resolved_at','resolved_by','version','updated_at','updated_by']::text[])
+     <> (to_jsonb(OLD)-ARRAY['status','resolution_note','resolved_at','resolved_by','version','updated_at','updated_by']::text[]) THEN
+    RAISE EXCEPTION '% immutable business fields changed',TG_TABLE_NAME;
+  END IF;
+  IF NEW.version<>OLD.version+1 THEN RAISE EXCEPTION '% version must increment exactly once',TG_TABLE_NAME; END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_adv_delivery_blocks_transition_0455 ON public.adv_delivery_blocks;
+CREATE TRIGGER trg_adv_delivery_blocks_transition_0455 BEFORE UPDATE OR DELETE ON public.adv_delivery_blocks
+  FOR EACH ROW EXECUTE FUNCTION public.adv_case_transition_guard_0455();
+DROP TRIGGER IF EXISTS trg_adv_payment_promises_transition_0455 ON public.adv_payment_promises;
+CREATE TRIGGER trg_adv_payment_promises_transition_0455 BEFORE UPDATE OR DELETE ON public.adv_payment_promises
+  FOR EACH ROW EXECUTE FUNCTION public.adv_case_transition_guard_0455();
+DROP TRIGGER IF EXISTS trg_adv_invoice_disputes_transition_0455 ON public.adv_invoice_disputes;
+CREATE TRIGGER trg_adv_invoice_disputes_transition_0455 BEFORE UPDATE OR DELETE ON public.adv_invoice_disputes
+  FOR EACH ROW EXECUTE FUNCTION public.adv_case_transition_guard_0455();
+
+CREATE OR REPLACE FUNCTION public.adv_append_only_guard_0455()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN RAISE EXCEPTION '% is append-only',TG_TABLE_NAME; END $$;
+DROP TRIGGER IF EXISTS trg_adv_case_events_append_only_0455 ON public.adv_case_events;
+CREATE TRIGGER trg_adv_case_events_append_only_0455 BEFORE UPDATE OR DELETE ON public.adv_case_events
+  FOR EACH ROW EXECUTE FUNCTION public.adv_append_only_guard_0455();
+DROP TRIGGER IF EXISTS trg_adv_otif_append_only_0455 ON public.adv_otif_assessments;
+CREATE TRIGGER trg_adv_otif_append_only_0455 BEFORE UPDATE OR DELETE ON public.adv_otif_assessments
+  FOR EACH ROW EXECUTE FUNCTION public.adv_append_only_guard_0455();
+DROP TRIGGER IF EXISTS trg_adv_receipts_append_only_0455 ON public.adv_command_receipts;
+CREATE TRIGGER trg_adv_receipts_append_only_0455 BEFORE UPDATE OR DELETE ON public.adv_command_receipts
+  FOR EACH ROW EXECUTE FUNCTION public.adv_append_only_guard_0455();
+
+CREATE OR REPLACE FUNCTION public.adv_freeze_otif_0455()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  v_eligible boolean;
+  v_complete boolean;
+  v_pass boolean;
+  v_promised date;
+  v_completion date;
+  v_lines jsonb;
+BEGIN
+  IF NEW.commande_id IS NULL OR NEW.statut NOT IN ('SHIPPED','DELIVERED') OR OLD.statut=NEW.statut THEN RETURN NEW; END IF;
+  WITH line_facts AS (
+    SELECT cl.id,cl.delai_client,cl.quantite,
+           COALESCE(SUM(bll.quantite) FILTER(WHERE bl.statut IN ('SHIPPED','DELIVERED')),0) AS shipped_qty,
+           MAX(COALESCE(bl.date_expedition,bl.date_livraison,bl.date_creation)) FILTER(WHERE bl.statut IN ('SHIPPED','DELIVERED')) AS completion_date
+      FROM public.commande_ligne cl
+      LEFT JOIN public.bon_livraison_ligne bll ON bll.commande_ligne_id=cl.id
+      LEFT JOIN public.bon_livraison bl ON bl.id=bll.bon_livraison_id
+     WHERE cl.commande_id=NEW.commande_id GROUP BY cl.id,cl.delai_client,cl.quantite
+  )
+  SELECT BOOL_AND(delai_client IS NOT NULL),BOOL_AND(shipped_qty>=quantite),
+         BOOL_AND(completion_date IS NOT NULL AND completion_date<=delai_client),MAX(delai_client),MAX(completion_date),
+         jsonb_agg(jsonb_build_object('line_id',id,'promised_date',delai_client,'ordered_qty',quantite,'shipped_qty',shipped_qty,'completion_date',completion_date) ORDER BY id)
+    INTO v_eligible,v_complete,v_pass,v_promised,v_completion,v_lines FROM line_facts;
+  IF v_eligible AND v_complete THEN
+    INSERT INTO public.adv_otif_assessments(order_id,promised_date,completion_date,on_time_in_full,line_snapshot,frozen_by)
+    VALUES(NEW.commande_id,v_promised,v_completion,v_pass,v_lines,NEW.updated_by)
+    ON CONFLICT(order_id) DO NOTHING;
+  END IF;
+  RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS trg_adv_freeze_otif_0455 ON public.bon_livraison;
+CREATE TRIGGER trg_adv_freeze_otif_0455 AFTER UPDATE OF statut ON public.bon_livraison
+  FOR EACH ROW EXECUTE FUNCTION public.adv_freeze_otif_0455();
+
+DO $$ BEGIN
+  IF EXISTS(SELECT 1 FROM pg_roles WHERE rolname='cerp_app') THEN
+    ALTER TABLE public.adv_delivery_blocks OWNER TO cerp_app;
+    ALTER TABLE public.adv_payment_promises OWNER TO cerp_app;
+    ALTER TABLE public.adv_invoice_disputes OWNER TO cerp_app;
+    ALTER TABLE public.adv_case_events OWNER TO cerp_app;
+    ALTER TABLE public.adv_otif_assessments OWNER TO cerp_app;
+    ALTER TABLE public.adv_command_receipts OWNER TO cerp_app;
+    GRANT SELECT,INSERT,UPDATE ON public.adv_delivery_blocks,public.adv_payment_promises,public.adv_invoice_disputes TO cerp_app;
+    GRANT SELECT,INSERT ON public.adv_case_events,public.adv_otif_assessments,public.adv_command_receipts TO cerp_app;
+  END IF;
+END $$;
+
+COMMENT ON TABLE public.adv_otif_assessments IS 'SOL-23: preuve OTIF figée à la première complétude de la commande; aucune réécriture historique.';
+COMMENT ON TABLE public.adv_payment_promises IS 'SOL-23: promesses client explicites; la prévision les plafonne au solde et évite le double comptage des échéances.';
+
+COMMIT;

--- a/db/patches/support/20260814_adv_reliability_sol23.preflight.sql
+++ b/db/patches/support/20260814_adv_reliability_sol23.preflight.sql
@@ -1,0 +1,27 @@
+\set ON_ERROR_STOP on
+
+DO $$
+DECLARE missing text[]:=ARRAY[]::text[];
+BEGIN
+  IF current_setting('server_version_num')::int<140000 THEN RAISE EXCEPTION 'PostgreSQL 14+ requis'; END IF;
+  IF to_regclass('public.commande_client') IS NULL THEN missing:=array_append(missing,'commande_client'); END IF;
+  IF to_regclass('public.commande_ligne') IS NULL THEN missing:=array_append(missing,'commande_ligne'); END IF;
+  IF to_regclass('public.bon_livraison') IS NULL THEN missing:=array_append(missing,'bon_livraison'); END IF;
+  IF to_regclass('public.bon_livraison_ligne') IS NULL THEN missing:=array_append(missing,'bon_livraison_ligne'); END IF;
+  IF to_regclass('public.facture') IS NULL THEN missing:=array_append(missing,'facture'); END IF;
+  IF to_regclass('public.facture_echeance') IS NULL THEN missing:=array_append(missing,'facture_echeance'); END IF;
+  IF to_regclass('public.paiement_allocations') IS NULL THEN missing:=array_append(missing,'paiement_allocations'); END IF;
+  IF to_regclass('public.avoir_source_allocations') IS NULL THEN missing:=array_append(missing,'avoir_source_allocations'); END IF;
+  IF to_regclass('public.erp_audit_logs') IS NULL THEN missing:=array_append(missing,'erp_audit_logs'); END IF;
+  IF array_length(missing,1) IS NOT NULL THEN RAISE EXCEPTION 'Prerequis SOL-23 manquants: %',array_to_string(missing,', '); END IF;
+END $$;
+
+SELECT current_database() AS database_name,current_setting('server_version') AS postgres_version,
+       pg_size_pretty(pg_database_size(current_database())) AS database_size,
+       (SELECT count(*) FROM public.commande_client) AS orders,
+       (SELECT count(*) FROM public.bon_livraison) AS deliveries,
+       (SELECT count(*) FROM public.facture) AS invoices;
+
+SELECT count(*) AS invoices_without_currency FROM public.facture WHERE currency IS NULL OR btrim(currency)='';
+SELECT count(*) AS issued_invoices_without_due_date FROM public.facture
+ WHERE statut IN ('ISSUED','PARTIALLY_PAID','emis','emise','envoyee','partielle') AND date_echeance IS NULL;

--- a/db/patches/support/20260814_adv_reliability_sol23.rollback.sql
+++ b/db/patches/support/20260814_adv_reliability_sol23.rollback.sql
@@ -1,0 +1,27 @@
+\set ON_ERROR_STOP on
+
+DO $$ BEGIN
+  IF current_database()<>'cerp_test' AND current_setting('cerp.migration_rehearsal',true) IS DISTINCT FROM 'on' THEN
+    RAISE EXCEPTION 'Rollback SOL-23 autorise uniquement sur cerp_test ou une repetition isolee; restaurer la sauvegarde en production';
+  END IF;
+  IF to_regclass('public.adv_case_events') IS NOT NULL AND EXISTS(SELECT 1 FROM public.adv_case_events) THEN RAISE EXCEPTION 'Rollback refuse: historique ADV present'; END IF;
+  IF to_regclass('public.adv_otif_assessments') IS NOT NULL AND EXISTS(SELECT 1 FROM public.adv_otif_assessments) THEN RAISE EXCEPTION 'Rollback refuse: preuves OTIF presentes'; END IF;
+END $$;
+
+BEGIN;
+DROP TRIGGER IF EXISTS trg_adv_freeze_otif_0455 ON public.bon_livraison;
+DROP FUNCTION IF EXISTS public.adv_freeze_otif_0455();
+DROP TABLE IF EXISTS public.adv_command_receipts;
+DROP TRIGGER IF EXISTS trg_adv_otif_append_only_0455 ON public.adv_otif_assessments;
+DROP TABLE IF EXISTS public.adv_otif_assessments;
+DROP TRIGGER IF EXISTS trg_adv_case_events_append_only_0455 ON public.adv_case_events;
+DROP TABLE IF EXISTS public.adv_case_events;
+DROP TRIGGER IF EXISTS trg_adv_invoice_disputes_transition_0455 ON public.adv_invoice_disputes;
+DROP TABLE IF EXISTS public.adv_invoice_disputes;
+DROP TRIGGER IF EXISTS trg_adv_payment_promises_transition_0455 ON public.adv_payment_promises;
+DROP TABLE IF EXISTS public.adv_payment_promises;
+DROP TRIGGER IF EXISTS trg_adv_delivery_blocks_transition_0455 ON public.adv_delivery_blocks;
+DROP TABLE IF EXISTS public.adv_delivery_blocks;
+DROP FUNCTION IF EXISTS public.adv_case_transition_guard_0455();
+DROP FUNCTION IF EXISTS public.adv_append_only_guard_0455();
+COMMIT;

--- a/db/patches/support/20260814_adv_reliability_sol23.verify.sql
+++ b/db/patches/support/20260814_adv_reliability_sol23.verify.sql
@@ -1,0 +1,22 @@
+\set ON_ERROR_STOP on
+
+DO $$ BEGIN
+  IF to_regclass('public.adv_delivery_blocks') IS NULL OR to_regclass('public.adv_payment_promises') IS NULL
+     OR to_regclass('public.adv_invoice_disputes') IS NULL OR to_regclass('public.adv_case_events') IS NULL
+     OR to_regclass('public.adv_otif_assessments') IS NULL OR to_regclass('public.adv_command_receipts') IS NULL THEN
+    RAISE EXCEPTION 'Tables SOL-23 absentes';
+  END IF;
+  IF NOT EXISTS(SELECT 1 FROM pg_trigger WHERE tgname='trg_adv_freeze_otif_0455' AND NOT tgisinternal) THEN RAISE EXCEPTION 'Trigger OTIF absent'; END IF;
+  IF NOT EXISTS(SELECT 1 FROM pg_trigger WHERE tgname='trg_adv_case_events_append_only_0455' AND NOT tgisinternal) THEN RAISE EXCEPTION 'Audit ADV append-only absent'; END IF;
+  IF NOT EXISTS(SELECT 1 FROM pg_indexes WHERE schemaname='public' AND indexname='adv_delivery_blocks_active_0455_uq') THEN RAISE EXCEPTION 'Unicite blocage actif absente'; END IF;
+END $$;
+
+SELECT current_database() AS database_name,
+       (SELECT count(*) FROM public.adv_delivery_blocks) AS delivery_blocks,
+       (SELECT count(*) FROM public.adv_payment_promises) AS payment_promises,
+       (SELECT count(*) FROM public.adv_invoice_disputes) AS invoice_disputes,
+       (SELECT count(*) FROM public.adv_otif_assessments) AS frozen_otif;
+
+SELECT count(*) AS orphan_delivery_blocks FROM public.adv_delivery_blocks b LEFT JOIN public.bon_livraison bl ON bl.id=b.delivery_id WHERE bl.id IS NULL;
+SELECT count(*) AS orphan_promises FROM public.adv_payment_promises p LEFT JOIN public.facture f ON f.id=p.facture_id WHERE f.id IS NULL;
+SELECT count(*) AS orphan_disputes FROM public.adv_invoice_disputes d LEFT JOIN public.facture f ON f.id=d.facture_id WHERE f.id IS NULL;

--- a/docs/adr/ADR-0069-adv-otif-cash-boundary.md
+++ b/docs/adr/ADR-0069-adv-otif-cash-boundary.md
@@ -1,0 +1,34 @@
+# ADR-0069 — Frontière ADV, preuve OTIF et prévision de cash
+
+- Statut : accepté
+- Date : 2026-08-14
+- Propriétaire : Direction / ADV / Comptabilité
+- Contrat : `CERP-ADV-1.0.0`
+
+## Contexte
+
+La facturation sait déjà produire des factures partielles, des avoirs, des échéanciers et des paiements rapprochés. Le reporting commercial expose une balance âgée, mais il ne conserve pas la promesse client au moment où une commande devient intégralement expédiée. Les blocages de livraison, promesses de paiement et litiges de facture ne disposent pas non plus d'une file commune auditée. Calculer le cash attendu en additionnant promesses et échéances créerait un double comptage.
+
+## Décision
+
+1. La facturation existante reste l'autorité des documents, taxes, arrondis, allocations et soldes. SOL-23 ne duplique aucun grand livre.
+2. Une preuve OTIF est figée une seule fois à la première complétude d'une commande. Les commandes historiques sans preuve sont calculées depuis l'état courant et portent la fiabilité `PARTIAL`; elles ne sont pas réécrites rétroactivement.
+3. L'OTIF est au grain commande : toutes les lignes doivent avoir une date promise, être livrées intégralement et leur date de complétude doit être antérieure ou égale à leur propre date promise.
+4. Les blocages sont limités aux catégories `QUALITY`, `DOCUMENT`, `STOCK` et `TRANSPORT`. Ils portent un responsable, une échéance et une prochaine action.
+5. Les promesses de paiement et litiges sont des dossiers à transition unique, auditée et idempotente. Leur montant ne peut dépasser le solde de facture connu.
+6. Le DSO est calculé séparément par devise : `encours TTC / TTC émis sur 365 jours × 365`. Sans dénominateur, il est indisponible.
+7. La prévision de cash à 30 jours affecte d'abord les promesses actives puis les échéances au solde résiduel, avec plafond au solde de facture. L'absence de promesse n'est pas convertie en encaissement certain.
+8. La marge reste celle du moteur SOL-13. Le drill-down ne fait que relier les portées `DEVIS`, `AFFAIRE` et `OF` avec leurs snapshots et statuts de fiabilité.
+9. Avant le choix d'un prestataire, la facturation électronique n'expose que `NOT_ASSESSED`, `BLOCKED` et `READY_FOR_CONNECTOR`, explicitement qualifiés de complétude interne. Aucun état réglementaire d'échange n'est simulé.
+
+## Sécurité et exploitation
+
+- Lecture financière : capacité backend `reporting_financial`.
+- Blocages : `draft_write`; promesses : `payment_register`; litiges : `credit_write`.
+- Toute mutation exige `Idempotency-Key`, un hash de payload, une transaction, un événement immuable et un audit ERP.
+- Les données restent mono-instance; aucun identifiant société/site n'est inventé.
+- Le patch fournit preflight, vérification et rollback limité à `cerp_test` ou à la répétition isolée. En production, le retour arrière est une restauration de sauvegarde dès qu'une preuve a été créée.
+
+## Conséquences
+
+Les nouvelles commandes acquièrent une preuve OTIF forte. La couverture historique reste explicitement partielle jusqu'à extinction naturelle de l'ancien périmètre. Le cash attendu devient explicable et réconciliable, mais n'est pas une prévision statistique. Le futur connecteur de facturation électronique pourra s'appuyer sur la complétude interne sans reprendre un faux cycle de vie externe.

--- a/docs/execution-reports/SOL-23.md
+++ b/docs/execution-reports/SOL-23.md
@@ -1,0 +1,108 @@
+# SOL-23 — Livraisons, facturation, ADV et marge (backend)
+
+- Date : 2026-08-14
+- Propriétaire : Keenan Martin
+- Issue : [#455](https://github.com/BigFootLime/erp-crp-backend/issues/455)
+- Branche : `feature/455-sol23-adv-cash-margin`
+- Base initiale : `origin/main` (`d07022df94f85bd131798b587c8dba444b0acdc7`)
+- ADR : `docs/adr/ADR-0069-adv-otif-cash-boundary.md`
+
+## Diagnostic et cause racine
+
+Les objets de livraison, facture, échéance, paiement, avoir, affaire et OF
+existaient, mais sans frontière ADV unique. L'OTIF était recalculable depuis
+l'état courant, donc réécrivable de fait ; les blocages de livraison, promesses
+de paiement et litiges n'avaient ni dossier audité ni commande idempotente ; le
+cash attendu pouvait être double compté entre promesse et échéancier. La marge
+SOL-13 n'était pas reliée à la chronologie commande → livraison → facture.
+
+La première recette Playwright réelle a en outre découvert SQLSTATE `42P18` : la
+file de livraison transmettait des paramètres inutilisés avant les paramètres
+référencés. PostgreSQL ne pouvait pas typer `$1`. La numérotation a été corrigée
+à la source ; aucun timeout, mock ou fallback n'a été ajouté.
+
+## Choix d'architecture
+
+- le ledger Finance existant reste l'autorité pour factures partielles, avoirs,
+  échéances et allocations de paiements ; SOL-23 ne le duplique pas ;
+- l'OTIF est figé à la première complétude d'une commande par preuve append-only ;
+  les commandes historiques encore dérivées de l'état courant sont marquées
+  `PARTIAL`, jamais présentées comme preuve constatée ;
+- DSO par devise = encours TTC / TTC émis sur 365 jours × 365, en centimes exacts ;
+- le cash à 30 jours consomme d'abord les promesses puis seulement l'échéancier
+  résiduel, le tout plafonné au solde de la facture ;
+- catégories de blocage : qualité, document, stock et transport ; dossiers à
+  transition unique, contrôle de concurrence, idempotence et audit ;
+- préparation e-facture strictement interne : `NOT_ASSESSED`, `BLOCKED` ou
+  `READY_FOR_CONNECTOR`. Aucun statut transport/réglementaire n'est inventé ;
+- drill-down vers les snapshots de marge SOL-13 par devis, affaire et OF.
+
+## Fichiers modifiés
+
+- module `src/module/adv-reliability/` : domaine, validation, repository,
+  contrôleurs, routes et tests numériques ;
+- montage sous `src/module/facturation/routes/reporting.routes.ts` ;
+- patch `db/patches/20260814_adv_reliability_sol23.sql` et scripts de support ;
+- garde de migration, tests route/RBAC et documentation HTTP ;
+- ADR-0069 et présent rapport.
+
+## Migration, données et rollback
+
+Le patch est additif : six tables ADV, index, contraintes, journal append-only,
+reçus idempotents et trigger de gel OTIF. Il ne crée aucune promesse, aucun
+litige, aucun blocage, aucun taux et aucun montant métier. Les propriétaires et
+droits sont bornés au rôle applicatif existant.
+
+Répétition PostgreSQL 16 jetable : **154 appliqués, 0 en attente, 0 checksum
+divergent**. Sauvegarde, rollback SQL contrôlé, restauration vers une base neuve,
+rejeu et contrôles d'orphelins ont réussi. En production, le retour arrière sûr
+consiste à redéployer l'ancien SHA en conservant les objets additifs. Si un retour
+de schéma devient obligatoire après création de preuves, geler les écritures et
+restaurer le dump pré-migration dans une base neuve ; ne pas exécuter les `DROP`
+du script test sur `cerp_prod`.
+
+## Tests exécutés
+
+| Contrôle | Résultat réel |
+|---|---|
+| tests SOL-23 ciblés | PASS — 3 fichiers, 13/13 |
+| typecheck backend | PASS |
+| suite backend complète | PASS — 0 échec |
+| build backend + frontière données production | PASS — 673 fichiers runtime |
+| audit dépendances production | PASS — 0 vulnérabilité connue |
+| répétition migration SOL-06 | PASS — sauvegarde, rollback, restauration et rejeu |
+| E2E isolé ADV Chromium | PASS — 1/1 en 3,9 s, sans retry |
+
+L'E2E a réellement démarré PostgreSQL, appliqué 154 migrations, chargé le seed
+déterministe, construit frontend/backend, authentifié un rôle autorisé, appelé
+l'API et affiché l'onglet ADV. Les traces, captures et vidéos restent limitées
+aux échecs dans `test-results/sol-05/`.
+
+## Permissions, audit et compatibilité
+
+- lecture : capacité serveur `reporting_financial` ;
+- blocages livraison : `draft_write` ; promesses : `payment_register` ; litiges :
+  `credit_write` ; les refus anonymes et rôle insuffisant sont testés ;
+- chaque mutation exige `Idempotency-Key`, verrouille l'objet métier, vérifie la
+  version lors d'une clôture et écrit événement + audit dans la transaction ;
+- le contrat est `CERP-ADV-1.0.0`, privé et `no-store` ;
+- aucune isolation société/site supplémentaire n'existe dans le schéma actuel ;
+  le module suit donc la frontière d'autorisation globale existante et ne prétend
+  pas fournir une segmentation absente.
+
+## Risques et éléments restant réellement à faire
+
+- l'OTIF antérieur au déploiement reste `PARTIAL` tant qu'aucune preuve figée
+  n'existe ; aucun backfill spéculatif n'est effectué ;
+- les factures sans date d'échéance sont classées `UNKNOWN`, pas zéro jour ;
+- le cash reste `PARTIAL` car une promesse est une déclaration, non un paiement ;
+- le connecteur de facturation électronique reste volontairement indisponible
+  jusqu'au choix et à la qualification d'un fournisseur réel ;
+- les migrations réelles, promotions et déploiements sont consignés dans la
+  mise à jour finale de ce rapport après vérification des SHA distants.
+
+## Traçabilité de pilotage
+
+Le dry-run Project Office a refusé l'appel avant toute écriture car
+`CERP_PROJECT_OFFICE_URL` n'est pas configurée comme URL HTTP(S). L'issue GitHub
+#455 constitue donc la trace canonique de cette exécution.

--- a/docs/http/adv-reliability-sol23.md
+++ b/docs/http/adv-reliability-sol23.md
@@ -1,0 +1,25 @@
+# API ADV fiable — SOL-23
+
+Toutes les routes sont sous `/api/v1/reporting/commercial/adv`, exigent un JWT et sont protégées par les capacités Finance côté serveur.
+
+## Lecture
+
+- `GET /overview` : filtres du reporting 360 (`period`, `from`, `to`, `as_of`, `client_id`, `currency`, `limit`). Renvoie les définitions, la fraîcheur, la fiabilité, la file livraison, l'OTIF, le DSO, le cash à 30 jours, la balance âgée et la complétude e-facture interne.
+- `GET /orders/:id/chain` : commande → livraisons → factures → paiements/avoirs/promesses/litiges → preuves de marge.
+
+## Mutations idempotentes
+
+L'en-tête `Idempotency-Key` de 8 à 120 caractères est obligatoire. Réutiliser la même clé avec le même payload renvoie la réponse initiale; un payload différent reçoit `409 IDEMPOTENCY_PAYLOAD_MISMATCH`.
+
+- `POST /deliveries/:id/blocks`
+- `POST /delivery-blocks/:id/resolve`
+- `POST /invoices/:id/payment-promises`
+- `POST /payment-promises/:id/status`
+- `POST /invoices/:id/disputes`
+- `POST /invoice-disputes/:id/status`
+
+Les clôtures exigent `expected_updated_at` pour refuser une décision sur une version périmée.
+
+## Limite volontaire
+
+`electronic_invoicing.connector.available=false` signifie qu'aucun prestataire n'est sélectionné. `READY_FOR_CONNECTOR` n'est ni un dépôt, ni un envoi, ni une acceptation fiscale.

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-13T23:31:29.113Z",
+  "started_at": "2026-08-14T04:49:06.637Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 19605,
-    "source_seed": 230,
-    "backup": 740,
-    "preflight": 130,
-    "integrity_before": 630,
-    "migration": 395,
-    "verify": 180,
-    "replay": 123,
-    "integrity_after": 1453,
-    "negative_gate": 48,
-    "rollback": 192,
-    "restore": 4334
+    "source_migration": 18356,
+    "source_seed": 193,
+    "backup": 726,
+    "preflight": 119,
+    "integrity_before": 586,
+    "migration": 457,
+    "verify": 195,
+    "replay": 119,
+    "integrity_after": 1401,
+    "negative_gate": 41,
+    "rollback": 248,
+    "restore": 3997
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-13T23:31:52.288Z",
-    "duration_ms": 80,
+    "checked_at": "2026-08-14T04:49:28.456Z",
+    "duration_ms": 73,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36355095"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-FVm76h\\cerp-test-before-sol06.dump",
-      "bytes": 1968435,
-      "sha256": "342f22beca3c93bdb5dc8bf191693a704d70cf0e15f13f0f71a8b8e529e880d1",
-      "free_bytes": 415471935488
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-8b8RIq\\cerp-test-before-sol06.dump",
+      "bytes": 1968404,
+      "sha256": "60bdbca8744707751f9888705711ba1f8e7a9fc832b281a7ebc0aec06c6f5909",
+      "free_bytes": 419015507968
     },
     "ledger": {
       "applied": 140,
@@ -52,7 +52,9 @@
         "20260813_quality_delivery_workflow_0437.sql",
         "20260813_sol20_tooling_technical_ged.sql",
         "20260813_stock_intelligence_sol19.sql",
-        "20260814_planning_execution_intelligence_0021.sql"
+        "20260814_adv_reliability_sol23.sql",
+        "20260814_planning_execution_intelligence_0021.sql",
+        "20260814_sol22_quality_intelligence.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
@@ -445,12 +447,14 @@
         "20260813_quality_delivery_workflow_0437.sql",
         "20260813_sol20_tooling_technical_ged.sql",
         "20260813_stock_intelligence_sol19.sql",
-        "20260814_planning_execution_intelligence_0021.sql"
+        "20260814_adv_reliability_sol23.sql",
+        "20260814_planning_execution_intelligence_0021.sql",
+        "20260814_sol22_quality_intelligence.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
     },
-    "fingerprint": "687a3a0e5c56d2413ba0e726fec13ab6d32b3113e7a640df01c9673c8990961d"
+    "fingerprint": "15817807200ec885da9cfab50277497674edd0f4b81e6c406a3e21325820771c"
   },
   "replay": {
     "applied_zero": true,
@@ -458,14 +462,20 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-13T23:31:55.072Z",
-    "duration_ms": 1437,
+    "checked_at": "2026-08-14T04:49:31.217Z",
+    "duration_ms": 1386,
     "table_counts": {
       "admin_account_invitations": "0",
       "admin_user_provisioning_migration_state": "12",
       "admin_user_provisioning_requests": "0",
       "adresse_facturation": "1",
       "adresse_livraison": "1",
+      "adv_case_events": "0",
+      "adv_command_receipts": "0",
+      "adv_delivery_blocks": "0",
+      "adv_invoice_disputes": "0",
+      "adv_otif_assessments": "0",
+      "adv_payment_promises": "0",
       "adv_reminder_attempts": "0",
       "adv_reminder_client_preferences": "0",
       "adv_reminder_command_receipts": "0",
@@ -516,7 +526,7 @@
       "centres_frais": "1",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "152",
+      "cerp_schema_migrations": "154",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -774,11 +784,13 @@
       "project_work_logs": "0",
       "project_work_packages": "0",
       "quality_action": "0",
+      "quality_cause_catalog": "9",
       "quality_command_receipts": "0",
       "quality_control": "0",
       "quality_control_plan": "1",
       "quality_control_plan_characteristic": "1",
       "quality_control_points": "0",
+      "quality_cost_entry": "0",
       "quality_delivery_dossier_versions": "0",
       "quality_delivery_release_policy": "0",
       "quality_delivery_release_policy_event": "0",
@@ -788,6 +800,7 @@
       "quality_event_log": "0",
       "quality_measurement_revisions": "0",
       "quality_release_decision": "0",
+      "quality_spc_policy": "0",
       "realtime_authorization_epoch": "1",
       "realtime_chat_presence": "0",
       "realtime_control_plane_v2_provenance": "1",
@@ -848,7 +861,7 @@
       "users": "8",
       "warehouses": "4"
     },
-    "table_count": 386,
+    "table_count": 395,
     "unvalidated_constraints": [
       {
         "table_name": "avoir",
@@ -925,7 +938,7 @@
         "groups": 0
       }
     ],
-    "foreign_key_count": 1111,
+    "foreign_key_count": 1138,
     "orphans": [],
     "readiness": [
       {
@@ -934,10 +947,10 @@
         "ready": true,
         "definition": "Calendrier de capacité actif avec jours et horaires explicites.",
         "unit": "calendriers",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -951,10 +964,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -969,10 +982,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -995,10 +1008,10 @@
         "ready": true,
         "definition": "Calendrier de capacité actif avec jours et horaires explicites.",
         "unit": "calendriers",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1012,10 +1025,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1030,10 +1043,10 @@
         "ready": true,
         "definition": "Unités canoniques utilisables sans conversion implicite.",
         "unit": "unités",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1050,10 +1063,10 @@
         "ready": true,
         "definition": "Chaque centre de frais actif possède un taux horaire versionné applicable et sourcé.",
         "unit": "EUR/heure",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1068,10 +1081,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1094,10 +1107,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1112,10 +1125,10 @@
         "ready": true,
         "definition": "Au moins un magasin et un emplacement actifs sont reliés au référentiel warehouse/location.",
         "unit": "emplacements",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1131,10 +1144,10 @@
         "ready": true,
         "definition": "Unités canoniques utilisables sans conversion implicite.",
         "unit": "unités",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1169,10 +1182,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-12T22:00:00.000Z",
+        "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-13T23:31:53.636Z",
+        "freshness_at": "2026-08-14T04:49:29.832Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1191,12 +1204,12 @@
       }
     ],
     "ledger": {
-      "applied": 152,
+      "applied": 154,
       "pending": [],
       "checksum_mismatches": [],
       "unknown_applied": []
     },
-    "fingerprint": "16d821450436ef45e62b9634e1e249178e734b8a18b3d12b792c273a8f11f058"
+    "fingerprint": "501d6bb85e60d9dd472ae428d3c1db3d27f7d9688b3cb939df3e2c1e6dec1274"
   },
   "negative_gate": {
     "status": "passed",
@@ -1235,7 +1248,7 @@
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "687a3a0e5c56d2413ba0e726fec13ab6d32b3113e7a640df01c9673c8990961d",
+    "fingerprint": "15817807200ec885da9cfab50277497674edd0f4b81e6c406a3e21325820771c",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1251,11 +1264,13 @@
         "20260813_quality_delivery_workflow_0437.sql",
         "20260813_sol20_tooling_technical_ged.sql",
         "20260813_stock_intelligence_sol19.sql",
-        "20260814_planning_execution_intelligence_0021.sql"
+        "20260814_adv_reliability_sol23.sql",
+        "20260814_planning_execution_intelligence_0021.sql",
+        "20260814_sol22_quality_intelligence.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-13T23:31:59.852Z"
+  "completed_at": "2026-08-14T04:49:35.668Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-13T23:31:59.852Z
+- Exécutée : 2026-08-14T04:49:35.668Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36355095 octets
-- Sauvegarde : 1968435 octets, SHA-256 `342f22beca3c93bdb5dc8bf191693a704d70cf0e15f13f0f71a8b8e529e880d1`
-- Patches avant/après : 140 / 152
+- Sauvegarde : 1968404 octets, SHA-256 `60bdbca8744707751f9888705711ba1f8e7a9fc832b281a7ebc0aec06c6f5909`
+- Patches avant/après : 140 / 154
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `687a3a0e5c56d2413ba0e726fec13ab6d32b3113e7a640df01c9673c8990961d` / `687a3a0e5c56d2413ba0e726fec13ab6d32b3113e7a640df01c9673c8990961d`
+- Empreinte source/restaurée : `15817807200ec885da9cfab50277497674edd0f4b81e6c406a3e21325820771c` / `15817807200ec885da9cfab50277497674edd0f4b81e6c406a3e21325820771c`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 19605 |
-| source_seed | 230 |
-| backup | 740 |
-| preflight | 130 |
-| integrity_before | 630 |
-| migration | 395 |
-| verify | 180 |
-| replay | 123 |
-| integrity_after | 1453 |
-| negative_gate | 48 |
-| rollback | 192 |
-| restore | 4334 |
+| source_migration | 18356 |
+| source_seed | 193 |
+| backup | 726 |
+| preflight | 119 |
+| integrity_before | 586 |
+| migration | 457 |
+| verify | 195 |
+| replay | 119 |
+| integrity_after | 1401 |
+| negative_gate | 41 |
+| rollback | 248 |
+| restore | 3997 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -17,6 +17,7 @@ const PROCUREMENT_RELIABILITY_PATCH = "20260812_procurement_reliability_sol18.sq
 const STOCK_INTELLIGENCE_PATCH = "20260813_stock_intelligence_sol19.sql";
 const TOOLING_TECHNICAL_GED_PATCH = "20260813_sol20_tooling_technical_ged.sql";
 const PLANNING_EXECUTION_PATCH = "20260814_planning_execution_intelligence_0021.sql";
+const ADV_RELIABILITY_PATCH = "20260814_adv_reliability_sol23.sql";
 const SOL06_SUPPORT = path.join(SUPPORT_DIR, "20260810_system_reference_data_readiness");
 const POSTGRES_IMAGE = "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229";
 const DEFAULT_REPORT_DIR = path.join(ROOT, "docs", "release");
@@ -447,6 +448,13 @@ async function proveRollback(databaseUrl) {
   await client.connect();
   try {
     await client.query("SET cerp.migration_rehearsal = 'on'");
+    const advReliabilityRollback = patchSupportSql(ADV_RELIABILITY_PATCH, "rollback");
+    const advReliabilityObject = await client.query(
+      "SELECT to_regclass('public.adv_delivery_blocks') IS NOT NULL AS present"
+    );
+    if (advReliabilityRollback && advReliabilityObject.rows[0].present) {
+      await runSqlFile(client, advReliabilityRollback);
+    }
     const planningExecutionRollback = patchSupportSql(PLANNING_EXECUTION_PATCH, "rollback");
     const planningExecutionObject = await client.query(
       "SELECT to_regclass('public.planning_user_preferences') IS NOT NULL AS present"
@@ -752,6 +760,7 @@ module.exports = {
   PROCUREMENT_RELIABILITY_PATCH,
   STOCK_INTELLIGENCE_PATCH,
   PLANNING_EXECUTION_PATCH,
+  ADV_RELIABILITY_PATCH,
   expectedRehearsalPatches,
   inventory,
   inventoryMarkdown,

--- a/src/__tests__/adv-reliability-sol23.migration-guards.test.ts
+++ b/src/__tests__/adv-reliability-sol23.migration-guards.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(__dirname, "../..");
+const read = (path: string) => readFileSync(resolve(root, path), "utf8");
+const patch = read("db/patches/20260814_adv_reliability_sol23.sql");
+const preflight = read("db/patches/support/20260814_adv_reliability_sol23.preflight.sql");
+const verify = read("db/patches/support/20260814_adv_reliability_sol23.verify.sql");
+const rollback = read("db/patches/support/20260814_adv_reliability_sol23.rollback.sql");
+const releaseGate = read("scripts/migrations/release-gate.js");
+
+describe("SOL-23 migration safety", () => {
+  it("creates structured cases, immutable evidence and idempotent receipts", () => {
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.adv_delivery_blocks");
+    expect(patch).toContain("QUALITY','DOCUMENT','STOCK','TRANSPORT");
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.adv_payment_promises");
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.adv_invoice_disputes");
+    expect(patch).toContain("trg_adv_case_events_append_only_0455");
+    expect(patch).toContain("adv_command_receipts_action_key_0455_uq");
+  });
+
+  it("freezes future OTIF without rewriting historical promises", () => {
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.adv_otif_assessments");
+    expect(patch).toContain("trg_adv_freeze_otif_0455");
+    expect(patch).toContain("ON CONFLICT(order_id) DO NOTHING");
+    expect(patch).not.toMatch(/INSERT INTO public\.adv_otif_assessments[\s\S]{0,800}FROM public\.commande_client/i);
+  });
+
+  it("provides preflight, verification and isolated guarded rollback", () => {
+    expect(preflight).toContain("PostgreSQL 14+ requis");
+    expect(verify).toContain("Tables SOL-23 absentes");
+    expect(rollback).toContain("cerp.migration_rehearsal");
+    expect(rollback).toContain("Rollback refuse: historique ADV present");
+    expect(releaseGate).toContain('const ADV_RELIABILITY_PATCH = "20260814_adv_reliability_sol23.sql"');
+  });
+});

--- a/src/__tests__/adv-reliability.routes.test.ts
+++ b/src/__tests__/adv-reliability.routes.test.ts
@@ -1,0 +1,73 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { repoAdvOverview, repoAdvOrderChain, repoCreateDeliveryBlock, repoCreatePaymentPromise } = vi.hoisted(() => ({
+  repoAdvOverview: vi.fn(),
+  repoAdvOrderChain: vi.fn(),
+  repoCreateDeliveryBlock: vi.fn(),
+  repoCreatePaymentPromise: vi.fn(),
+}));
+
+vi.mock("../module/adv-reliability/repository/adv-reliability.repository", () => ({
+  repoAdvOverview,
+  repoAdvOrderChain,
+  repoCreateDeliveryBlock,
+  repoResolveDeliveryBlock: vi.fn(),
+  repoCreatePaymentPromise,
+  repoUpdatePaymentPromise: vi.fn(),
+  repoCreateInvoiceDispute: vi.fn(),
+  repoUpdateInvoiceDispute: vi.fn(),
+}));
+
+import routes from "../module/adv-reliability/routes/adv-reliability.routes";
+
+function app(role: string | null) {
+  const server = express();
+  server.use(express.json());
+  server.use((req, _res, next) => {
+    if (role) req.user = { id: 7, username: "tester", role };
+    next();
+  });
+  server.use("/adv", routes);
+  server.use((error: { status?: number; code?: string; message?: string }, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(error.status ?? 500).json({ code: error.code, message: error.message });
+  });
+  return server;
+}
+
+describe("SOL-23 ADV RBAC and idempotency HTTP boundary", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("refuses anonymous and standard users on financial data", async () => {
+    expect((await request(app(null)).get("/adv/overview?period=custom&from=2026-08-01&to=2026-08-31")).status).toBe(401);
+    expect((await request(app("Utilisateur")).get("/adv/overview?period=custom&from=2026-08-01&to=2026-08-31")).status).toBe(403);
+    expect(repoAdvOverview).not.toHaveBeenCalled();
+  });
+
+  it("allows accounting to read and requires idempotency on writes", async () => {
+    repoAdvOverview.mockResolvedValue({ contract_version: "CERP-ADV-1.0.0" });
+    expect((await request(app("Comptable")).get("/adv/overview?period=custom&from=2026-08-01&to=2026-08-31")).status).toBe(200);
+    const missingKey = await request(app("Comptable")).post("/adv/invoices/1/payment-promises").send({
+      amount_ttc: "10.00", currency: "EUR", promised_date: "2026-08-20", owner_user_id: 7, next_action: "Relancer le client", due_date: "2026-08-21",
+    });
+    expect(missingKey.status).toBe(400);
+    expect(repoCreatePaymentPromise).not.toHaveBeenCalled();
+  });
+
+  it("prevents a standard commercial user from recording a payment promise", async () => {
+    const response = await request(app("Commercial")).post("/adv/invoices/1/payment-promises").set("Idempotency-Key", "promise-0001").send({
+      amount_ttc: "10.00", currency: "EUR", promised_date: "2026-08-20", owner_user_id: 7, next_action: "Relancer le client", due_date: "2026-08-21",
+    });
+    expect(response.status).toBe(403);
+    expect(repoCreatePaymentPromise).not.toHaveBeenCalled();
+  });
+
+  it("validates that a delivery block points to a structured category", async () => {
+    const response = await request(app("Comptable")).post("/adv/deliveries/2ecb92c3-3994-4cec-9f2d-68d0fefb2eb6/blocks").set("Idempotency-Key", "block-0001").send({
+      order_id: 12, category: "UNKNOWN", detail: "Blocage", owner_user_id: null, next_action: "Décider", due_date: "2026-08-20",
+    });
+    expect(response.status).toBe(422);
+    expect(repoCreateDeliveryBlock).not.toHaveBeenCalled();
+  });
+});

--- a/src/module/adv-reliability/controllers/adv-reliability.controller.ts
+++ b/src/module/adv-reliability/controllers/adv-reliability.controller.ts
@@ -1,0 +1,127 @@
+import type { Request, RequestHandler } from "express";
+import type { z } from "zod";
+
+import { HttpError } from "../../../utils/httpError";
+import { resolveRequest } from "../../facturation/services/reporting-v2.service";
+import { reportingFiltersSchema } from "../../facturation/validators/reporting-v2.validators";
+import {
+  repoAdvOrderChain,
+  repoAdvOverview,
+  repoCreateDeliveryBlock,
+  repoCreateInvoiceDispute,
+  repoCreatePaymentPromise,
+  repoResolveDeliveryBlock,
+  repoUpdateInvoiceDispute,
+  repoUpdatePaymentPromise,
+  type AdvActor,
+} from "../repository/adv-reliability.repository";
+import {
+  advOverviewQuerySchema,
+  caseParamsSchema,
+  deliveryBlockBodySchema,
+  deliveryParamsSchema,
+  invoiceDisputeBodySchema,
+  invoiceDisputeStatusBodySchema,
+  invoiceParamsSchema,
+  orderParamsSchema,
+  paymentPromiseBodySchema,
+  paymentPromiseStatusBodySchema,
+  resolveCaseBodySchema,
+} from "../validators/adv-reliability.validators";
+
+function parse<T extends z.ZodTypeAny>(schema: T, value: unknown): z.infer<T> {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) throw new HttpError(422, "VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Demande invalide.", parsed.error.flatten());
+  return parsed.data;
+}
+
+function actorFrom(req: Request): AdvActor {
+  if (!req.user) throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  const forwarded = req.headers["x-forwarded-for"];
+  return {
+    user_id: req.user.id,
+    ip: typeof forwarded === "string" ? forwarded.split(",")[0]?.trim() ?? null : req.ip ?? null,
+    user_agent: typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null,
+    path: req.originalUrl ?? null,
+    page_key: typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null,
+    client_session_id: typeof req.headers["x-client-session-id"] === "string" ? req.headers["x-client-session-id"] : null,
+  };
+}
+
+function idempotencyKeyFrom(req: Request): string {
+  const value = req.headers["idempotency-key"];
+  if (typeof value !== "string" || value.trim().length < 8 || value.trim().length > 120) {
+    throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "L'en-tête Idempotency-Key (8 à 120 caractères) est obligatoire.");
+  }
+  return value.trim();
+}
+
+export const advOverview: RequestHandler = async (req, res, next) => {
+  try {
+    actorFrom(req);
+    const reportingRequest = resolveRequest(parse(reportingFiltersSchema, req.query));
+    const query = parse(advOverviewQuerySchema, {
+      ...req.query,
+      from: reportingRequest.ctx.period.from,
+      to: reportingRequest.ctx.period.to,
+      as_of: reportingRequest.ctx.asOf,
+      client_id: reportingRequest.ctx.clientId,
+      currency: reportingRequest.ctx.currency,
+      limit: reportingRequest.ctx.limit,
+    });
+    res.setHeader("Cache-Control", "no-store, private");
+    res.json(await repoAdvOverview(query));
+  } catch (error) { next(error); }
+};
+
+export const advOrderChain: RequestHandler = async (req, res, next) => {
+  try {
+    actorFrom(req);
+    res.setHeader("Cache-Control", "no-store, private");
+    res.json(await repoAdvOrderChain(parse(orderParamsSchema, req.params).id));
+  } catch (error) { next(error); }
+};
+
+export const createDeliveryBlock: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = parse(deliveryParamsSchema, req.params);
+    res.status(201).json(await repoCreateDeliveryBlock({
+      deliveryId: id, input: parse(deliveryBlockBodySchema, req.body), actor: actorFrom(req), idempotencyKey: idempotencyKeyFrom(req),
+    }));
+  } catch (error) { next(error); }
+};
+
+export const resolveDeliveryBlock: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = parse(caseParamsSchema, req.params);
+    res.json(await repoResolveDeliveryBlock({ id, input: parse(resolveCaseBodySchema, req.body), actor: actorFrom(req), idempotencyKey: idempotencyKeyFrom(req) }));
+  } catch (error) { next(error); }
+};
+
+export const createPaymentPromise: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = parse(invoiceParamsSchema, req.params);
+    res.status(201).json(await repoCreatePaymentPromise({ invoiceId: id, input: parse(paymentPromiseBodySchema, req.body), actor: actorFrom(req), idempotencyKey: idempotencyKeyFrom(req) }));
+  } catch (error) { next(error); }
+};
+
+export const updatePaymentPromise: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = parse(caseParamsSchema, req.params);
+    res.json(await repoUpdatePaymentPromise({ id, input: parse(paymentPromiseStatusBodySchema, req.body), actor: actorFrom(req), idempotencyKey: idempotencyKeyFrom(req) }));
+  } catch (error) { next(error); }
+};
+
+export const createInvoiceDispute: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = parse(invoiceParamsSchema, req.params);
+    res.status(201).json(await repoCreateInvoiceDispute({ invoiceId: id, input: parse(invoiceDisputeBodySchema, req.body), actor: actorFrom(req), idempotencyKey: idempotencyKeyFrom(req) }));
+  } catch (error) { next(error); }
+};
+
+export const updateInvoiceDispute: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = parse(caseParamsSchema, req.params);
+    res.json(await repoUpdateInvoiceDispute({ id, input: parse(invoiceDisputeStatusBodySchema, req.body), actor: actorFrom(req), idempotencyKey: idempotencyKeyFrom(req) }));
+  } catch (error) { next(error); }
+};

--- a/src/module/adv-reliability/domain/adv-reliability.test.ts
+++ b/src/module/adv-reliability/domain/adv-reliability.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  agingBucket,
+  assessEInvoiceReadiness,
+  classifyDeliveryQueue,
+  computeCashForecast,
+  computeDsoDays,
+  reliabilityFromCoverage,
+} from "./adv-reliability";
+
+describe("SOL-23 ADV domain", () => {
+  it("prioritizes a structured blocker over lateness and readiness", () => {
+    expect(classifyDeliveryQueue({ dueDate: "2026-08-01", asOf: "2026-08-14", remainingQuantity: 2, ready: true, blocked: true })).toBe("BLOCKED");
+    expect(classifyDeliveryQueue({ dueDate: "2026-08-01", asOf: "2026-08-14", remainingQuantity: 2, ready: true, blocked: false })).toBe("LATE");
+    expect(classifyDeliveryQueue({ dueDate: "2026-08-20", asOf: "2026-08-14", remainingQuantity: 2, ready: true, blocked: false })).toBe("READY");
+    expect(classifyDeliveryQueue({ dueDate: null, asOf: "2026-08-14", remainingQuantity: 0, ready: false, blocked: false })).toBe("COMPLETE");
+  });
+
+  it("computes DSO in exact cents and returns unavailable without sales denominator", () => {
+    expect(computeDsoDays("1000.00", "36500.00")).toBe("10.00");
+    expect(computeDsoDays("1000.01", "36500.00")).toBe("10.00");
+    expect(computeDsoDays("1000.00", "0.00")).toBeNull();
+  });
+
+  it("caps promises and schedules at invoice balance without double counting", () => {
+    expect(computeCashForecast({ invoiceId: "42", currency: "EUR", balanceTtc: "100.00", promisedWithinHorizonTtc: "70.00", scheduledWithinHorizonTtc: "80.00" })).toEqual({
+      invoice_id: "42", currency: "EUR", promised_ttc: "70.00", scheduled_ttc: "30.00", expected_ttc: "100.00",
+    });
+    expect(computeCashForecast({ invoiceId: "43", currency: "EUR", balanceTtc: "50.00", promisedWithinHorizonTtc: "70.00", scheduledWithinHorizonTtc: "10.00" }).expected_ttc).toBe("50.00");
+  });
+
+  it("keeps missing due dates separate from non-due receivables", () => {
+    expect(agingBucket(null, "2026-08-14")).toBe("UNKNOWN");
+    expect(agingBucket("2026-08-14", "2026-08-14")).toBe("NOT_DUE");
+    expect(agingBucket("2026-07-01", "2026-08-14")).toBe("DUE_31_60");
+    expect(agingBucket("2026-01-01", "2026-08-14")).toBe("DUE_91_PLUS");
+  });
+
+  it("never invents external e-invoice statuses", () => {
+    expect(assessEInvoiceReadiness({ issued: false, legalNumber: null, currency: null, clientId: null, totalTtc: null })).toEqual({ status: "NOT_ASSESSED", missing: [], reliability: "PARTIAL" });
+    expect(assessEInvoiceReadiness({ issued: true, legalNumber: null, currency: "EUR", clientId: "001", totalTtc: "120.00" })).toEqual({ status: "BLOCKED", missing: ["LEGAL_NUMBER"], reliability: "PARTIAL" });
+    expect(assessEInvoiceReadiness({ issued: true, legalNumber: "FA-2026-1", currency: "EUR", clientId: "001", totalTtc: "120.00" }).status).toBe("READY_FOR_CONNECTOR");
+  });
+
+  it("qualifies OTIF reliability from frozen evidence coverage", () => {
+    expect(reliabilityFromCoverage(0, 0)).toBe("UNAVAILABLE");
+    expect(reliabilityFromCoverage(10, 6)).toBe("PARTIAL");
+    expect(reliabilityFromCoverage(10, 10)).toBe("ACTUAL");
+  });
+});

--- a/src/module/adv-reliability/domain/adv-reliability.ts
+++ b/src/module/adv-reliability/domain/adv-reliability.ts
@@ -1,0 +1,162 @@
+import crypto from "node:crypto";
+
+import { divideHalfUp, formatDecimal, moneyToCents } from "../../facturation/domain/decimal-money";
+
+export const ADV_RELIABILITY_CONTRACT_VERSION = "CERP-ADV-1.0.0" as const;
+export const ADV_RELIABILITY_TIMEZONE = "Europe/Paris" as const;
+
+export const DELIVERY_BLOCK_CATEGORIES = ["QUALITY", "DOCUMENT", "STOCK", "TRANSPORT"] as const;
+export const DELIVERY_BLOCK_STATUSES = ["OPEN", "RESOLVED"] as const;
+export const PAYMENT_PROMISE_STATUSES = ["OPEN", "KEPT", "BROKEN", "CANCELLED"] as const;
+export const INVOICE_DISPUTE_CATEGORIES = [
+  "QUALITY",
+  "DOCUMENT",
+  "PRICE",
+  "QUANTITY",
+  "DELIVERY",
+  "TAX",
+  "OTHER",
+] as const;
+export const INVOICE_DISPUTE_STATUSES = ["OPEN", "RESOLVED", "CANCELLED"] as const;
+
+export type AdvReliability = "ACTUAL" | "PARTIAL" | "UNAVAILABLE";
+export type DeliveryQueueState = "DUE" | "READY" | "BLOCKED" | "LATE" | "PLANNED" | "COMPLETE";
+
+const DAY_MS = 86_400_000;
+
+function day(value: string): number {
+  return Date.parse(`${value.slice(0, 10)}T00:00:00Z`);
+}
+
+export function calendarAgeDays(from: string | null, asOf: string): number | null {
+  if (!from) return null;
+  const start = day(from);
+  const end = day(asOf);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  return Math.max(0, Math.floor((end - start) / DAY_MS));
+}
+
+/**
+ * Priority is intentional: a known blocker outranks readiness and lateness, so
+ * the work queue always exposes the action that can unlock the promise.
+ */
+export function classifyDeliveryQueue(input: {
+  dueDate: string | null;
+  asOf: string;
+  remainingQuantity: number;
+  ready: boolean;
+  blocked: boolean;
+}): DeliveryQueueState {
+  if (input.remainingQuantity <= 0) return "COMPLETE";
+  if (input.blocked) return "BLOCKED";
+  if (input.dueDate && input.dueDate < input.asOf) return "LATE";
+  if (input.ready) return "READY";
+  if (input.dueDate && input.dueDate <= input.asOf) return "DUE";
+  return "PLANNED";
+}
+
+export function reliabilityFromCoverage(total: number, evidenced: number): AdvReliability {
+  if (total <= 0 || evidenced <= 0) return "UNAVAILABLE";
+  return evidenced >= total ? "ACTUAL" : "PARTIAL";
+}
+
+/**
+ * Ratio DSO: encours TTC / chiffre d'affaires TTC émis sur les 365 jours × 365.
+ * Inputs are exact decimal strings; arithmetic stays in integer cents.
+ */
+export function computeDsoDays(openTtc: string, issuedTtc365d: string): string | null {
+  const open = moneyToCents(openTtc, "Encours TTC");
+  const issued = moneyToCents(issuedTtc365d, "Facturé TTC sur 365 jours");
+  if (open < 0n || issued <= 0n) return null;
+  const hundredthsOfDay = divideHalfUp(open * 36500n, issued);
+  return formatDecimal(hundredthsOfDay, 2);
+}
+
+export type CashForecastInvoice = {
+  invoiceId: string;
+  currency: string;
+  balanceTtc: string;
+  scheduledWithinHorizonTtc: string;
+  promisedWithinHorizonTtc: string;
+};
+
+/** A promise consumes the invoice balance first; schedules use only the remainder. */
+export function computeCashForecast(invoice: CashForecastInvoice): {
+  invoice_id: string;
+  currency: string;
+  promised_ttc: string;
+  scheduled_ttc: string;
+  expected_ttc: string;
+} {
+  const balance = moneyToCents(invoice.balanceTtc, "Solde facture");
+  const promised = moneyToCents(invoice.promisedWithinHorizonTtc, "Promesses");
+  const scheduled = moneyToCents(invoice.scheduledWithinHorizonTtc, "Échéances");
+  const boundedBalance = balance > 0n ? balance : 0n;
+  const boundedPromise = promised > 0n ? (promised < boundedBalance ? promised : boundedBalance) : 0n;
+  const remaining = boundedBalance - boundedPromise;
+  const boundedSchedule = scheduled > 0n ? (scheduled < remaining ? scheduled : remaining) : 0n;
+  return {
+    invoice_id: invoice.invoiceId,
+    currency: invoice.currency,
+    promised_ttc: formatDecimal(boundedPromise, 2),
+    scheduled_ttc: formatDecimal(boundedSchedule, 2),
+    expected_ttc: formatDecimal(boundedPromise + boundedSchedule, 2),
+  };
+}
+
+export type AgingBucket = "NOT_DUE" | "DUE_0_30" | "DUE_31_60" | "DUE_61_90" | "DUE_91_PLUS" | "UNKNOWN";
+
+export function agingBucket(dueDate: string | null, asOf: string): AgingBucket {
+  if (!dueDate) return "UNKNOWN";
+  if (dueDate >= asOf) return "NOT_DUE";
+  const age = calendarAgeDays(dueDate, asOf);
+  if (age === null) return "UNKNOWN";
+  if (age <= 30) return "DUE_0_30";
+  if (age <= 60) return "DUE_31_60";
+  if (age <= 90) return "DUE_61_90";
+  return "DUE_91_PLUS";
+}
+
+export type EInvoiceReadiness = {
+  status: "NOT_ASSESSED" | "BLOCKED" | "READY_FOR_CONNECTOR";
+  missing: string[];
+  reliability: "PARTIAL";
+};
+
+/**
+ * Internal completeness only. This deliberately never emits a regulatory
+ * transport status (sent/received/accepted/rejected) without a connector.
+ */
+export function assessEInvoiceReadiness(input: {
+  issued: boolean;
+  legalNumber: string | null;
+  currency: string | null;
+  clientId: string | null;
+  totalTtc: string | null;
+}): EInvoiceReadiness {
+  if (!input.issued) return { status: "NOT_ASSESSED", missing: [], reliability: "PARTIAL" };
+  const missing: string[] = [];
+  if (!input.legalNumber?.trim()) missing.push("LEGAL_NUMBER");
+  if (!input.currency?.trim()) missing.push("CURRENCY");
+  if (!input.clientId?.trim()) missing.push("CLIENT");
+  if (input.totalTtc === null) missing.push("TOTAL_TTC");
+  return {
+    status: missing.length === 0 ? "READY_FOR_CONNECTOR" : "BLOCKED",
+    missing,
+    reliability: "PARTIAL",
+  };
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  return `{${Object.entries(value as Record<string, unknown>)
+    .filter(([, child]) => child !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, child]) => `${JSON.stringify(key)}:${stableStringify(child)}`)
+    .join(",")}}`;
+}
+
+export function advPayloadHash(value: unknown): string {
+  return crypto.createHash("sha256").update(stableStringify(value), "utf8").digest("hex");
+}

--- a/src/module/adv-reliability/repository/adv-reliability.repository.ts
+++ b/src/module/adv-reliability/repository/adv-reliability.repository.ts
@@ -1,0 +1,460 @@
+import type { PoolClient } from "pg";
+
+import db from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+import {
+  ADV_RELIABILITY_CONTRACT_VERSION,
+  ADV_RELIABILITY_TIMEZONE,
+  advPayloadHash,
+  agingBucket,
+  assessEInvoiceReadiness,
+  calendarAgeDays,
+  classifyDeliveryQueue,
+  computeCashForecast,
+  computeDsoDays,
+  reliabilityFromCoverage,
+} from "../domain/adv-reliability";
+import type {
+  AdvOverviewQueryDTO,
+  DeliveryBlockBodyDTO,
+  InvoiceDisputeBodyDTO,
+  InvoiceDisputeStatusBodyDTO,
+  PaymentPromiseBodyDTO,
+  PaymentPromiseStatusBodyDTO,
+  ResolveCaseBodyDTO,
+} from "../validators/adv-reliability.validators";
+import { moneyToCents } from "../../facturation/domain/decimal-money";
+import {
+  Params,
+  balancesCte,
+  creditedCte,
+  ledgerFactureCte,
+  paiementNetPredicate,
+  settledCte,
+} from "../../facturation/repository/reporting-sql";
+
+type Queryer = Pick<PoolClient, "query">;
+type AdvCommandAction = "DELIVERY_BLOCK_CREATE" | "DELIVERY_BLOCK_RESOLVE" | "PAYMENT_PROMISE_CREATE" | "PAYMENT_PROMISE_STATUS" | "INVOICE_DISPUTE_CREATE" | "INVOICE_DISPUTE_STATUS";
+
+export type AdvActor = {
+  user_id: number;
+  ip: string | null;
+  user_agent: string | null;
+  path: string | null;
+  page_key: string | null;
+  client_session_id: string | null;
+};
+
+function int(value: unknown): number {
+  const parsed = Number.parseInt(String(value ?? "0"), 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function numeric(value: unknown): number {
+  const parsed = Number.parseFloat(String(value ?? "0"));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function moneyText(value: unknown): string {
+  const raw = String(value ?? "0.00");
+  return (Number.parseFloat(raw) || 0).toFixed(2);
+}
+
+async function ensureInstalled(queryer: Queryer = db): Promise<void> {
+  const result = await queryer.query<{ installed: boolean }>(`
+    SELECT to_regclass('public.adv_delivery_blocks') IS NOT NULL
+       AND to_regclass('public.adv_payment_promises') IS NOT NULL
+       AND to_regclass('public.adv_invoice_disputes') IS NOT NULL
+       AND to_regclass('public.adv_case_events') IS NOT NULL
+       AND to_regclass('public.adv_otif_assessments') IS NOT NULL
+       AND to_regclass('public.adv_command_receipts') IS NOT NULL AS installed
+  `);
+  if (!result.rows[0]?.installed) {
+    throw new HttpError(503, "ADV_RELIABILITY_NOT_INSTALLED", "Le patch SOL-23 doit être appliqué avant d'utiliser le cockpit ADV.");
+  }
+}
+
+async function inTransaction<T>(work: (tx: PoolClient) => Promise<T>): Promise<T> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const value = await work(client);
+    await client.query("COMMIT");
+    return value;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function insertAudit(tx: Queryer, actor: AdvActor, entry: { action: string; entity_type: string; entity_id: string; details: Record<string, unknown> }) {
+  const body: CreateAuditLogBodyDTO = {
+    event_type: "ACTION",
+    action: entry.action,
+    page_key: actor.page_key,
+    entity_type: entry.entity_type,
+    entity_id: entry.entity_id,
+    path: actor.path,
+    client_session_id: actor.client_session_id,
+    details: entry.details,
+  };
+  await repoInsertAuditLog({ user_id: actor.user_id, body, ip: actor.ip, user_agent: actor.user_agent, device_type: null, os: null, browser: null, tx });
+}
+
+async function readReceipt<T>(tx: Queryer, action: AdvCommandAction, key: string, hash: string): Promise<T | null> {
+  const result = await tx.query<{ request_hash: string; response_snapshot: T }>(
+    `SELECT request_hash,response_snapshot FROM public.adv_command_receipts WHERE action=$1 AND idempotency_key=$2 FOR SHARE`,
+    [action, key],
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  if (row.request_hash !== hash) throw new HttpError(409, "IDEMPOTENCY_PAYLOAD_MISMATCH", "Cette clé d'idempotence a déjà servi avec une demande différente.");
+  return { ...(row.response_snapshot as Record<string, unknown>), idempotent_replay: true } as T;
+}
+
+async function saveReceipt(tx: Queryer, action: AdvCommandAction, key: string, hash: string, actorId: number, response: unknown) {
+  await tx.query(
+    `INSERT INTO public.adv_command_receipts(action,idempotency_key,request_hash,actor_user_id,response_snapshot)
+     VALUES ($1,$2,$3,$4,$5::jsonb)`,
+    [action, key, hash, actorId, JSON.stringify(response)],
+  );
+}
+
+async function appendCaseEvent(tx: Queryer, params: { caseType: string; caseId: string; eventType: string; actorId: number; snapshot: unknown }) {
+  await tx.query(
+    `INSERT INTO public.adv_case_events(case_type,case_id,event_type,actor_user_id,snapshot)
+     VALUES ($1,$2::uuid,$3,$4,$5::jsonb)`,
+    [params.caseType, params.caseId, params.eventType, params.actorId, JSON.stringify(params.snapshot)],
+  );
+}
+
+async function loadDeliveryQueue(query: AdvOverviewQueryDTO, asOf: string) {
+  const values: unknown[] = [query.to, query.limit];
+  const clientFilter = query.client_id ? `AND cc.client_id=$${values.push(query.client_id)}::text ` : "";
+  const result = await db.query<Record<string, unknown>>(`
+    WITH shipped AS (
+      SELECT bll.commande_ligne_id, SUM(bll.quantite)::numeric(18,3) AS shipped_qty,
+             MAX(COALESCE(bl.date_expedition,bl.date_livraison,bl.date_creation))::date AS last_ship_date
+        FROM public.bon_livraison_ligne bll
+        JOIN public.bon_livraison bl ON bl.id=bll.bon_livraison_id
+       WHERE bll.commande_ligne_id IS NOT NULL AND bl.statut IN ('SHIPPED','DELIVERED')
+       GROUP BY bll.commande_ligne_id
+    ), line_facts AS (
+      SELECT cc.id AS order_id,cc.numero,cc.client_id,c.company_name,
+             cl.id AS line_id,cl.delai_client,cl.quantite::numeric(18,3) AS ordered_qty,
+             GREATEST(cl.quantite-COALESCE(s.shipped_qty,0),0)::numeric(18,3) AS remaining_qty,
+             s.last_ship_date
+        FROM public.commande_client cc
+        JOIN public.commande_ligne cl ON cl.commande_id=cc.id
+        LEFT JOIN public.clients c ON c.client_id=cc.client_id
+        LEFT JOIN shipped s ON s.commande_ligne_id=cl.id
+       WHERE COALESCE(cc.order_type,'FERME') <> 'INTERNE' ${clientFilter}
+    ), orders AS (
+      SELECT order_id,numero,client_id,company_name,
+             MIN(delai_client) FILTER (WHERE remaining_qty>0)::text AS due_date,
+             SUM(ordered_qty)::text AS ordered_qty,SUM(remaining_qty)::text AS remaining_qty,
+             MAX(last_ship_date)::text AS last_ship_date
+        FROM line_facts GROUP BY order_id,numero,client_id,company_name
+    ), deliveries AS (
+      SELECT commande_id,
+             COUNT(*) FILTER (WHERE statut='READY')::int AS ready_count,
+             COALESCE(jsonb_agg(jsonb_build_object('id',id::text,'numero',numero,'status',statut,
+               'planned_date',date_livraison::text,'shipped_at',date_expedition::text,'updated_at',updated_at::text)
+               ORDER BY date_creation,id) FILTER (WHERE statut<>'CANCELLED'),'[]'::jsonb) AS rows
+        FROM public.bon_livraison WHERE commande_id IS NOT NULL GROUP BY commande_id
+    )
+    SELECT o.*,COALESCE(d.ready_count,0) AS ready_count,d.rows,
+           b.id::text AS block_id,b.delivery_id::text,b.category AS block_category,b.detail AS block_detail,
+           b.owner_user_id,u.username AS owner_name,b.next_action,b.due_date::text AS action_due_date,
+           b.created_at::text AS blocked_at,b.updated_at::text AS block_updated_at
+      FROM orders o
+      LEFT JOIN deliveries d ON d.commande_id=o.order_id
+      LEFT JOIN LATERAL (
+        SELECT ab.* FROM public.adv_delivery_blocks ab
+         WHERE ab.order_id=o.order_id AND ab.status='OPEN'
+         ORDER BY ab.created_at,ab.id LIMIT 1
+      ) b ON TRUE
+      LEFT JOIN public.users u ON u.id=b.owner_user_id
+     WHERE o.remaining_qty::numeric>0
+       AND (o.due_date::date <= $1::date OR o.due_date IS NULL)
+     ORDER BY (o.due_date IS NULL),o.due_date,o.order_id
+     LIMIT $2
+  `, values);
+  return result.rows.map((row) => {
+    const dueDate = row.due_date === null ? null : String(row.due_date);
+    const remaining = numeric(row.remaining_qty);
+    const blocked = row.block_id !== null;
+    const ready = int(row.ready_count) > 0;
+    return {
+      order_id: int(row.order_id), numero: String(row.numero), client_id: String(row.client_id), company_name: row.company_name === null ? null : String(row.company_name),
+      due_date: dueDate, ordered_qty: numeric(row.ordered_qty), remaining_qty: remaining,
+      state: classifyDeliveryQueue({ dueDate, asOf, remainingQuantity: remaining, ready, blocked }),
+      aging_days: calendarAgeDays(dueDate, asOf), deliveries: Array.isArray(row.rows) ? row.rows : [],
+      block: blocked ? {
+        id: String(row.block_id), delivery_id: String(row.delivery_id), category: String(row.block_category), detail: String(row.block_detail),
+        owner_user_id: row.owner_user_id === null ? null : int(row.owner_user_id), owner_name: row.owner_name === null ? null : String(row.owner_name),
+        next_action: String(row.next_action), due_date: String(row.action_due_date), blocked_at: String(row.blocked_at), updated_at: String(row.block_updated_at),
+      } : null,
+    };
+  });
+}
+
+async function loadOtif(query: AdvOverviewQueryDTO, asOf: string) {
+  const values: unknown[] = [asOf, query.from, query.to];
+  const clientFilter = query.client_id ? `AND cc.client_id=$${values.push(query.client_id)} ` : "";
+  const result = await db.query<Record<string, unknown>>(`
+    WITH shipped_daily AS (
+      SELECT bll.commande_ligne_id,COALESCE(bl.date_expedition,bl.date_livraison,bl.date_creation)::date AS ship_date,
+             SUM(bll.quantite)::numeric(18,3) AS qty
+        FROM public.bon_livraison_ligne bll JOIN public.bon_livraison bl ON bl.id=bll.bon_livraison_id
+       WHERE bl.statut IN ('SHIPPED','DELIVERED') AND COALESCE(bl.date_expedition,bl.date_livraison,bl.date_creation)::date <= $1::date
+       GROUP BY bll.commande_ligne_id,COALESCE(bl.date_expedition,bl.date_livraison,bl.date_creation)::date
+    ), progress AS (
+      SELECT commande_ligne_id,ship_date,SUM(qty) OVER(PARTITION BY commande_ligne_id ORDER BY ship_date)::numeric(18,3) AS cumulative_qty FROM shipped_daily
+    ), line_completion AS (
+      SELECT cl.commande_id,cl.id,cl.delai_client,cl.quantite,
+             (SELECT MIN(p.ship_date) FROM progress p WHERE p.commande_ligne_id=cl.id AND p.cumulative_qty>=cl.quantite) AS completion_date
+        FROM public.commande_ligne cl
+    ), derived AS (
+      SELECT cc.id AS order_id,MAX(lc.delai_client)::date AS promised_date,MAX(lc.completion_date)::date AS completion_date,
+             BOOL_AND(lc.delai_client IS NOT NULL) AS eligible,
+             BOOL_AND(lc.completion_date IS NOT NULL AND lc.completion_date<=lc.delai_client) AS pass
+        FROM public.commande_client cc JOIN line_completion lc ON lc.commande_id=cc.id
+       WHERE COALESCE(cc.order_type,'FERME')<>'INTERNE' ${clientFilter}
+       GROUP BY cc.id
+    ), population AS (
+      SELECT d.*,a.on_time_in_full AS frozen_pass,a.id IS NOT NULL AS frozen
+        FROM derived d LEFT JOIN public.adv_otif_assessments a ON a.order_id=d.order_id
+       WHERE d.eligible AND d.completion_date IS NOT NULL AND d.promised_date BETWEEN $2::date AND $3::date
+    )
+    SELECT COUNT(*)::int AS eligible,
+           COUNT(*) FILTER (WHERE COALESCE(frozen_pass,pass))::int AS passed,
+           COUNT(*) FILTER (WHERE frozen)::int AS frozen,
+           COALESCE(jsonb_agg(jsonb_build_object('order_id',order_id,'promised_date',promised_date::text,
+             'completion_date',completion_date::text,'pass',COALESCE(frozen_pass,pass),'evidence',CASE WHEN frozen THEN 'FROZEN' ELSE 'CURRENT_DERIVED' END)
+             ORDER BY promised_date,order_id),'[]'::jsonb) AS evidence
+      FROM population
+  `, values);
+  const row = result.rows[0] ?? {};
+  const eligible = int(row.eligible);
+  const passed = int(row.passed);
+  const frozen = int(row.frozen);
+  return {
+    value_pct: eligible > 0 ? Math.round((passed / eligible) * 10_000) / 100 : null,
+    numerator: passed, denominator: eligible, frozen_evidence_count: frozen,
+    current_derived_count: Math.max(0, eligible - frozen),
+    reliability: reliabilityFromCoverage(eligible, frozen),
+    evidence: Array.isArray(row.evidence) ? row.evidence : [],
+  };
+}
+
+async function loadFinance(query: AdvOverviewQueryDTO, asOf: string) {
+  const p = new Params();
+  const ledger = ledgerFactureCte(p, { asOf, basis: "document_date", clientId: query.client_id, currency: query.currency });
+  const settled = settledCte(p, asOf);
+  const credited = creditedCte(p, asOf, "document_date");
+  const horizon = p.push(asOf);
+  const limit = p.push(query.limit);
+  const result = await db.query<Record<string, unknown>>(`
+    WITH ${ledger},${settled},${credited},${balancesCte()},
+    schedules AS (
+      SELECT fe.facture_id,SUM(GREATEST(fe.amount_due-fe.amount_allocated,0))::numeric(18,2) AS amount
+        FROM public.facture_echeance fe
+       WHERE fe.status IN ('OPEN','PARTIALLY_PAID','OVERDUE') AND fe.due_date BETWEEN ${horizon}::date AND (${horizon}::date+30)
+       GROUP BY fe.facture_id
+    ), promises AS (
+      SELECT facture_id,SUM(amount_ttc)::numeric(18,2) AS amount
+        FROM public.adv_payment_promises
+       WHERE status='OPEN' AND promised_date BETWEEN ${horizon}::date AND (${horizon}::date+30)
+       GROUP BY facture_id
+    ), disputes AS (
+      SELECT facture_id,COUNT(*)::int AS open_count,SUM(COALESCE(disputed_amount_ttc,0))::numeric(18,2) AS disputed_ttc
+        FROM public.adv_invoice_disputes WHERE status='OPEN' GROUP BY facture_id
+    )
+    SELECT b.id::text,b.numero,b.client_id,c.company_name,b.currency,b.date_emission::text,b.date_echeance::text,
+           b.total_ttc::text,b.balance_ttc::text,b.settled_ttc::text,b.credited_ttc::text,
+           COALESCE(s.amount,0)::text AS scheduled_ttc,COALESCE(p.amount,0)::text AS promised_ttc,
+           COALESCE(d.open_count,0) AS dispute_count,COALESCE(d.disputed_ttc,0)::text AS disputed_ttc,
+           f.legal_number,f.statut,f.updated_at::text
+      FROM balances b JOIN public.facture f ON f.id=b.id LEFT JOIN public.clients c ON c.client_id=b.client_id
+      LEFT JOIN schedules s ON s.facture_id=b.id LEFT JOIN promises p ON p.facture_id=b.id LEFT JOIN disputes d ON d.facture_id=b.id
+     WHERE b.balance_ttc>0 ORDER BY b.date_echeance NULLS LAST,b.id LIMIT ${limit}
+  `, p.values);
+  const invoices = result.rows.map((row) => {
+    const forecast = computeCashForecast({ invoiceId: String(row.id), currency: String(row.currency), balanceTtc: moneyText(row.balance_ttc), scheduledWithinHorizonTtc: moneyText(row.scheduled_ttc), promisedWithinHorizonTtc: moneyText(row.promised_ttc) });
+    return {
+      id: String(row.id), numero: String(row.numero), client_id: String(row.client_id), company_name: row.company_name === null ? null : String(row.company_name),
+      currency: String(row.currency), issue_date: String(row.date_emission), due_date: row.date_echeance === null ? null : String(row.date_echeance),
+      balance_ttc: moneyText(row.balance_ttc), settled_ttc: moneyText(row.settled_ttc), credited_ttc: moneyText(row.credited_ttc),
+      aging_bucket: agingBucket(row.date_echeance === null ? null : String(row.date_echeance), asOf),
+      dispute: { open_count: int(row.dispute_count), disputed_ttc: moneyText(row.disputed_ttc) }, forecast,
+      e_invoice_readiness: assessEInvoiceReadiness({ issued: ["ISSUED","PARTIALLY_PAID","PAID","emis","emise","envoyee","partielle","payee"].includes(String(row.statut)), legalNumber: row.legal_number === null ? null : String(row.legal_number), currency: row.currency === null ? null : String(row.currency), clientId: row.client_id === null ? null : String(row.client_id), totalTtc: row.total_ttc === null ? null : String(row.total_ttc) }),
+      freshness_at: String(row.updated_at),
+    };
+  });
+
+  const salesParams: unknown[] = [asOf, query.client_id ?? null, query.currency ?? null];
+  const sales = await db.query<Record<string, unknown>>(`
+    SELECT UPPER(COALESCE(currency,'EUR')) AS currency,SUM(total_ttc)::numeric(18,2)::text AS issued_ttc
+      FROM public.facture
+     WHERE statut IN ('ISSUED','PARTIALLY_PAID','PAID','emis','emise','envoyee','partielle','payee')
+       AND date_emission BETWEEN ($1::date-364) AND $1::date
+       AND ($2::text IS NULL OR client_id=$2)
+       AND ($3::text IS NULL OR UPPER(COALESCE(currency,'EUR'))=$3)
+     GROUP BY UPPER(COALESCE(currency,'EUR'))
+  `, salesParams);
+  const issuedByCurrency = new Map(sales.rows.map((row) => [String(row.currency), moneyText(row.issued_ttc)]));
+  const grouped = new Map<string, { open: bigint; scheduled: bigint; promised: bigint; expected: bigint; count: number }>();
+  for (const invoice of invoices) {
+    const current = grouped.get(invoice.currency) ?? { open: 0n, scheduled: 0n, promised: 0n, expected: 0n, count: 0 };
+    current.open += moneyToCents(invoice.balance_ttc);
+    current.scheduled += moneyToCents(invoice.forecast.scheduled_ttc);
+    current.promised += moneyToCents(invoice.forecast.promised_ttc);
+    current.expected += moneyToCents(invoice.forecast.expected_ttc);
+    current.count += 1;
+    grouped.set(invoice.currency, current);
+  }
+  const currencies = [...grouped.entries()].map(([currency, value]) => ({
+    currency, invoice_count: value.count, open_ttc: (Number(value.open) / 100).toFixed(2),
+    scheduled_30d_ttc: (Number(value.scheduled) / 100).toFixed(2), promised_30d_ttc: (Number(value.promised) / 100).toFixed(2),
+    expected_30d_ttc: (Number(value.expected) / 100).toFixed(2), issued_365d_ttc: issuedByCurrency.get(currency) ?? "0.00",
+    dso_days: computeDsoDays((Number(value.open) / 100).toFixed(2), issuedByCurrency.get(currency) ?? "0.00"),
+  }));
+  return { currencies, invoices };
+}
+
+export async function repoAdvOverview(query: AdvOverviewQueryDTO) {
+  await ensureInstalled();
+  const asOf = query.as_of ?? new Date().toISOString().slice(0, 10);
+  const [deliveries, otif, finance] = await Promise.all([loadDeliveryQueue(query, asOf), loadOtif(query, asOf), loadFinance(query, asOf)]);
+  const counts = { due: 0, ready: 0, blocked: 0, late: 0, planned: 0 };
+  for (const item of deliveries) {
+    if (item.state === "DUE") counts.due += 1;
+    else if (item.state === "READY") counts.ready += 1;
+    else if (item.state === "BLOCKED") counts.blocked += 1;
+    else if (item.state === "LATE") counts.late += 1;
+    else if (item.state === "PLANNED") counts.planned += 1;
+  }
+  return {
+    contract_version: ADV_RELIABILITY_CONTRACT_VERSION,
+    generated_at: new Date().toISOString(), timezone: ADV_RELIABILITY_TIMEZONE,
+    period: { from: query.from, to: query.to, as_of: asOf },
+    delivery: {
+      counts, otif, queue: deliveries,
+      metric_definition: { unit: "orders", period: "open promises due no later than period end", source: ["commande_client","commande_ligne","bon_livraison","adv_delivery_blocks"], freshness_at: new Date().toISOString(), reliability: deliveries.some((row) => row.due_date === null) ? "PARTIAL" : "ACTUAL" },
+    },
+    finance: {
+      ...finance,
+      metric_definitions: {
+        dso: { unit: "calendar_days", formula: "open_receivables_ttc / issued_ttc_last_365_days × 365", period: "rolling_365_days", source: ["facture","paiement_allocations","avoir_source_allocations"], reliability: "ACTUAL" },
+        cash_30d: { unit: "currency", formula: "active promises first + due schedules on residual balance, capped at invoice balance", period: "as_of through as_of+30d", source: ["facture_echeance","adv_payment_promises","paiement_allocations","avoir_source_allocations"], reliability: "PARTIAL" },
+      },
+    },
+    electronic_invoicing: { scope: "INTERNAL_READINESS_ONLY", connector: { available: false, status: "UNAVAILABLE", reason: "NO_PROVIDER_SELECTED" }, statuses: ["NOT_ASSESSED","BLOCKED","READY_FOR_CONNECTOR"] },
+    existing_finance_capabilities: { partial_invoices: true, credit_notes: true, schedules: true, reconciled_payments: true },
+  };
+}
+
+export async function repoAdvOrderChain(orderId: number) {
+  await ensureInstalled();
+  const order = await db.query<Record<string, unknown>>(`SELECT cc.id::text,cc.numero,cc.client_id,cc.devis_id::text,c.company_name FROM public.commande_client cc LEFT JOIN public.clients c ON c.client_id=cc.client_id WHERE cc.id=$1`, [orderId]);
+  if (!order.rows[0]) throw new HttpError(404, "ORDER_NOT_FOUND", "Commande client introuvable.");
+  const [deliveries, invoices, affairs, ofs] = await Promise.all([
+    db.query(`SELECT bl.id::text,bl.numero,bl.statut AS status,bl.date_expedition::text,bl.date_livraison::text,
+      COALESCE(jsonb_agg(jsonb_build_object('id',bll.id::text,'order_line_id',bll.commande_ligne_id::text,'quantity',bll.quantite::text) ORDER BY bll.ordre) FILTER(WHERE bll.id IS NOT NULL),'[]'::jsonb) AS lines
+      FROM public.bon_livraison bl LEFT JOIN public.bon_livraison_ligne bll ON bll.bon_livraison_id=bl.id WHERE bl.commande_id=$1 GROUP BY bl.id ORDER BY bl.date_creation,bl.id`, [orderId]),
+    db.query(`SELECT f.id::text,f.numero,f.statut AS status,f.total_ht::text,f.total_ttc::text,f.currency,f.date_emission::text,f.date_echeance::text,
+      COALESCE((SELECT jsonb_agg(jsonb_build_object('payment_id',p.id::text,'date',p.date_paiement::text,'amount_ttc',pa.amount_ttc::text,'status',p.status) ORDER BY p.date_paiement,p.id) FROM public.paiement_allocations pa JOIN public.paiement p ON p.id=pa.paiement_id WHERE pa.facture_id=f.id),'[]'::jsonb) AS payments,
+      COALESCE((SELECT jsonb_agg(jsonb_build_object('credit_id',a.id::text,'number',a.numero,'amount_ttc',aa.amount_ttc::text,'status',a.statut) ORDER BY a.date_emission,a.id) FROM public.avoir_source_allocations aa JOIN public.avoir a ON a.id=aa.avoir_id WHERE aa.facture_id=f.id),'[]'::jsonb) AS credits,
+      COALESCE((SELECT jsonb_agg(jsonb_build_object('id',d.id::text,'category',d.category,'status',d.status,'amount_ttc',d.disputed_amount_ttc::text,'next_action',d.next_action,'due_date',d.due_date::text) ORDER BY d.created_at) FROM public.adv_invoice_disputes d WHERE d.facture_id=f.id),'[]'::jsonb) AS disputes,
+      COALESCE((SELECT jsonb_agg(jsonb_build_object('id',pp.id::text,'status',pp.status,'amount_ttc',pp.amount_ttc::text,'promised_date',pp.promised_date::text,'next_action',pp.next_action) ORDER BY pp.created_at) FROM public.adv_payment_promises pp WHERE pp.facture_id=f.id),'[]'::jsonb) AS promises
+      FROM public.facture f WHERE f.commande_id=$1 OR EXISTS(SELECT 1 FROM public.facture_source_allocations fsa JOIN public.bon_livraison_ligne bll ON bll.id::text=fsa.source_line_id JOIN public.bon_livraison bl ON bl.id=bll.bon_livraison_id WHERE fsa.facture_id=f.id AND fsa.source_type='DELIVERY_LINE' AND bl.commande_id=$1) ORDER BY f.date_emission,f.id`, [orderId]),
+    db.query(`SELECT id::text,reference,numero FROM public.affaire WHERE commande_id=$1 OR id IN (SELECT affaire_id FROM public.commande_to_affaire WHERE commande_id=$1)`, [orderId]),
+    db.query(`SELECT id::text,numero,affaire_id::text FROM public.ordres_fabrication WHERE commande_id=$1 OR commande_ligne_id IN (SELECT id FROM public.commande_ligne WHERE commande_id=$1)`, [orderId]),
+  ]);
+  const base = order.rows[0];
+  const marginScopes = [
+    ...(base.devis_id ? [{ type: "DEVIS", ref: String(base.devis_id) }] : []),
+    ...affairs.rows.map((row) => ({ type: "AFFAIRE", ref: String(row.id) })),
+    ...ofs.rows.map((row) => ({ type: "OF", ref: String(row.id) })),
+  ];
+  const margins = marginScopes.length === 0 ? [] : (await db.query<Record<string, unknown>>(`
+    SELECT DISTINCT ON (scope_type,scope_ref,basis) scope_type,scope_ref,basis,as_of::text,created_at::text,
+           result_snapshot->>'reliability' AS reliability,result_snapshot->>'availability' AS availability,
+           result_snapshot->>'gross_margin_ht' AS gross_margin_ht,result_snapshot->>'currency' AS currency,
+           calculation_hash
+      FROM public.margin_recalculations
+     WHERE (scope_type,scope_ref) IN (${marginScopes.map((_, index) => `($${index * 2 + 1},$${index * 2 + 2})`).join(",")})
+     ORDER BY scope_type,scope_ref,basis,created_at DESC
+  `, marginScopes.flatMap((scope) => [scope.type, scope.ref]))).rows;
+  return {
+    contract_version: ADV_RELIABILITY_CONTRACT_VERSION,
+    order: base, deliveries: deliveries.rows, invoices: invoices.rows,
+    production: { affairs: affairs.rows, manufacturing_orders: ofs.rows },
+    margins: { links: marginScopes.map((scope) => ({ ...scope, endpoint: `/api/v1/margins/${scope.type.toLowerCase()}/${scope.ref}` })), snapshots: margins, reliability_authority: "SOL-13 margin engine" },
+    chain: "order → delivery → invoice → payment/credit → margin",
+  };
+}
+
+async function invoiceIdentity(tx: Queryer, invoiceId: number) {
+  const result = await tx.query<Record<string, unknown>>(`
+    SELECT f.id,f.client_id,UPPER(COALESCE(f.currency,'EUR')) AS currency,f.total_ttc::text,
+           (f.total_ttc-COALESCE((SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa JOIN public.paiement p ON p.id=pa.paiement_id WHERE pa.facture_id=f.id AND p.status NOT IN ('REJECTED','REVERSED')),0)
+             -COALESCE((SELECT SUM(asa.amount_ttc) FROM public.avoir_source_allocations asa JOIN public.avoir a ON a.id=asa.avoir_id WHERE asa.facture_id=f.id AND asa.allocation_status='CONSUMED' AND a.statut IN ('ISSUED','emis','emise')),0))::numeric(18,2)::text AS balance_ttc
+      FROM public.facture f WHERE f.id=$1 FOR UPDATE`, [invoiceId]);
+  if (!result.rows[0]) throw new HttpError(404, "INVOICE_NOT_FOUND", "Facture introuvable.");
+  return result.rows[0];
+}
+
+export async function repoCreateDeliveryBlock(params: { deliveryId: string; input: DeliveryBlockBodyDTO; actor: AdvActor; idempotencyKey: string }) {
+  return inTransaction(async (tx) => {
+    await ensureInstalled(tx);
+    const hash = advPayloadHash({ delivery_id: params.deliveryId, ...params.input });
+    const replay = await readReceipt<Record<string, unknown>>(tx, "DELIVERY_BLOCK_CREATE", params.idempotencyKey, hash); if (replay) return replay;
+    const delivery = await tx.query(`SELECT id,commande_id FROM public.bon_livraison WHERE id=$1::uuid FOR UPDATE`, [params.deliveryId]);
+    if (!delivery.rows[0]) throw new HttpError(404, "DELIVERY_NOT_FOUND", "Bon de livraison introuvable.");
+    if (int(delivery.rows[0].commande_id) !== params.input.order_id) throw new HttpError(409, "DELIVERY_ORDER_MISMATCH", "Le bon de livraison n'appartient pas à cette commande.");
+    let inserted;
+    try {
+      inserted = await tx.query<Record<string, unknown>>(`INSERT INTO public.adv_delivery_blocks(delivery_id,order_id,category,detail,owner_user_id,next_action,due_date,created_by,updated_by)
+        VALUES($1::uuid,$2,$3,$4,$5,$6,$7,$8,$8) RETURNING id::text,status,created_at::text,updated_at::text`,
+        [params.deliveryId,params.input.order_id,params.input.category,params.input.detail,params.input.owner_user_id,params.input.next_action,params.input.due_date,params.actor.user_id]);
+    } catch (error) { if ((error as { code?: string }).code === "23505") throw new HttpError(409,"DELIVERY_BLOCK_ALREADY_OPEN","Un blocage de cette catégorie est déjà ouvert pour cette livraison."); throw error; }
+    const response = { block: inserted.rows[0], idempotent_replay: false };
+    await appendCaseEvent(tx,{caseType:"DELIVERY_BLOCK",caseId:String(inserted.rows[0]?.id),eventType:"OPENED",actorId:params.actor.user_id,snapshot:{delivery_id:params.deliveryId,...params.input}});
+    await insertAudit(tx,params.actor,{action:"adv.delivery_block.opened",entity_type:"bon_livraison",entity_id:params.deliveryId,details:{block_id:inserted.rows[0]?.id,category:params.input.category,order_id:params.input.order_id}});
+    await saveReceipt(tx,"DELIVERY_BLOCK_CREATE",params.idempotencyKey,hash,params.actor.user_id,response); return response;
+  });
+}
+
+export async function repoResolveDeliveryBlock(params: { id: string; input: ResolveCaseBodyDTO; actor: AdvActor; idempotencyKey: string }) {
+  return inTransaction(async (tx) => {
+    await ensureInstalled(tx); const hash=advPayloadHash({id:params.id,...params.input}); const replay=await readReceipt<Record<string, unknown>>(tx,"DELIVERY_BLOCK_RESOLVE",params.idempotencyKey,hash); if(replay)return replay;
+    const current=await tx.query<Record<string, unknown>>(`SELECT *,updated_at::text AS updated_at_text FROM public.adv_delivery_blocks WHERE id=$1::uuid FOR UPDATE`,[params.id]); const row=current.rows[0];
+    if(!row)throw new HttpError(404,"DELIVERY_BLOCK_NOT_FOUND","Blocage de livraison introuvable.");
+    if(String(row.status)!=="OPEN")throw new HttpError(409,"DELIVERY_BLOCK_ALREADY_CLOSED","Ce blocage est déjà résolu.");
+    if(String(row.updated_at_text)!==params.input.expected_updated_at)throw new HttpError(409,"CONCURRENT_MODIFICATION","Le blocage a changé. Rechargez la file.");
+    const updated=await tx.query<Record<string, unknown>>(`UPDATE public.adv_delivery_blocks SET status='RESOLVED',resolution_note=$2,resolved_at=now(),resolved_by=$3,updated_at=now(),updated_by=$3,version=version+1 WHERE id=$1::uuid RETURNING id::text,status,updated_at::text`,[params.id,params.input.resolution_note,params.actor.user_id]);
+    const response={block:updated.rows[0],idempotent_replay:false}; await appendCaseEvent(tx,{caseType:"DELIVERY_BLOCK",caseId:params.id,eventType:"RESOLVED",actorId:params.actor.user_id,snapshot:{resolution_note:params.input.resolution_note}});
+    await insertAudit(tx,params.actor,{action:"adv.delivery_block.resolved",entity_type:"bon_livraison",entity_id:String(row.delivery_id),details:{block_id:params.id}}); await saveReceipt(tx,"DELIVERY_BLOCK_RESOLVE",params.idempotencyKey,hash,params.actor.user_id,response);return response;
+  });
+}
+
+export async function repoCreatePaymentPromise(params: { invoiceId: number; input: PaymentPromiseBodyDTO; actor: AdvActor; idempotencyKey: string }) {
+  return inTransaction(async(tx)=>{await ensureInstalled(tx);const hash=advPayloadHash({invoice_id:params.invoiceId,...params.input});const replay=await readReceipt<Record<string,unknown>>(tx,"PAYMENT_PROMISE_CREATE",params.idempotencyKey,hash);if(replay)return replay;
+    const invoice=await invoiceIdentity(tx,params.invoiceId);if(String(invoice.currency)!==params.input.currency)throw new HttpError(409,"PROMISE_CURRENCY_MISMATCH","La devise de la promesse doit être celle de la facture.");
+    if(moneyToCents(params.input.amount_ttc)>moneyToCents(String(invoice.balance_ttc)))throw new HttpError(422,"PROMISE_EXCEEDS_BALANCE","La promesse dépasse le solde restant de la facture.");
+    const inserted=await tx.query<Record<string,unknown>>(`INSERT INTO public.adv_payment_promises(facture_id,client_id,amount_ttc,currency,promised_date,owner_user_id,next_action,due_date,note,created_by,updated_by)
+      VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$10) RETURNING id::text,status,created_at::text,updated_at::text`,[params.invoiceId,invoice.client_id,params.input.amount_ttc,params.input.currency,params.input.promised_date,params.input.owner_user_id,params.input.next_action,params.input.due_date,params.input.note??null,params.actor.user_id]);
+    const response={promise:inserted.rows[0],idempotent_replay:false};await appendCaseEvent(tx,{caseType:"PAYMENT_PROMISE",caseId:String(inserted.rows[0]?.id),eventType:"OPENED",actorId:params.actor.user_id,snapshot:{invoice_id:params.invoiceId,...params.input}});await insertAudit(tx,params.actor,{action:"adv.payment_promise.recorded",entity_type:"facture",entity_id:String(params.invoiceId),details:{promise_id:inserted.rows[0]?.id,amount_ttc:params.input.amount_ttc,promised_date:params.input.promised_date}});await saveReceipt(tx,"PAYMENT_PROMISE_CREATE",params.idempotencyKey,hash,params.actor.user_id,response);return response;});
+}
+
+export async function repoUpdatePaymentPromise(params:{id:string;input:PaymentPromiseStatusBodyDTO;actor:AdvActor;idempotencyKey:string}){return inTransaction(async(tx)=>{await ensureInstalled(tx);const hash=advPayloadHash({id:params.id,...params.input});const replay=await readReceipt<Record<string,unknown>>(tx,"PAYMENT_PROMISE_STATUS",params.idempotencyKey,hash);if(replay)return replay;const current=await tx.query<Record<string,unknown>>(`SELECT *,updated_at::text AS updated_at_text FROM public.adv_payment_promises WHERE id=$1::uuid FOR UPDATE`,[params.id]);const row=current.rows[0];if(!row)throw new HttpError(404,"PAYMENT_PROMISE_NOT_FOUND","Promesse introuvable.");if(String(row.status)!=="OPEN")throw new HttpError(409,"PAYMENT_PROMISE_CLOSED","La promesse est déjà clôturée.");if(String(row.updated_at_text)!==params.input.expected_updated_at)throw new HttpError(409,"CONCURRENT_MODIFICATION","La promesse a changé. Rechargez la file.");const updated=await tx.query<Record<string,unknown>>(`UPDATE public.adv_payment_promises SET status=$2,resolution_note=$3,resolved_at=now(),resolved_by=$4,updated_at=now(),updated_by=$4,version=version+1 WHERE id=$1::uuid RETURNING id::text,status,updated_at::text`,[params.id,params.input.status,params.input.resolution_note,params.actor.user_id]);const response={promise:updated.rows[0],idempotent_replay:false};await appendCaseEvent(tx,{caseType:"PAYMENT_PROMISE",caseId:params.id,eventType:params.input.status,actorId:params.actor.user_id,snapshot:{resolution_note:params.input.resolution_note}});await insertAudit(tx,params.actor,{action:"adv.payment_promise.status_changed",entity_type:"facture",entity_id:String(row.facture_id),details:{promise_id:params.id,status:params.input.status}});await saveReceipt(tx,"PAYMENT_PROMISE_STATUS",params.idempotencyKey,hash,params.actor.user_id,response);return response;});}
+
+export async function repoCreateInvoiceDispute(params:{invoiceId:number;input:InvoiceDisputeBodyDTO;actor:AdvActor;idempotencyKey:string}){return inTransaction(async(tx)=>{await ensureInstalled(tx);const hash=advPayloadHash({invoice_id:params.invoiceId,...params.input});const replay=await readReceipt<Record<string,unknown>>(tx,"INVOICE_DISPUTE_CREATE",params.idempotencyKey,hash);if(replay)return replay;const invoice=await invoiceIdentity(tx,params.invoiceId);if(params.input.disputed_amount_ttc&&moneyToCents(params.input.disputed_amount_ttc)>moneyToCents(String(invoice.balance_ttc)))throw new HttpError(422,"DISPUTE_EXCEEDS_BALANCE","Le montant litigieux dépasse le solde restant.");const inserted=await tx.query<Record<string,unknown>>(`INSERT INTO public.adv_invoice_disputes(facture_id,category,disputed_amount_ttc,owner_user_id,next_action,due_date,detail,created_by,updated_by) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$8) RETURNING id::text,status,created_at::text,updated_at::text`,[params.invoiceId,params.input.category,params.input.disputed_amount_ttc??null,params.input.owner_user_id,params.input.next_action,params.input.due_date,params.input.detail,params.actor.user_id]);const response={dispute:inserted.rows[0],idempotent_replay:false};await appendCaseEvent(tx,{caseType:"INVOICE_DISPUTE",caseId:String(inserted.rows[0]?.id),eventType:"OPENED",actorId:params.actor.user_id,snapshot:{invoice_id:params.invoiceId,...params.input}});await insertAudit(tx,params.actor,{action:"adv.invoice_dispute.opened",entity_type:"facture",entity_id:String(params.invoiceId),details:{dispute_id:inserted.rows[0]?.id,category:params.input.category,disputed_amount_ttc:params.input.disputed_amount_ttc??null}});await saveReceipt(tx,"INVOICE_DISPUTE_CREATE",params.idempotencyKey,hash,params.actor.user_id,response);return response;});}
+
+export async function repoUpdateInvoiceDispute(params:{id:string;input:InvoiceDisputeStatusBodyDTO;actor:AdvActor;idempotencyKey:string}){return inTransaction(async(tx)=>{await ensureInstalled(tx);const hash=advPayloadHash({id:params.id,...params.input});const replay=await readReceipt<Record<string,unknown>>(tx,"INVOICE_DISPUTE_STATUS",params.idempotencyKey,hash);if(replay)return replay;const current=await tx.query<Record<string,unknown>>(`SELECT *,updated_at::text AS updated_at_text FROM public.adv_invoice_disputes WHERE id=$1::uuid FOR UPDATE`,[params.id]);const row=current.rows[0];if(!row)throw new HttpError(404,"INVOICE_DISPUTE_NOT_FOUND","Litige introuvable.");if(String(row.status)!=="OPEN")throw new HttpError(409,"INVOICE_DISPUTE_CLOSED","Le litige est déjà clôturé.");if(String(row.updated_at_text)!==params.input.expected_updated_at)throw new HttpError(409,"CONCURRENT_MODIFICATION","Le litige a changé. Rechargez la file.");const updated=await tx.query<Record<string,unknown>>(`UPDATE public.adv_invoice_disputes SET status=$2,resolution_note=$3,resolved_at=now(),resolved_by=$4,updated_at=now(),updated_by=$4,version=version+1 WHERE id=$1::uuid RETURNING id::text,status,updated_at::text`,[params.id,params.input.status,params.input.resolution_note,params.actor.user_id]);const response={dispute:updated.rows[0],idempotent_replay:false};await appendCaseEvent(tx,{caseType:"INVOICE_DISPUTE",caseId:params.id,eventType:params.input.status,actorId:params.actor.user_id,snapshot:{resolution_note:params.input.resolution_note}});await insertAudit(tx,params.actor,{action:"adv.invoice_dispute.status_changed",entity_type:"facture",entity_id:String(row.facture_id),details:{dispute_id:params.id,status:params.input.status}});await saveReceipt(tx,"INVOICE_DISPUTE_STATUS",params.idempotencyKey,hash,params.actor.user_id,response);return response;});}

--- a/src/module/adv-reliability/routes/adv-reliability.routes.ts
+++ b/src/module/adv-reliability/routes/adv-reliability.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+
+import { requireFinanceCapability } from "../../facturation/middlewares/finance-authorization.middleware";
+import {
+  advOrderChain,
+  advOverview,
+  createDeliveryBlock,
+  createInvoiceDispute,
+  createPaymentPromise,
+  resolveDeliveryBlock,
+  updateInvoiceDispute,
+  updatePaymentPromise,
+} from "../controllers/adv-reliability.controller";
+
+const router = Router();
+
+router.get("/overview", requireFinanceCapability("reporting_financial"), advOverview);
+router.get("/orders/:id/chain", requireFinanceCapability("reporting_financial"), advOrderChain);
+router.post("/deliveries/:id/blocks", requireFinanceCapability("draft_write"), createDeliveryBlock);
+router.post("/delivery-blocks/:id/resolve", requireFinanceCapability("draft_write"), resolveDeliveryBlock);
+router.post("/invoices/:id/payment-promises", requireFinanceCapability("payment_register"), createPaymentPromise);
+router.post("/payment-promises/:id/status", requireFinanceCapability("payment_register"), updatePaymentPromise);
+router.post("/invoices/:id/disputes", requireFinanceCapability("credit_write"), createInvoiceDispute);
+router.post("/invoice-disputes/:id/status", requireFinanceCapability("credit_write"), updateInvoiceDispute);
+
+export default router;

--- a/src/module/adv-reliability/validators/adv-reliability.validators.ts
+++ b/src/module/adv-reliability/validators/adv-reliability.validators.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+
+import {
+  DELIVERY_BLOCK_CATEGORIES,
+  INVOICE_DISPUTE_CATEGORIES,
+  INVOICE_DISPUTE_STATUSES,
+  PAYMENT_PROMISE_STATUSES,
+} from "../domain/adv-reliability";
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format YYYY-MM-DD");
+const isoDateTime = z.string().datetime({ offset: true });
+const uuid = z.string().uuid();
+const positiveMoney = z.string().regex(/^(?:0|[1-9]\d*)\.\d{2}$/, "Montant positif avec deux décimales attendu")
+  .refine((value) => value !== "0.00", "Le montant doit être strictement positif.");
+
+export const advOverviewQuerySchema = z.object({
+  from: isoDate,
+  to: isoDate,
+  as_of: isoDate.optional(),
+  client_id: z.string().trim().min(1).max(40).optional(),
+  currency: z.string().trim().length(3).transform((value) => value.toUpperCase()).optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+}).superRefine((value, ctx) => {
+  if (value.from > value.to) ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["to"], message: "La fin doit suivre le début." });
+  const days = Math.floor((Date.parse(`${value.to}T00:00:00Z`) - Date.parse(`${value.from}T00:00:00Z`)) / 86_400_000);
+  if (days > 731) ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["to"], message: "La période est limitée à 24 mois." });
+});
+
+export const orderParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+export const deliveryParamsSchema = z.object({ id: uuid });
+export const invoiceParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+export const caseParamsSchema = z.object({ id: uuid });
+
+export const deliveryBlockBodySchema = z.object({
+  order_id: z.number().int().positive(),
+  category: z.enum(DELIVERY_BLOCK_CATEGORIES),
+  detail: z.string().trim().min(3).max(1000),
+  owner_user_id: z.number().int().positive().nullable(),
+  next_action: z.string().trim().min(3).max(500),
+  due_date: isoDate,
+});
+
+export const resolveCaseBodySchema = z.object({
+  resolution_note: z.string().trim().min(3).max(1000),
+  expected_updated_at: isoDateTime,
+});
+
+export const paymentPromiseBodySchema = z.object({
+  amount_ttc: positiveMoney,
+  currency: z.string().trim().length(3).transform((value) => value.toUpperCase()),
+  promised_date: isoDate,
+  owner_user_id: z.number().int().positive().nullable(),
+  next_action: z.string().trim().min(3).max(500),
+  due_date: isoDate,
+  note: z.string().trim().min(3).max(1000).nullable().optional(),
+});
+
+export const paymentPromiseStatusBodySchema = z.object({
+  status: z.enum(PAYMENT_PROMISE_STATUSES).exclude(["OPEN"]),
+  resolution_note: z.string().trim().min(3).max(1000),
+  expected_updated_at: isoDateTime,
+});
+
+export const invoiceDisputeBodySchema = z.object({
+  category: z.enum(INVOICE_DISPUTE_CATEGORIES),
+  disputed_amount_ttc: positiveMoney.nullable().optional(),
+  owner_user_id: z.number().int().positive().nullable(),
+  next_action: z.string().trim().min(3).max(500),
+  due_date: isoDate,
+  detail: z.string().trim().min(3).max(1000),
+});
+
+export const invoiceDisputeStatusBodySchema = z.object({
+  status: z.enum(INVOICE_DISPUTE_STATUSES).exclude(["OPEN"]),
+  resolution_note: z.string().trim().min(3).max(1000),
+  expected_updated_at: isoDateTime,
+});
+
+export type AdvOverviewQueryDTO = z.infer<typeof advOverviewQuerySchema>;
+export type DeliveryBlockBodyDTO = z.infer<typeof deliveryBlockBodySchema>;
+export type ResolveCaseBodyDTO = z.infer<typeof resolveCaseBodySchema>;
+export type PaymentPromiseBodyDTO = z.infer<typeof paymentPromiseBodySchema>;
+export type PaymentPromiseStatusBodyDTO = z.infer<typeof paymentPromiseStatusBodySchema>;
+export type InvoiceDisputeBodyDTO = z.infer<typeof invoiceDisputeBodySchema>;
+export type InvoiceDisputeStatusBodyDTO = z.infer<typeof invoiceDisputeStatusBodySchema>;

--- a/src/module/facturation/routes/reporting.routes.ts
+++ b/src/module/facturation/routes/reporting.routes.ts
@@ -15,6 +15,7 @@ import {
 } from "../controllers/reporting-v2.controller";
 import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
 import commercialReliabilityRoutes from "../../commercial-reliability/routes/commercial-reliability.routes";
+import advReliabilityRoutes from "../../adv-reliability/routes/adv-reliability.routes";
 
 const router = Router();
 
@@ -22,6 +23,7 @@ const router = Router();
 // Montée sous /reporting pour réutiliser la frontière module existante, avec RBAC
 // d'action supplémentaire sur chaque mutation.
 router.use("/commercial/reliability", commercialReliabilityRoutes);
+router.use("/commercial/adv", advReliabilityRoutes);
 
 // --- Surface historique (#227), conservée pour ses consommateurs ---------------
 // Contrat inchangé ; les agrégats sous-jacents ont été corrigés par #275.


### PR DESCRIPTION
Promotion contrôlée de SOL-23 depuis dev après suites globales, migration restaurée et E2E isolé. Le patch SQL additif sera appliqué avec sauvegarde et vérification après fusion.

## Summary by Sourcery

Introduce a backend ADV reliability cockpit that links orders, deliveries, invoices, payments and margin, backed by an additive SOL-23 migration with guarded rollout and rollback.

New Features:
- Expose a new ADV reliability API under the reporting module to surface delivery queue, OTIF, cash forecast, DSO and electronic invoicing readiness.
- Add ADV case management capabilities for delivery blocks, payment promises and invoice disputes with idempotent commands, audit trails and RBAC-based access control.
- Freeze OTIF assessments per order and provide drill-down from sales orders to deliveries, invoices, payments, credit notes and margin snapshots.

Bug Fixes:
- Correct a delivery queue SQL parameter ordering issue that previously caused PostgreSQL typing errors in end-to-end tests.

Enhancements:
- Add an additive SOL-23 database patch defining ADV tables, OTIF evidence, idempotency receipts and safety triggers without altering existing ledgers.
- Integrate the ADV cockpit routes into the existing facturation/reporting router and enforce finance capabilities on read and write operations.
- Document the ADV boundary, OTIF and cash computation model, API contract and execution report via new ADR and HTTP documentation.

Documentation:
- Add ADR-0069 and SOL-23 execution report detailing the ADV boundary, OTIF evidence model, cash forecasting rules and operational risks.
- Document the new ADV reliability HTTP endpoints, idempotency requirements and limitations around electronic invoicing connectors.

Tests:
- Add domain tests around ADV classification, DSO and cash forecast calculations and e-invoicing readiness assessment.
- Add HTTP/RBAC tests for the ADV routes and migration guard tests for the SOL-23 patch, including preflight, verify and rollback scripts.