### PR TITLE
Release SOL-23 : sécuriser l’application SQL

### DIFF
--- a/docs/execution-reports/SOL-23.md
+++ b/docs/execution-reports/SOL-23.md
@@ -21,6 +21,13 @@ file de livraison transmettait des paramètres inutilisés avant les paramètres
 référencés. PostgreSQL ne pouvait pas typer `$1`. La numérotation a été corrigée
 à la source ; aucun timeout, mock ou fallback n'a été ajouté.
 
+Le preflight opérateur réel a ensuite démontré un second défaut avant écriture :
+le patch était couvert par la répétition SOL-06 mais absent du registre immuable
+`--only` du runner d'exploitation. Son SHA-256 LF canonique
+`f14a8d356312133841168e681f4266142ff95f7e4a07dc6c2a18dd50b9a4f52e`
+est désormais enregistré et testé. Le runner avait bien refusé les deux bases
+avant toute mutation.
+
 ## Choix d'architecture
 
 - le ledger Finance existant reste l'autorité pour factures partielles, avoirs,

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -49,6 +49,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "2657f0f1eeca1a708a32ec41ae4c2a9eb2755df074d0a7984ccebcfce6b2dde5",
   "20260814_sol22_quality_intelligence.sql":
     "adf2b97867ef23f9c40ecd5df7c271cd40cc4d4d67c04cc60e7444f2cf367264",
+  "20260814_adv_reliability_sol23.sql":
+    "f14a8d356312133841168e681f4266142ff95f7e4a07dc6c2a18dd50b9a4f52e",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -80,6 +80,10 @@ const recentSolPatchChecksums = new Map([
     "20260814_sol22_quality_intelligence.sql",
     "adf2b97867ef23f9c40ecd5df7c271cd40cc4d4d67c04cc60e7444f2cf367264",
   ],
+  [
+    "20260814_adv_reliability_sol23.sql",
+    "f14a8d356312133841168e681f4266142ff95f7e4a07dc6c2a18dd50b9a4f52e",
+  ],
 ]);
 const wave9PatchChecksums = new Map([
   [


### PR DESCRIPTION
Promotion du correctif du registre immuable détecté par le preflight réel. Aucune base n’a été écrite avant cette correction.

## Summary by Sourcery

Record the SOL-23 immutable patch checksum and document its validation in the execution report.

Documentation:
- Update the SOL-23 execution report to describe the immutable registry issue detected by the real preflight run and its resolution.

Tests:
- Extend database patch runner tests to cover the SOL-23 patch checksum.

Chores:
- Register the SOL-23 SQL patch in the immutable-only patch registry used by the deployment runner.