### PR TITLE
release: promouvoir SOL-24 Project Office et RH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,12 @@ RUN sed -i 's/\r$//' \
 COPY package*.json ./
 RUN npm ci --omit=dev
 
+# Ship the exact migration inventory and runner with the release image. This
+# keeps operator-driven preflight/apply/status commands pinned to SOURCE_COMMIT
+# instead of relying on an unrelated host checkout.
+COPY scripts/db-patches.js ./scripts/db-patches.js
+COPY db/patches ./db/patches
+
 # ...
 COPY --from=builder /app/dist ./dist
 RUN mkdir -p \

--- a/db/patches/20260814_project_operations_sol24.sql
+++ b/db/patches/20260814_project_operations_sol24.sql
@@ -1,0 +1,145 @@
+-- SOL-24 — Affaires, Project Office, temps et déplacements.
+-- Migration additive et rejouable. Aucune donnée métier n'est fabriquée.
+-- Preflight : support/20260814_project_operations_sol24.preflight.sql
+-- Vérification : support/20260814_project_operations_sol24.verify.sql
+-- Rollback test uniquement : support/20260814_project_operations_sol24.rollback.sql
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.project_budget_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id uuid NOT NULL REFERENCES public.project_projects(id) ON DELETE CASCADE,
+  amount numeric(18,6) NOT NULL,
+  currency char(3) NOT NULL DEFAULT 'EUR',
+  effective_from date NOT NULL,
+  effective_to date NULL,
+  definition text NOT NULL,
+  source_type text NOT NULL,
+  source_ref text NULL,
+  observed_at timestamptz NOT NULL,
+  reliability text NOT NULL,
+  supersedes_id uuid NULL REFERENCES public.project_budget_versions(id) ON DELETE RESTRICT,
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT project_budget_versions_amount_0462_ck CHECK (amount >= 0),
+  CONSTRAINT project_budget_versions_currency_0462_ck CHECK (currency ~ '^[A-Z]{3}$'),
+  CONSTRAINT project_budget_versions_period_0462_ck CHECK (effective_to IS NULL OR effective_to >= effective_from),
+  CONSTRAINT project_budget_versions_definition_0462_ck CHECK (char_length(btrim(definition)) >= 5),
+  CONSTRAINT project_budget_versions_source_0462_ck CHECK (source_type IN ('DECLARATION','CONTRACT','DOCUMENT','OTHER')),
+  CONSTRAINT project_budget_versions_reliability_0462_ck CHECK (reliability IN ('DECLARED','VERIFIED','ESTIMATED'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS project_budget_versions_current_0462_uq
+  ON public.project_budget_versions(project_id) WHERE effective_to IS NULL;
+CREATE INDEX IF NOT EXISTS project_budget_versions_project_period_0462_idx
+  ON public.project_budget_versions(project_id, effective_from DESC, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.project_affaire_links (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id uuid NOT NULL REFERENCES public.project_projects(id) ON DELETE CASCADE,
+  affaire_id bigint NOT NULL REFERENCES public.affaire(id) ON DELETE RESTRICT,
+  source_ref text NULL,
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT project_affaire_links_project_affaire_0462_uq UNIQUE (project_id, affaire_id)
+);
+CREATE INDEX IF NOT EXISTS project_affaire_links_affaire_0462_idx
+  ON public.project_affaire_links(affaire_id);
+
+CREATE TABLE IF NOT EXISTS public.hr_absence_records (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  absence_date date NOT NULL,
+  minutes integer NOT NULL,
+  absence_type text NOT NULL,
+  timezone text NOT NULL DEFAULT 'Europe/Paris',
+  status text NOT NULL DEFAULT 'REQUESTED',
+  reason text NOT NULL,
+  source_ref text NULL,
+  requested_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  decided_by integer NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  decided_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_absence_records_minutes_0462_ck CHECK (minutes > 0 AND minutes <= 1440),
+  CONSTRAINT hr_absence_records_type_0462_ck CHECK (absence_type IN ('PAID_LEAVE','SICK_LEAVE','RTT','TRAINING','OTHER')),
+  CONSTRAINT hr_absence_records_status_0462_ck CHECK (status IN ('REQUESTED','APPROVED','REJECTED','CANCELLED')),
+  CONSTRAINT hr_absence_records_reason_0462_ck CHECK (char_length(btrim(reason)) >= 3),
+  CONSTRAINT hr_absence_records_decision_0462_ck CHECK (
+    (status = 'REQUESTED' AND decided_by IS NULL AND decided_at IS NULL)
+    OR (status IN ('APPROVED','REJECTED') AND decided_by IS NOT NULL AND decided_at IS NOT NULL)
+    OR status = 'CANCELLED'
+  )
+);
+CREATE INDEX IF NOT EXISTS hr_absence_records_employee_date_0462_idx
+  ON public.hr_absence_records(employee_id, absence_date DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS hr_absence_records_active_0462_uq
+  ON public.hr_absence_records(employee_id, absence_date, absence_type)
+  WHERE status IN ('REQUESTED','APPROVED');
+
+CREATE TABLE IF NOT EXISTS public.hr_period_closures (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  period_start date NOT NULL,
+  period_end date NOT NULL,
+  employee_id uuid NULL REFERENCES public.hr_employees(id) ON DELETE RESTRICT,
+  timezone text NOT NULL DEFAULT 'Europe/Paris',
+  status text NOT NULL DEFAULT 'CLOSED',
+  reason text NOT NULL,
+  closed_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  closed_at timestamptz NOT NULL DEFAULT now(),
+  reopened_by integer NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  reopened_at timestamptz NULL,
+  CONSTRAINT hr_period_closures_period_0462_ck CHECK (period_end >= period_start),
+  CONSTRAINT hr_period_closures_status_0462_ck CHECK (status IN ('CLOSED','REOPENED')),
+  CONSTRAINT hr_period_closures_reason_0462_ck CHECK (char_length(btrim(reason)) >= 5),
+  CONSTRAINT hr_period_closures_reopen_0462_ck CHECK (
+    (status = 'CLOSED' AND reopened_by IS NULL AND reopened_at IS NULL)
+    OR (status = 'REOPENED' AND reopened_by IS NOT NULL AND reopened_at IS NOT NULL)
+  )
+);
+CREATE INDEX IF NOT EXISTS hr_period_closures_active_0462_idx
+  ON public.hr_period_closures(period_start, period_end, employee_id) WHERE status = 'CLOSED';
+
+CREATE TABLE IF NOT EXISTS public.hr_kilometer_rate_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_type public.hr_vehicle_owner NOT NULL,
+  rate_per_km numeric(12,6) NOT NULL,
+  currency char(3) NOT NULL DEFAULT 'EUR',
+  effective_from date NOT NULL,
+  effective_to date NULL,
+  definition text NOT NULL,
+  source_type text NOT NULL,
+  source_ref text NULL,
+  observed_at timestamptz NOT NULL,
+  reliability text NOT NULL,
+  supersedes_id uuid NULL REFERENCES public.hr_kilometer_rate_versions(id) ON DELETE RESTRICT,
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_kilometer_rate_versions_rate_0462_ck CHECK (rate_per_km >= 0),
+  CONSTRAINT hr_kilometer_rate_versions_currency_0462_ck CHECK (currency ~ '^[A-Z]{3}$'),
+  CONSTRAINT hr_kilometer_rate_versions_period_0462_ck CHECK (effective_to IS NULL OR effective_to >= effective_from),
+  CONSTRAINT hr_kilometer_rate_versions_definition_0462_ck CHECK (char_length(btrim(definition)) >= 5),
+  CONSTRAINT hr_kilometer_rate_versions_source_0462_ck CHECK (source_type IN ('DECLARATION','LEGAL_SCALE','CONTRACT','OTHER')),
+  CONSTRAINT hr_kilometer_rate_versions_reliability_0462_ck CHECK (reliability IN ('DECLARED','VERIFIED','ESTIMATED'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hr_kilometer_rate_versions_current_0462_uq
+  ON public.hr_kilometer_rate_versions(owner_type) WHERE effective_to IS NULL;
+CREATE INDEX IF NOT EXISTS hr_kilometer_rate_versions_period_0462_idx
+  ON public.hr_kilometer_rate_versions(owner_type, effective_from DESC);
+
+ALTER TABLE public.hr_kilometer_entries
+  ADD COLUMN IF NOT EXISTS rate_version_id uuid NULL REFERENCES public.hr_kilometer_rate_versions(id) ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS cost_amount numeric(18,6) NULL,
+  ADD COLUMN IF NOT EXISTS cost_currency char(3) NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'hr_kilometer_entries_cost_0462_ck') THEN
+    ALTER TABLE public.hr_kilometer_entries
+      ADD CONSTRAINT hr_kilometer_entries_cost_0462_ck CHECK (
+        (cost_amount IS NULL AND cost_currency IS NULL AND rate_version_id IS NULL)
+        OR (cost_amount IS NOT NULL AND cost_amount >= 0 AND cost_currency ~ '^[A-Z]{3}$' AND rate_version_id IS NOT NULL)
+      );
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260814_project_operations_sol24.preflight.sql
+++ b/db/patches/support/20260814_project_operations_sol24.preflight.sql
@@ -1,0 +1,36 @@
+\set ON_ERROR_STOP on
+
+DO $$
+DECLARE
+  missing text[] := ARRAY[]::text[];
+BEGIN
+  IF current_setting('server_version_num')::int < 140000 THEN
+    RAISE EXCEPTION 'PostgreSQL 14+ requis';
+  END IF;
+  IF to_regclass('public.project_projects') IS NULL THEN missing := array_append(missing, 'project_projects'); END IF;
+  IF to_regclass('public.project_work_packages') IS NULL THEN missing := array_append(missing, 'project_work_packages'); END IF;
+  IF to_regclass('public.project_milestones') IS NULL THEN missing := array_append(missing, 'project_milestones'); END IF;
+  IF to_regclass('public.project_risks') IS NULL THEN missing := array_append(missing, 'project_risks'); END IF;
+  IF to_regclass('public.affaire') IS NULL THEN missing := array_append(missing, 'affaire'); END IF;
+  IF to_regclass('public.hr_employees') IS NULL THEN missing := array_append(missing, 'hr_employees'); END IF;
+  IF to_regclass('public.hr_kilometer_entries') IS NULL THEN missing := array_append(missing, 'hr_kilometer_entries'); END IF;
+  IF array_length(missing, 1) IS NOT NULL THEN
+    RAISE EXCEPTION 'Prerequis SOL-24 manquants: %', array_to_string(missing, ', ');
+  END IF;
+END $$;
+
+SELECT current_database() AS database_name,
+       current_setting('server_version') AS postgres_version,
+       pg_size_pretty(pg_database_size(current_database())) AS database_size,
+       (SELECT COUNT(*) FROM public.project_projects) AS projects,
+       (SELECT COUNT(*) FROM public.affaire) AS affaires,
+       (SELECT COUNT(*) FROM public.hr_employees) AS employees,
+       (SELECT COUNT(*) FROM public.hr_kilometer_entries) AS kilometer_entries;
+
+SELECT COUNT(*) AS duplicate_active_absence_candidates
+FROM (
+  SELECT employee_id, date, COUNT(*)
+  FROM public.hr_timesheet_days
+  GROUP BY employee_id, date
+  HAVING COUNT(*) > 1
+) d;

--- a/db/patches/support/20260814_project_operations_sol24.rollback.sql
+++ b/db/patches/support/20260814_project_operations_sol24.rollback.sql
@@ -1,0 +1,31 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Rollback SOL-24 autorise uniquement sur cerp_test; restaurer la sauvegarde en production';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.project_budget_versions)
+     OR EXISTS (SELECT 1 FROM public.project_affaire_links)
+     OR EXISTS (SELECT 1 FROM public.hr_absence_records)
+     OR EXISTS (SELECT 1 FROM public.hr_period_closures)
+     OR EXISTS (SELECT 1 FROM public.hr_kilometer_rate_versions) THEN
+    RAISE EXCEPTION 'Rollback refuse: donnees SOL-24 presentes';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.hr_kilometer_entries WHERE cost_amount IS NOT NULL OR rate_version_id IS NOT NULL) THEN
+    RAISE EXCEPTION 'Rollback refuse: cout kilometrique fige present';
+  END IF;
+END $$;
+
+BEGIN;
+ALTER TABLE public.hr_kilometer_entries DROP CONSTRAINT IF EXISTS hr_kilometer_entries_cost_0462_ck;
+ALTER TABLE public.hr_kilometer_entries
+  DROP COLUMN IF EXISTS cost_currency,
+  DROP COLUMN IF EXISTS cost_amount,
+  DROP COLUMN IF EXISTS rate_version_id;
+DROP TABLE IF EXISTS public.hr_kilometer_rate_versions;
+DROP TABLE IF EXISTS public.hr_period_closures;
+DROP TABLE IF EXISTS public.hr_absence_records;
+DROP TABLE IF EXISTS public.project_affaire_links;
+DROP TABLE IF EXISTS public.project_budget_versions;
+COMMIT;

--- a/db/patches/support/20260814_project_operations_sol24.verify.sql
+++ b/db/patches/support/20260814_project_operations_sol24.verify.sql
@@ -1,0 +1,46 @@
+\set ON_ERROR_STOP on
+
+DO $$
+DECLARE
+  missing text[] := ARRAY[]::text[];
+BEGIN
+  IF to_regclass('public.project_budget_versions') IS NULL THEN missing := array_append(missing, 'project_budget_versions'); END IF;
+  IF to_regclass('public.project_affaire_links') IS NULL THEN missing := array_append(missing, 'project_affaire_links'); END IF;
+  IF to_regclass('public.hr_absence_records') IS NULL THEN missing := array_append(missing, 'hr_absence_records'); END IF;
+  IF to_regclass('public.hr_period_closures') IS NULL THEN missing := array_append(missing, 'hr_period_closures'); END IF;
+  IF to_regclass('public.hr_kilometer_rate_versions') IS NULL THEN missing := array_append(missing, 'hr_kilometer_rate_versions'); END IF;
+  IF array_length(missing, 1) IS NOT NULL THEN
+    RAISE EXCEPTION 'Objets SOL-24 manquants: %', array_to_string(missing, ', ');
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'hr_kilometer_entries' AND column_name = 'rate_version_id'
+  ) THEN
+    RAISE EXCEPTION 'Colonne hr_kilometer_entries.rate_version_id absente';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='public' AND indexname='project_budget_versions_current_0462_uq') THEN
+    RAISE EXCEPTION 'Unicite budget projet courant absente';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='public' AND indexname='hr_absence_records_active_0462_uq') THEN
+    RAISE EXCEPTION 'Protection doublon absence active absente';
+  END IF;
+END $$;
+
+SELECT current_database() AS database_name,
+       (SELECT COUNT(*) FROM public.project_budget_versions) AS project_budget_versions,
+       (SELECT COUNT(*) FROM public.project_affaire_links) AS project_affaire_links,
+       (SELECT COUNT(*) FROM public.hr_absence_records) AS absence_records,
+       (SELECT COUNT(*) FROM public.hr_period_closures WHERE status='CLOSED') AS active_period_closures,
+       (SELECT COUNT(*) FROM public.hr_kilometer_rate_versions) AS kilometer_rate_versions,
+       (SELECT COUNT(*) FROM public.hr_kilometer_entries WHERE cost_amount IS NOT NULL AND rate_version_id IS NULL) AS kilometer_costs_without_rate;
+
+SELECT COUNT(*) AS orphan_project_affaire_links
+FROM public.project_affaire_links l
+LEFT JOIN public.project_projects p ON p.id=l.project_id
+LEFT JOIN public.affaire a ON a.id=l.affaire_id
+WHERE p.id IS NULL OR a.id IS NULL;
+
+SELECT COUNT(*) AS overlapping_open_budget_versions
+FROM (
+  SELECT project_id FROM public.project_budget_versions WHERE effective_to IS NULL GROUP BY project_id HAVING COUNT(*) > 1
+) d;

--- a/docs/adr/ADR-0070-project-operations-and-hr-control-boundary.md
+++ b/docs/adr/ADR-0070-project-operations-and-hr-control-boundary.md
@@ -1,0 +1,98 @@
+# ADR-0070 — Frontière de pilotage affaires, temps et déplacements
+
+- Statut : accepté
+- Date : 2026-08-14
+- Décideur : Keenan Martin
+- Périmètre : Project Office, affaires, temps RH, absences, kilomètres et clôtures
+
+## Contexte
+
+Le Project Office savait suivre projets, lots, jalons, dépendances et risques,
+mais ne disposait ni d'un budget versionné ni d'un lien explicite vers les
+affaires qui portent les coûts constatés. Le module Temps & Déplacements savait
+pointer, corriger et déclarer des kilomètres, mais l'absence explicite, la
+clôture de période, le taux kilométrique daté et la file d'exceptions n'avaient
+pas de frontière serveur cohérente.
+
+Calculer un budget restant avec un coût incomplet, assimiler une absence non
+qualifiée à zéro heure, valoriser des kilomètres avec le taux courant ou laisser
+une personne approuver sa propre saisie produirait une décision non traçable.
+
+## Décision
+
+### Project Office
+
+- Le budget est une suite de versions datées et non un champ mutable. Chaque
+  version porte montant, devise, définition, type/référence de source, date
+  d'observation, fiabilité, auteur et version remplacée.
+- Le consommé HT est la somme exacte des coûts `ACTUAL` complets du moteur de
+  marge pour les affaires explicitement liées au projet. Si une affaire est
+  partielle, `consumed_ht` et `remaining_ht` restent `null`; le sous-total
+  partiel est exposé séparément et marqué `PARTIAL`.
+- Le restant n'est calculé que lorsque budget et consommé complet sont
+  comparables en EUR. Une devise différente est `UNAVAILABLE`, jamais convertie
+  implicitement.
+- Les heures prévues/réalisées sont les sommes des lots non annulés. Les lignes
+  incomplètes dégradent la fiabilité en `PARTIAL`.
+- Le burn-up sur douze semaines est `ESTIMATED`: l'échéance donne le prévu et
+  `updated_at` la meilleure preuve disponible de terminaison. Aucun historique
+  antérieur n'est inventé.
+- Les liens affaire, budgets, risques, jalons et dépendances restent des
+  drill-downs vers leurs entités sources. Les mutations exigent un rôle projet
+  de gestion et écrivent activité projet et audit global dans la transaction.
+
+### Temps, absences et déplacements
+
+- Une absence est un enregistrement explicite demandé, approuvé, rejeté ou
+  annulé. Un déficit contractuel sans absence approuvée reste « manque non
+  justifié »; il n'est pas requalifié automatiquement.
+- Les corrections, absences, journées/semaines et kilomètres ne peuvent pas être
+  auto-approuvés. Le salarié agit sur son identité issue du jeton; un manager est
+  limité à ses collaborateurs; RH/Direction/Administration disposent du
+  périmètre global.
+- La clôture d'une période est refusée tant que journées, semaines, anomalies,
+  corrections, kilomètres ou absences restent en attente. Elle bloque ensuite
+  toute mutation couvrant la période et peut uniquement être rouverte avec audit.
+- Un taux kilométrique est versionné par type de véhicule et date d'effet. La
+  validation photographie la version, le coût et la devise applicables à la date
+  du trajet. L'absence de taux bloque la valorisation au lieu de produire zéro.
+- La file opérationnelle serveur regroupe feuilles non validées, anomalies,
+  corrections et absences en attente, doublons kilométriques et kilomètres
+  validés non valorisés.
+
+## Données décisionnelles
+
+| Donnée | Unité / période | Source | Fraîcheur | Fiabilité |
+|---|---|---|---|---|
+| Budget courant | devise, période d'effet | `project_budget_versions` | `observed_at` | valeur déclarée ou vérifiée par la version |
+| Consommé / restant | EUR HT, état courant | moteur de marge `AFFAIRE/ACTUAL` | plus ancienne source liée | `ACTUAL`, `PARTIAL` ou `UNAVAILABLE` |
+| Temps prévu / réalisé | heures, vie du projet | `project_work_packages` non annulés | dernier `updated_at` | `VERIFIED` ou `PARTIAL` |
+| Burn-up | lots, douze semaines | lots et échéances | génération de la réponse | `ESTIMATED` |
+| Coût kilométrique | devise, date du trajet | entrée km + version de taux applicable | validation | `DECLARED`/`VERIFIED` selon le taux |
+
+## Sécurité et confidentialité
+
+Les routes restent sous authentification et gardes module. Les lectures projet
+appliquent l'anti-IDOR existant. Les opérations RH n'exposent ni trajet détaillé
+à un manager hors périmètre ni donnée d'un autre salarié. Les audits stockent
+identifiants métier, décisions et métadonnées, pas de contenu documentaire ni de
+secret. Le schéma actuel n'a pas de dimension société/site exploitable pour ces
+domaines; aucune isolation fictive n'est revendiquée.
+
+## Migration et retour arrière
+
+Le patch `20260814_project_operations_sol24.sql` est additif et rejouable. Il
+ajoute budgets, liens affaire, absences, clôtures, taux et snapshots de coût
+kilométrique, avec contraintes et index. Le rollback SQL est réservé à
+`cerp_test`, exige zéro donnée SOL-24 et sert à la répétition. En production, le
+retour applicatif consiste à redéployer le SHA précédent en conservant les objets
+additifs. Si un retour de schéma est indispensable après écriture, geler les flux
+et restaurer le dump pré-migration dans une base neuve.
+
+## Conséquences
+
+Les chiffres incomplets deviennent visibles mais parfois indisponibles, ce qui
+est volontaire. Les coûts constatés restent sous l'autorité du moteur de marge;
+SOL-24 ne crée pas de second grand livre. Les clôtures et taux demandent une
+configuration RH réelle avant validation. Une future historisation explicite de
+la date de terminaison pourra faire passer le burn-up de `ESTIMATED` à `ACTUAL`.

--- a/docs/execution-reports/SOL-24.md
+++ b/docs/execution-reports/SOL-24.md
@@ -1,0 +1,131 @@
+# SOL-24 — Affaires, Project Office, temps et déplacements (backend)
+
+- Date : 2026-08-14
+- Propriétaire : Keenan Martin
+- Issue : [#462](https://github.com/BigFootLime/erp-crp-backend/issues/462)
+- Branche : `feature/462-sol24-project-operations`
+- Base initiale : `origin/main` (`ad46ce5639523f5d59c9f5216e6fb11cdae5f09f`)
+- ADR : `docs/adr/ADR-0070-project-operations-and-hr-control-boundary.md`
+
+## Diagnostic et cause racine
+
+Les projets contenaient lots, jalons, dépendances et risques, mais pas de budget
+versionné ni de provenance financière vers les affaires. Le temps RH distinguait
+les pointages de production, mais l'absence explicite, les périodes closes, les
+taux kilométriques datés et la file d'exceptions n'étaient pas représentés.
+Plusieurs validations reposaient encore sur un rôle trop large et autorisaient
+potentiellement l'auto-approbation.
+
+La première recette PostgreSQL réelle a trouvé deux défauts que les repositories
+mockés ne pouvaient pas révéler : `/projects` envoyait un paramètre sans placeholder
+en contexte administrateur (`08P01`) et la détection de doublons appelait
+`min(uuid)`, fonction absente (`42883`). Les requêtes ont été corrigées à la
+source et couvertes par des contrats de repository et l'E2E réel.
+
+## Architecture livrée
+
+- budget Project Office append-only, daté, sourcé et audité ;
+- liens projet → affaire explicites et anti-doublon ;
+- consommé issu exclusivement du moteur de marge réel ; un coût partiel n'est
+  jamais soustrait comme complet ;
+- heures, jalons en retard, dépendances bloquantes, burn-up douze semaines et
+  matrice de risques avec définition, source, fraîcheur et fiabilité ;
+- absences demandées/décidées, clôtures avec preflight, taux kilométriques datés
+  et coût photographié sur l'entrée validée ;
+- file d'action manager/RH et règles salarié/manager/admin fail-closed ;
+- interdiction d'auto-approbation pour absences, corrections, feuilles et km.
+
+Le burn-up reste `ESTIMATED` parce que le schéma ne conserve pas encore une date
+historique immuable de terminaison. L'absence de coût, taux, affaire ou heures est
+retournée comme donnée manquante, jamais comme zéro.
+
+## Fichiers modifiés
+
+- `src/module/project-office/` : contrôleur, service, repository, validation,
+  routes et correction du contrat de liste ;
+- `src/module/temps-deplacements/` : politique de domaine, opérations, absences,
+  clôtures, taux, valorisation km, corrections, types et routes ;
+- `db/patches/20260814_project_operations_sol24.sql` et trois scripts support ;
+- runner de patch, release gate SOL-06 et seed E2E isolé ;
+- tests SOL-24 et adaptations T4/T6 ;
+- ADR-0070 et présent rapport.
+
+## Migration et données
+
+Le patch est additif : cinq tables, trois colonnes de snapshot kilométrique,
+contraintes, index et triggers de cohérence. Il ne crée aucun budget, taux,
+absence, clôture ou coût métier. Le seed SOL-24 est conditionné à la présence du
+schéma et au garde `cerp_test` local du runner E2E.
+
+Répétition PostgreSQL 16 jetable du 14/08/2026 : **155 patchs appliqués, zéro en
+attente, zéro checksum divergent**. Sauvegarde, vérification, rollback test-only,
+restauration vers base neuve, empreinte source/restaurée identique et rejeu à
+zéro patch ont réussi. Le dump de répétition faisait 1 968 391 octets, SHA-256
+`a5a0f52a892441d755aae43babfbc0e433696e60172cc337bd2680c71314bf7d`.
+
+## Tests exécutés
+
+| Contrôle | Résultat réel |
+|---|---|
+| tests SOL-24 ciblés | PASS — 4 fichiers, 16/16 après correctif SQL |
+| suite backend complète | PASS — 306 fichiers, 4 621 tests ; 4 tests optionnels ignorés |
+| typecheck backend | PASS |
+| build + frontière données production | PASS — 680 fichiers runtime/émis |
+| audit dépendances production | PASS — aucune vulnérabilité connue |
+| répétition migration SOL-06 | PASS — backup, rollback, restauration, rejeu |
+| E2E Chromium isolé SOL-24 | PASS — 3/3, sans retry, 12,2 s de tests |
+
+L'E2E a réellement créé PostgreSQL, appliqué 155 migrations, chargé huit comptes
+déterministes, construit le frontend, démarré l'API, vérifié Project Office,
+l'absence, l'administration RH et le refus d'un salarié standard, puis détruit
+la pile. Les deux premiers passages ont respectivement découvert les défauts SQL
+et des locators ambigus ; aucun timeout ni assertion métier n'a été assoupli.
+
+## Navigateur
+
+Le navigateur intégré a vérifié la pile jetable sur `127.0.0.1` : budget 25 000
+EUR et source déclarée, coût/restant indisponibles sans affaire, temps 20 h/12 h,
+jalon en retard, burn-up, matrice des risques, demande d'absence, manque non
+justifié, onglets Clôtures et Taux km. Les actions incomplètes restent désactivées.
+Aucune erreur console n'a été relevée ; deux avertissements structurés de temps
+réel local ont été observés. Les processus et le conteneur ont été supprimés.
+
+## Permissions, audit et compatibilité
+
+- lecture projet : accès projet existant et anti-IDOR ; mutation : owner/manager ;
+- salarié : ses propres demandes ; manager : collaborateurs directs ;
+  RH/Direction/Administration : périmètre global explicite ;
+- décision et création écrivent audit global et, pour Project Office, activité
+  projet dans la même transaction ;
+- clôture refuse toute exception en attente et bloque ensuite les mutations ;
+- aucun nouveau package et aucun changement visuel de design ;
+- aucune dimension société/site exploitable n'existe dans ces tables, limite
+  explicitement conservée.
+
+## Rollback
+
+Avant données réelles, le script support peut supprimer les objets uniquement
+sur `cerp_test`. Après mise en service, redéployer le SHA backend antérieur en
+conservant le schéma additif. Si le schéma doit revenir, suspendre les écritures,
+restaurer le dump pré-SOL-24 dans une base neuve, démarrer l'ancien SHA et vérifier
+comptages, clés étrangères, authentification, Project Office et exports RH.
+
+## Risques et reste réel
+
+- le burn-up historique est estimé tant qu'une date de terminaison immuable
+  n'est pas enregistrée ;
+- les budgets non EUR ne sont pas convertis faute de source de change qualifiée ;
+- la séparation société/site reste à concevoir si le produit devient multi-entité ;
+- la promotion, les sauvegardes réelles, l'application aux bases et les
+  déploiements sont consignés ci-dessous après exécution.
+
+## Promotion et exploitation
+
+À compléter après promotion contrôlée vers `dev` puis `main`, sauvegardes,
+application du patch par checksum immuable et vérifications HYPERBOX2/Coolify.
+
+## Traçabilité de pilotage
+
+Le canal Project Office externe n'est pas configuré ; l'issue GitHub #462 est la
+trace canonique de cette exécution. Aucune preuve de synchronisation externe
+n'est inventée.

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-14T04:49:06.637Z",
+  "started_at": "2026-08-14T07:35:03.528Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 18356,
-    "source_seed": 193,
-    "backup": 726,
-    "preflight": 119,
-    "integrity_before": 586,
-    "migration": 457,
-    "verify": 195,
-    "replay": 119,
-    "integrity_after": 1401,
-    "negative_gate": 41,
-    "rollback": 248,
-    "restore": 3997
+    "source_migration": 20094,
+    "source_seed": 212,
+    "backup": 741,
+    "preflight": 135,
+    "integrity_before": 657,
+    "migration": 522,
+    "verify": 225,
+    "replay": 127,
+    "integrity_after": 1427,
+    "negative_gate": 43,
+    "rollback": 317,
+    "restore": 4067
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-14T04:49:28.456Z",
-    "duration_ms": 73,
+    "checked_at": "2026-08-14T07:35:27.351Z",
+    "duration_ms": 83,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36355095"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-8b8RIq\\cerp-test-before-sol06.dump",
-      "bytes": 1968404,
-      "sha256": "60bdbca8744707751f9888705711ba1f8e7a9fc832b281a7ebc0aec06c6f5909",
-      "free_bytes": 419015507968
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-jObZsE\\cerp-test-before-sol06.dump",
+      "bytes": 1968391,
+      "sha256": "a5a0f52a892441d755aae43babfbc0e433696e60172cc337bd2680c71314bf7d",
+      "free_bytes": 416530526208
     },
     "ledger": {
       "applied": 140,
@@ -54,6 +54,7 @@
         "20260813_stock_intelligence_sol19.sql",
         "20260814_adv_reliability_sol23.sql",
         "20260814_planning_execution_intelligence_0021.sql",
+        "20260814_project_operations_sol24.sql",
         "20260814_sol22_quality_intelligence.sql"
       ],
       "checksum_mismatches": [],
@@ -449,12 +450,13 @@
         "20260813_stock_intelligence_sol19.sql",
         "20260814_adv_reliability_sol23.sql",
         "20260814_planning_execution_intelligence_0021.sql",
+        "20260814_project_operations_sol24.sql",
         "20260814_sol22_quality_intelligence.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
     },
-    "fingerprint": "15817807200ec885da9cfab50277497674edd0f4b81e6c406a3e21325820771c"
+    "fingerprint": "d00101a59074e6361baa8e0aa947a9322a4b5f536dadd893c9178ce264ecb8a3"
   },
   "replay": {
     "applied_zero": true,
@@ -462,8 +464,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-14T04:49:31.217Z",
-    "duration_ms": 1386,
+    "checked_at": "2026-08-14T07:35:30.313Z",
+    "duration_ms": 1413,
     "table_counts": {
       "admin_account_invitations": "0",
       "admin_user_provisioning_migration_state": "12",
@@ -526,7 +528,7 @@
       "centres_frais": "1",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "154",
+      "cerp_schema_migrations": "155",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -635,11 +637,14 @@
       "gestion_outils_revetement": "0",
       "gestion_outils_stock": "0",
       "gestion_outils_valeur_arete_coupe": "0",
+      "hr_absence_records": "0",
       "hr_badge_credentials": "0",
       "hr_employees": "0",
       "hr_employment_contracts": "0",
       "hr_kilometer_entries": "0",
+      "hr_kilometer_rate_versions": "0",
       "hr_payroll_export_batches": "0",
+      "hr_period_closures": "0",
       "hr_time_adjustments": "0",
       "hr_time_anomalies": "0",
       "hr_time_clock_devices": "0",
@@ -758,6 +763,8 @@
       "programmation_user_skills": "0",
       "programmations": "0",
       "project_activity_log": "0",
+      "project_affaire_links": "0",
+      "project_budget_versions": "0",
       "project_comments": "0",
       "project_corrective_actions": "0",
       "project_decisions": "0",
@@ -861,7 +868,7 @@
       "users": "8",
       "warehouses": "4"
     },
-    "table_count": 395,
+    "table_count": 400,
     "unvalidated_constraints": [
       {
         "table_name": "avoir",
@@ -938,7 +945,7 @@
         "groups": 0
       }
     ],
-    "foreign_key_count": 1138,
+    "foreign_key_count": 1153,
     "orphans": [],
     "readiness": [
       {
@@ -950,7 +957,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -967,7 +974,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -985,7 +992,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1011,7 +1018,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1028,7 +1035,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1046,7 +1053,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1066,7 +1073,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1084,7 +1091,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1110,7 +1117,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1128,7 +1135,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1147,7 +1154,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1185,7 +1192,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-14T04:49:29.832Z",
+        "freshness_at": "2026-08-14T07:35:28.899Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1204,12 +1211,12 @@
       }
     ],
     "ledger": {
-      "applied": 154,
+      "applied": 155,
       "pending": [],
       "checksum_mismatches": [],
       "unknown_applied": []
     },
-    "fingerprint": "501d6bb85e60d9dd472ae428d3c1db3d27f7d9688b3cb939df3e2c1e6dec1274"
+    "fingerprint": "b04705f2bbf8ccc1ee24139b3c9fed6a46cde21b9907e81f64e3a490410c0378"
   },
   "negative_gate": {
     "status": "passed",
@@ -1244,11 +1251,12 @@
     "stock_intelligence_removed": true,
     "tooling_technical_ged_removed": true,
     "planning_execution_removed": true,
+    "project_operations_removed": true,
     "trigger_removed": true
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "15817807200ec885da9cfab50277497674edd0f4b81e6c406a3e21325820771c",
+    "fingerprint": "d00101a59074e6361baa8e0aa947a9322a4b5f536dadd893c9178ce264ecb8a3",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1266,11 +1274,12 @@
         "20260813_stock_intelligence_sol19.sql",
         "20260814_adv_reliability_sol23.sql",
         "20260814_planning_execution_intelligence_0021.sql",
+        "20260814_project_operations_sol24.sql",
         "20260814_sol22_quality_intelligence.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-14T04:49:35.668Z"
+  "completed_at": "2026-08-14T07:35:34.912Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-14T04:49:35.668Z
+- Exécutée : 2026-08-14T07:35:34.912Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36355095 octets
-- Sauvegarde : 1968404 octets, SHA-256 `60bdbca8744707751f9888705711ba1f8e7a9fc832b281a7ebc0aec06c6f5909`
-- Patches avant/après : 140 / 154
+- Sauvegarde : 1968391 octets, SHA-256 `a5a0f52a892441d755aae43babfbc0e433696e60172cc337bd2680c71314bf7d`
+- Patches avant/après : 140 / 155
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `15817807200ec885da9cfab50277497674edd0f4b81e6c406a3e21325820771c` / `15817807200ec885da9cfab50277497674edd0f4b81e6c406a3e21325820771c`
+- Empreinte source/restaurée : `d00101a59074e6361baa8e0aa947a9322a4b5f536dadd893c9178ce264ecb8a3` / `d00101a59074e6361baa8e0aa947a9322a4b5f536dadd893c9178ce264ecb8a3`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 18356 |
-| source_seed | 193 |
-| backup | 726 |
-| preflight | 119 |
-| integrity_before | 586 |
-| migration | 457 |
-| verify | 195 |
-| replay | 119 |
-| integrity_after | 1401 |
-| negative_gate | 41 |
-| rollback | 248 |
-| restore | 3997 |
+| source_migration | 20094 |
+| source_seed | 212 |
+| backup | 741 |
+| preflight | 135 |
+| integrity_before | 657 |
+| migration | 522 |
+| verify | 225 |
+| replay | 127 |
+| integrity_after | 1427 |
+| negative_gate | 43 |
+| rollback | 317 |
+| restore | 4067 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -51,6 +51,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "adf2b97867ef23f9c40ecd5df7c271cd40cc4d4d67c04cc60e7444f2cf367264",
   "20260814_adv_reliability_sol23.sql":
     "f14a8d356312133841168e681f4266142ff95f7e4a07dc6c2a18dd50b9a4f52e",
+  "20260814_project_operations_sol24.sql":
+    "e978abeb2b6758744d3824540b2552ef6b6ca90f0c634bc49dd7af403d4e8cd9",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -666,6 +666,126 @@ async function main() {
         [documentType, FINANCE_ISSUER_ID, String(FINANCE_YEAR), prefix]
       );
     }
+
+    // SOL-24 — preuves Project Office et temps/déplacements. Ces valeurs sont
+    // exclusivement injectées dans la base jetable cerp_test protégée par assertIsolated().
+    const sol24Tables = await client.query(
+      `SELECT to_regclass('public.project_budget_versions') IS NOT NULL
+          AND to_regclass('public.hr_kilometer_rate_versions') IS NOT NULL AS available`
+    );
+    if (sol24Tables.rows[0]?.available) {
+    await client.query(
+      `INSERT INTO public.project_projects (
+         id,code,name,description,owner_id,visibility,status,start_date,target_date
+       ) VALUES (
+         '41000000-0000-4000-8000-000000000024','SOL24-E2E','Projet opérations SOL-24',
+         'Fixture déterministe isolée — jamais une donnée de production',
+         (SELECT id FROM public.users WHERE username='KEENAN'),'PRIVATE','ACTIVE',$1::date,$2::date
+       ) ON CONFLICT (id) DO UPDATE SET
+         name=EXCLUDED.name,description=EXCLUDED.description,owner_id=EXCLUDED.owner_id,
+         visibility=EXCLUDED.visibility,status=EXCLUDED.status,start_date=EXCLUDED.start_date,
+         target_date=EXCLUDED.target_date,updated_at=now()`,
+      [`${FINANCE_YEAR}-01-01`, `${FINANCE_YEAR}-12-31`]
+    );
+    await client.query(
+      `INSERT INTO public.project_members (id,project_id,user_id,role)
+       VALUES (
+         '41000000-0000-4000-8000-000000000025','41000000-0000-4000-8000-000000000024',
+         (SELECT id FROM public.users WHERE username='KEENAN'),'OWNER'
+       ) ON CONFLICT (project_id,user_id) DO UPDATE SET role='OWNER'`
+    );
+    await client.query(
+      `INSERT INTO public.project_work_packages (
+         id,project_id,code,title,type,status,priority,assignee_id,reporter_id,
+         start_date,due_date,progress_percent,estimated_hours,spent_hours
+       ) VALUES
+       ('41000000-0000-4000-8000-000000000026','41000000-0000-4000-8000-000000000024',
+        'SOL24-READY','Préparer la recette','TASK','DONE','NORMAL',
+        (SELECT id FROM public.users WHERE username='KEENAN'),(SELECT id FROM public.users WHERE username='KEENAN'),
+        CURRENT_DATE-14,CURRENT_DATE-7,100,8,8),
+       ('41000000-0000-4000-8000-000000000027','41000000-0000-4000-8000-000000000024',
+        'SOL24-BLOCKED','Traiter la dépendance','TASK','BLOCKED','HIGH',
+        (SELECT id FROM public.users WHERE username='KEENAN'),(SELECT id FROM public.users WHERE username='KEENAN'),
+        CURRENT_DATE-7,CURRENT_DATE+7,30,12,4)
+       ON CONFLICT (id) DO UPDATE SET
+         title=EXCLUDED.title,status=EXCLUDED.status,priority=EXCLUDED.priority,
+         due_date=EXCLUDED.due_date,progress_percent=EXCLUDED.progress_percent,
+         estimated_hours=EXCLUDED.estimated_hours,spent_hours=EXCLUDED.spent_hours,updated_at=now()`
+    );
+    await client.query(
+      `INSERT INTO public.project_dependencies (id,source_work_package_id,target_work_package_id,dependency_type)
+       VALUES ('41000000-0000-4000-8000-000000000028',
+         '41000000-0000-4000-8000-000000000027','41000000-0000-4000-8000-000000000026','BLOCKS')
+       ON CONFLICT (source_work_package_id,target_work_package_id,dependency_type) DO NOTHING`
+    );
+    await client.query(
+      `INSERT INTO public.project_milestones (id,project_id,name,due_date,status)
+       VALUES ('41000000-0000-4000-8000-000000000029','41000000-0000-4000-8000-000000000024',
+         'Jalon de preuve en retard',CURRENT_DATE-3,'PLANNED')
+       ON CONFLICT (id) DO UPDATE SET due_date=EXCLUDED.due_date,status='PLANNED',updated_at=now()`
+    );
+    await client.query(
+      `INSERT INTO public.project_risks (id,project_id,title,description,probability,impact,mitigation,owner_id,status)
+       VALUES ('41000000-0000-4000-8000-000000000030','41000000-0000-4000-8000-000000000024',
+         'Dépendance externe de preuve','Risque isolé SOL-24',3,4,'Action E2E documentée',
+         (SELECT id FROM public.users WHERE username='KEENAN'),'OPEN')
+       ON CONFLICT (id) DO UPDATE SET probability=3,impact=4,status='OPEN',updated_at=now()`
+    );
+    await client.query(
+      `INSERT INTO public.project_budget_versions (
+         id,project_id,amount,currency,effective_from,definition,source_type,source_ref,
+         observed_at,reliability,created_by
+       ) SELECT
+         '41000000-0000-4000-8000-000000000031','41000000-0000-4000-8000-000000000024',
+         25000,'EUR',$1::date,'Budget de preuve exclusivement isolé','DECLARATION','SOL24-E2E-SEED',
+         $1::date,'DECLARED',(SELECT id FROM public.users WHERE username='KEENAN')
+       WHERE NOT EXISTS (
+         SELECT 1 FROM public.project_budget_versions
+         WHERE project_id='41000000-0000-4000-8000-000000000024' AND effective_to IS NULL
+       )`,
+      [REFERENCE_PERIOD_START]
+    );
+
+    await client.query(
+      `INSERT INTO public.hr_employees (id,user_id,matricule,service,manager_user_id,status)
+       VALUES
+       ('42000000-0000-4000-8000-000000000024',(SELECT id FROM public.users WHERE username='KEENAN'),
+        'E2E-ADMIN','Direction',NULL,'ACTIVE'),
+       ('42000000-0000-4000-8000-000000000025',(SELECT id FROM public.users WHERE username='E2E_STANDARD'),
+        'E2E-EMPLOYEE','Atelier',(SELECT id FROM public.users WHERE username='KEENAN'),'ACTIVE')
+       ON CONFLICT (id) DO UPDATE SET
+         user_id=EXCLUDED.user_id,matricule=EXCLUDED.matricule,service=EXCLUDED.service,
+         manager_user_id=EXCLUDED.manager_user_id,status='ACTIVE',updated_at=now()`
+    );
+    await client.query(
+      `INSERT INTO public.hr_employment_contracts (
+         id,employee_id,contract_type,weekly_hours_target,daily_hours_target,start_date,active
+       ) VALUES (
+         '42000000-0000-4000-8000-000000000026','42000000-0000-4000-8000-000000000024',
+         'H35',35,7,$1::date,true
+       ) ON CONFLICT (id) DO UPDATE SET
+         weekly_hours_target=35,daily_hours_target=7,start_date=EXCLUDED.start_date,end_date=NULL,active=true`,
+      [REFERENCE_PERIOD_START]
+    );
+    await client.query(
+      `INSERT INTO public.hr_vehicles (id,label,plate,owner_type,active)
+       VALUES ('42000000-0000-4000-8000-000000000027','Véhicule société SOL-24','E2E-024','COMPANY',true)
+       ON CONFLICT (id) DO UPDATE SET label=EXCLUDED.label,plate=EXCLUDED.plate,owner_type='COMPANY',active=true`
+    );
+    await client.query(
+      `INSERT INTO public.hr_kilometer_rate_versions (
+         id,owner_type,rate_per_km,currency,effective_from,definition,source_type,source_ref,
+         observed_at,reliability,created_by
+       ) SELECT
+         '42000000-0000-4000-8000-000000000028','COMPANY',0.650000,'EUR',$1::date,
+         'Taux de preuve exclusivement isolé','DECLARATION','SOL24-E2E-SEED',$1::date,'DECLARED',
+         (SELECT id FROM public.users WHERE username='KEENAN')
+       WHERE NOT EXISTS (
+         SELECT 1 FROM public.hr_kilometer_rate_versions WHERE owner_type='COMPANY' AND effective_to IS NULL
+       )`,
+      [REFERENCE_PERIOD_START]
+    );
+    }
     await client.query("COMMIT");
     process.stdout.write(`SOL-05 deterministic seed ready: users=${USERS.length}, client=901, supplier=E2E-FOURN-001, finance_year=${FINANCE_YEAR}\n`);
   } catch (error) {

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -18,6 +18,7 @@ const STOCK_INTELLIGENCE_PATCH = "20260813_stock_intelligence_sol19.sql";
 const TOOLING_TECHNICAL_GED_PATCH = "20260813_sol20_tooling_technical_ged.sql";
 const PLANNING_EXECUTION_PATCH = "20260814_planning_execution_intelligence_0021.sql";
 const ADV_RELIABILITY_PATCH = "20260814_adv_reliability_sol23.sql";
+const PROJECT_OPERATIONS_PATCH = "20260814_project_operations_sol24.sql";
 const SOL06_SUPPORT = path.join(SUPPORT_DIR, "20260810_system_reference_data_readiness");
 const POSTGRES_IMAGE = "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229";
 const DEFAULT_REPORT_DIR = path.join(ROOT, "docs", "release");
@@ -448,6 +449,13 @@ async function proveRollback(databaseUrl) {
   await client.connect();
   try {
     await client.query("SET cerp.migration_rehearsal = 'on'");
+    const projectOperationsRollback = patchSupportSql(PROJECT_OPERATIONS_PATCH, "rollback");
+    const projectOperationsObject = await client.query(
+      "SELECT to_regclass('public.project_budget_versions') IS NOT NULL AS present"
+    );
+    if (projectOperationsRollback && projectOperationsObject.rows[0].present) {
+      await runSqlFile(client, projectOperationsRollback);
+    }
     const advReliabilityRollback = patchSupportSql(ADV_RELIABILITY_PATCH, "rollback");
     const advReliabilityObject = await client.query(
       "SELECT to_regclass('public.adv_delivery_blocks') IS NOT NULL AS present"
@@ -545,6 +553,16 @@ async function proveRollback(databaseUrl) {
               to_regclass('public.planning_user_preferences') IS NULL
                 AND to_regprocedure('public.fn_planning_color_map_is_valid(jsonb)') IS NULL
                 AS planning_execution_removed,
+              to_regclass('public.project_budget_versions') IS NULL
+                AND to_regclass('public.project_affaire_links') IS NULL
+                AND to_regclass('public.hr_absence_records') IS NULL
+                AND to_regclass('public.hr_period_closures') IS NULL
+                AND to_regclass('public.hr_kilometer_rate_versions') IS NULL
+                AND NOT EXISTS (
+                  SELECT 1 FROM information_schema.columns
+                  WHERE table_schema='public' AND table_name='hr_kilometer_entries'
+                    AND column_name IN ('rate_version_id','cost_amount','cost_currency')
+                ) AS project_operations_removed,
               NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='trg_stock_reference_readiness_2606') AS trigger_removed`
     );
     if (!objects.rows[0].function_removed || !objects.rows[0].function_v2_removed
@@ -553,6 +571,7 @@ async function proveRollback(databaseUrl) {
         || !objects.rows[0].stock_intelligence_removed
         || !objects.rows[0].tooling_technical_ged_removed
         || !objects.rows[0].planning_execution_removed
+        || !objects.rows[0].project_operations_removed
         || !objects.rows[0].trigger_removed) {
       fail("rollback left SOL-06 objects behind");
     }
@@ -761,6 +780,7 @@ module.exports = {
   STOCK_INTELLIGENCE_PATCH,
   PLANNING_EXECUTION_PATCH,
   ADV_RELIABILITY_PATCH,
+  PROJECT_OPERATIONS_PATCH,
   expectedRehearsalPatches,
   inventory,
   inventoryMarkdown,

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -84,6 +84,10 @@ const recentSolPatchChecksums = new Map([
     "20260814_adv_reliability_sol23.sql",
     "f14a8d356312133841168e681f4266142ff95f7e4a07dc6c2a18dd50b9a4f52e",
   ],
+  [
+    "20260814_project_operations_sol24.sql",
+    "e978abeb2b6758744d3824540b2552ef6b6ca90f0c634bc49dd7af403d4e8cd9",
+  ],
 ]);
 const wave9PatchChecksums = new Map([
   [

--- a/src/__tests__/dockerfile.storage.test.ts
+++ b/src/__tests__/dockerfile.storage.test.ts
@@ -51,6 +51,13 @@ describe("Dockerfile storage permissions", () => {
     expect(dockerfile).toContain("ENV CERP_RELEASE_VERSION=${SOURCE_COMMIT}");
   });
 
+  it("ships the commit-pinned migration runner and canonical patch inventory", () => {
+    expect(dockerfile).toContain("COPY scripts/db-patches.js ./scripts/db-patches.js");
+    expect(dockerfile).toContain("COPY db/patches ./db/patches");
+    expect(dockerfile.indexOf("COPY scripts/db-patches.js ./scripts/db-patches.js"))
+      .toBeLessThan(dockerfile.indexOf("COPY --from=builder /app/dist ./dist"));
+  });
+
   it("normalizes shell entrypoints for images built from a Windows checkout", () => {
     expect(gitAttributes).toContain("*.sh text eol=lf");
     expect(gitAttributes).toContain("docker/*.conf text eol=lf");

--- a/src/__tests__/project-office-operations.test.ts
+++ b/src/__tests__/project-office-operations.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../module/project-office/services/project-office-access.service", () => ({
+  requireProjectAccess: vi.fn(async () => ({ project_id: "p", owner_id: 7, visibility: "PRIVATE", effective_role: "OWNER" })),
+  canManage: vi.fn(() => true),
+}));
+vi.mock("../module/project-office/repository/project-office.repository", () => ({
+  withTransaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn({ query: vi.fn() })),
+  insertAuditLog: vi.fn(async () => undefined),
+  insertProjectActivity: vi.fn(async () => undefined),
+  isPgUniqueViolation: vi.fn((error: { code?: string }) => error?.code === "23505"),
+}));
+vi.mock("../module/project-office/repository/project-office-operations.repository", () => ({
+  repoGetCurrentProjectBudget: vi.fn(),
+  repoListProjectAffaireLinks: vi.fn(),
+  repoGetProjectTimeBudget: vi.fn(),
+  repoListOverdueMilestones: vi.fn(),
+  repoListBlockingDependencies: vi.fn(),
+  repoGetProjectBurnUp: vi.fn(),
+  repoGetProjectRiskMatrix: vi.fn(),
+  repoCreateProjectBudgetVersion: vi.fn(),
+  repoAffaireExists: vi.fn(),
+  repoCreateProjectAffaireLink: vi.fn(),
+  repoDeleteProjectAffaireLink: vi.fn(),
+}));
+vi.mock("../module/margin-engine/services/margin-engine.service", () => ({ svcGetMargin: vi.fn() }));
+
+import * as base from "../module/project-office/repository/project-office.repository";
+import * as ops from "../module/project-office/repository/project-office-operations.repository";
+import * as margin from "../module/margin-engine/services/margin-engine.service";
+import * as service from "../module/project-office/services/project-office-operations.service";
+
+const repository = vi.mocked(ops);
+const marginService = vi.mocked(margin);
+const PROJECT = "11111111-1111-4111-8111-111111111111";
+const AUDIT = { user_id: 7, ip: null, user_agent: null, device_type: null, os: null, browser: null, path: null, page_key: null, client_session_id: null };
+
+function budget(amount = "1000.000000") {
+  return {
+    id: "b", project_id: PROJECT, amount, currency: "EUR", effective_from: "2026-08-01", effective_to: null,
+    definition: "Budget validé", source_type: "CONTRACT" as const, source_ref: "DEV-1",
+    observed_at: "2026-08-01T10:00:00.000Z", reliability: "VERIFIED" as const,
+    supersedes_id: null, created_by: 7, created_at: "2026-08-01T10:00:00.000Z",
+  };
+}
+
+function marginResult(cost: string | null, partial: string) {
+  return {
+    actual: {
+      cost_total_ht: cost, partial_cost_total_ht: partial, reliability: cost ? "ACTUAL" : "PARTIAL",
+      freshness_at: "2026-08-14T08:00:00.000Z", missing_inputs: cost ? [] : [{ code: "MATERIAL_MISSING" }],
+      calculation_hash: "hash",
+    },
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  repository.repoGetCurrentProjectBudget.mockResolvedValue(budget());
+  repository.repoListProjectAffaireLinks.mockResolvedValue([
+    { id: "l1", project_id: PROJECT, affaire_id: 10, affaire_reference: "AFF-10", affaire_status: "OUVERTE", source_ref: null, created_by: 7, created_at: "t" },
+  ]);
+  repository.repoGetProjectTimeBudget.mockResolvedValue({ work_package_count: 2, planned_hours: "12", consumed_hours: "5", planned_missing_count: 0, consumed_missing_count: 0, freshness_at: "2026-08-14T08:00:00.000Z" });
+  repository.repoListOverdueMilestones.mockResolvedValue([]);
+  repository.repoListBlockingDependencies.mockResolvedValue([]);
+  repository.repoGetProjectBurnUp.mockResolvedValue([]);
+  repository.repoGetProjectRiskMatrix.mockResolvedValue([]);
+});
+
+describe("SOL-24 project operations", () => {
+  it("ne calcule pas un restant à partir d'un coût partiel", async () => {
+    marginService.svcGetMargin.mockResolvedValue(marginResult(null, "123.45"));
+    const result = await service.getProjectOperations({ id: 7, role: "Employee" }, PROJECT);
+    expect(result.financial.consumed_ht).toBeNull();
+    expect(result.financial.partial_consumed_ht).toBe("123.45");
+    expect(result.financial.remaining_ht).toBeNull();
+    expect(result.financial.reliability).toBe("PARTIAL");
+    expect(result.data_quality).toContain("ACTUAL_COSTS_PARTIAL");
+  });
+
+  it("additionne précisément les coûts complets des affaires liées", async () => {
+    repository.repoListProjectAffaireLinks.mockResolvedValue([
+      { id: "l1", project_id: PROJECT, affaire_id: 10, affaire_reference: "A", affaire_status: "OUVERTE", source_ref: null, created_by: 7, created_at: "t" },
+      { id: "l2", project_id: PROJECT, affaire_id: 11, affaire_reference: "B", affaire_status: "OUVERTE", source_ref: null, created_by: 7, created_at: "t" },
+    ]);
+    marginService.svcGetMargin
+      .mockResolvedValueOnce(marginResult("100.10", "100.10"))
+      .mockResolvedValueOnce(marginResult("200.20", "200.20"));
+    const result = await service.getProjectOperations({ id: 7, role: "Employee" }, PROJECT);
+    expect(result.financial.consumed_ht).toBe("300.30");
+    expect(result.financial.remaining_ht).toBe("699.70");
+    expect(result.financial.reliability).toBe("ACTUAL");
+  });
+
+  it("versionne le budget et audite la provenance", async () => {
+    repository.repoCreateProjectBudgetVersion.mockResolvedValue({ ...budget("1200"), id: "b2", supersedes_id: "b" });
+    const created = await service.createProjectBudget({ id: 7, role: "Direction" }, PROJECT, {
+      amount: "1200", currency: "EUR", effective_from: "2026-08-15", definition: "Budget direction validé",
+      source_type: "DECLARATION", source_ref: "DIR-2026-08", observed_at: "2026-08-14T08:00:00.000Z", reliability: "DECLARED",
+    }, AUDIT);
+    expect(created.supersedes_id).toBe("b");
+    expect(vi.mocked(base.insertAuditLog)).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "project-office.budget.version.create" }));
+  });
+
+  it("refuse une date de budget qui ne succède pas à la version courante", async () => {
+    await expect(service.createProjectBudget({ id: 7, role: "Direction" }, PROJECT, {
+      amount: "1200", currency: "EUR", effective_from: "2026-08-01", definition: "Budget direction validé",
+      source_type: "DECLARATION", observed_at: "2026-08-14T08:00:00.000Z", reliability: "DECLARED",
+    }, AUDIT)).rejects.toMatchObject({ status: 409, code: "PO_BUDGET_EFFECTIVE_DATE_INVALID" });
+  });
+});

--- a/src/__tests__/project-operations-sol24.migration-guards.test.ts
+++ b/src/__tests__/project-operations-sol24.migration-guards.test.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "../..");
+const patch = fs.readFileSync(path.join(root, "db/patches/20260814_project_operations_sol24.sql"), "utf8");
+const preflight = fs.readFileSync(path.join(root, "db/patches/support/20260814_project_operations_sol24.preflight.sql"), "utf8");
+const verify = fs.readFileSync(path.join(root, "db/patches/support/20260814_project_operations_sol24.verify.sql"), "utf8");
+const rollback = fs.readFileSync(path.join(root, "db/patches/support/20260814_project_operations_sol24.rollback.sql"), "utf8");
+const runner = fs.readFileSync(path.join(root, "scripts/db-patches.js"), "utf8");
+const releaseGate = fs.readFileSync(path.join(root, "scripts/migrations/release-gate.js"), "utf8");
+
+describe("SOL-24 migration guards", () => {
+  it("reste additive, transactionnelle et rejouable", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.project_budget_versions");
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.hr_period_closures");
+    expect(patch).toContain("ADD COLUMN IF NOT EXISTS rate_version_id");
+    expect(patch).not.toMatch(/\bDROP\s+(?:TABLE|COLUMN|TYPE)\b/i);
+    expect(patch).not.toMatch(/\bTRUNCATE\b/i);
+  });
+
+  it("dispose d'un preflight, d'une vérification et d'un rollback test-only", () => {
+    expect(preflight).toContain("Prerequis SOL-24 manquants");
+    expect(verify).toContain("Objets SOL-24 manquants");
+    expect(verify).toContain("orphan_project_affaire_links");
+    expect(rollback).toContain("current_database() <> 'cerp_test'");
+    expect(rollback).toContain("Rollback refuse: donnees SOL-24 presentes");
+    expect(runner).toContain('"20260814_project_operations_sol24.sql":');
+    expect(runner).toContain("e978abeb2b6758744d3824540b2552ef6b6ca90f0c634bc49dd7af403d4e8cd9");
+    expect(releaseGate).toContain('const PROJECT_OPERATIONS_PATCH = "20260814_project_operations_sol24.sql"');
+    expect(releaseGate).toContain("project_operations_removed");
+  });
+});

--- a/src/__tests__/project-operations-sol24.repository-contracts.test.ts
+++ b/src/__tests__/project-operations-sol24.repository-contracts.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runWithAccountModuleAccess } from "../module/access-control/context/account-module-access.context";
+import { repoListProjects } from "../module/project-office/repository/project-office.repository";
+import { repoGetTeamOperationsQueue } from "../module/temps-deplacements/repository/temps-deplacements-operations.repository";
+
+describe("SOL-24 PostgreSQL repository contracts", () => {
+  it("n'envoie aucun paramètre inutilisé quand le gate module élève la liste des projets", async () => {
+    const query = vi.fn()
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await new Promise<void>((resolve, reject) => {
+      runWithAccountModuleAccess({ userId: 7, moduleKey: "PROJECT_OFFICE", elevated: true }, () => {
+        void repoListProjects(7, { page: 1, pageSize: 25 }, { query } as never).then(() => resolve(), reject);
+      });
+    });
+
+    expect(query.mock.calls[0][1]).toEqual([]);
+    expect(query.mock.calls[1][1]).toEqual([25, 0]);
+  });
+
+  it("sélectionne un UUID de doublon sans appeler min(uuid), absent de PostgreSQL", async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    await repoGetTeamOperationsQueue({ manager_user_id: 7, privileged: true }, { query } as never);
+
+    const duplicateSql = String(query.mock.calls[4][0]);
+    expect(duplicateSql).toContain("array_agg(k.id ORDER BY k.id)");
+    expect(duplicateSql).not.toMatch(/min\s*\(\s*k\.id\s*\)/i);
+  });
+});

--- a/src/__tests__/project-operations-sol24.routes.test.ts
+++ b/src/__tests__/project-operations-sol24.routes.test.ts
@@ -1,0 +1,136 @@
+import { EventEmitter } from "events";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../utils/httpError";
+
+const mocks = vi.hoisted(() => ({
+  currentRole: { value: "Responsable RH" as string | null },
+  projectOperations: vi.fn(),
+  createBudget: vi.fn(),
+  createAbsence: vi.fn(),
+  createClosure: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = { on: emitter.on.bind(emitter), query: vi.fn(), connect: vi.fn() };
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+vi.mock("../utils/checkNetworkDrive", () => ({ checkNetworkDrive: vi.fn(() => Promise.resolve()) }));
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock("../module/project-office/middlewares/require-project-office-access", () => ({
+  requireProjectOfficeAccess: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; username: string; email: string; role: string; primary_role: string; roles: string[] } },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void,
+  ) => {
+    if (mocks.currentRole.value === null) {
+      res.status(401).json({ error: "UNAUTHORIZED" });
+      return;
+    }
+    req.user = {
+      id: 17,
+      username: "sol24-test",
+      email: "sol24@test.invalid",
+      role: mocks.currentRole.value,
+      primary_role: mocks.currentRole.value,
+      roles: [mocks.currentRole.value],
+    };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock("../module/project-office/services/project-office-operations.service", () => ({
+  getProjectOperations: mocks.projectOperations,
+  createProjectBudget: mocks.createBudget,
+  linkProjectAffaire: vi.fn(),
+  unlinkProjectAffaire: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/services/temps-deplacements-operations.service", () => ({
+  createMyAbsence: mocks.createAbsence,
+  listMyAbsences: vi.fn(async () => []),
+  listTeamAbsences: vi.fn(async () => []),
+  decideAbsence: vi.fn(),
+  getOperationsQueue: vi.fn(async () => ({ generated_at: "2026-08-14T08:00:00.000Z" })),
+  listClosures: vi.fn(async () => []),
+  createPeriodClosure: mocks.createClosure,
+  reopenPeriodClosure: vi.fn(),
+  listKilometerRates: vi.fn(async () => []),
+  createKilometerRate: vi.fn(),
+}));
+
+import app from "../config/app";
+
+const PROJECT = "11111111-1111-4111-8111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.currentRole.value = "Responsable RH";
+  mocks.projectOperations.mockResolvedValue({ generated_at: "2026-08-14T08:00:00.000Z", data_quality: [] });
+  mocks.createBudget.mockResolvedValue({ id: "22222222-2222-4222-8222-222222222222" });
+  mocks.createAbsence.mockResolvedValue({ id: "33333333-3333-4333-8333-333333333333", status: "REQUESTED" });
+  mocks.createClosure.mockImplementation(async (actor: { role: string }) => {
+    if (actor.role === "Employee") throw new HttpError(403, "HR_ADMIN_REQUIRED", "Action réservée à l'administration RH.");
+    return { closure: { id: "44444444-4444-4444-8444-444444444444" }, preflight: {} };
+  });
+});
+
+describe("SOL-24 route contracts and RBAC", () => {
+  it("refuse les nouveaux contrats à un appel anonyme", async () => {
+    mocks.currentRole.value = null;
+    expect((await request(app).get(`/api/v1/project-office/projects/${PROJECT}/operations`)).status).toBe(401);
+    expect((await request(app).get("/api/v1/time-clock/team/operations-queue")).status).toBe(401);
+  });
+
+  it("expose le pilotage projet à un membre authentifié et valide le budget avant service", async () => {
+    expect((await request(app).get(`/api/v1/project-office/projects/${PROJECT}/operations`)).status).toBe(200);
+    const invalid = await request(app).post(`/api/v1/project-office/projects/${PROJECT}/budget-versions`).send({ amount: "10" });
+    expect(invalid.status).toBe(400);
+    expect(mocks.createBudget).not.toHaveBeenCalled();
+  });
+
+  it("dérive l'auteur d'une absence du JWT et refuse tout employee_id injecté", async () => {
+    mocks.currentRole.value = "Employee";
+    const injected = await request(app).post("/api/v1/time-clock/absences").send({
+      employee_id: "99999999-9999-4999-8999-999999999999",
+      absence_date: "2026-08-20",
+      minutes: 420,
+      absence_type: "PAID_LEAVE",
+      timezone: "Europe/Paris",
+      reason: "Congé planifié",
+    });
+    expect(injected.status).toBe(400);
+    expect(mocks.createAbsence).not.toHaveBeenCalled();
+
+    const response = await request(app).post("/api/v1/time-clock/absences").send({
+      absence_date: "2026-08-20",
+      minutes: 420,
+      absence_type: "PAID_LEAVE",
+      timezone: "Europe/Paris",
+      reason: "Congé planifié",
+    });
+    expect(response.status).toBe(201);
+    expect(mocks.createAbsence).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 17, role: "Employee" }),
+      expect.not.objectContaining({ employee_id: expect.anything() }),
+      expect.anything(),
+    );
+  });
+
+  it("réserve la clôture de période à l'administration RH", async () => {
+    mocks.currentRole.value = "Employee";
+    const response = await request(app).post("/api/v1/time-clock/admin/period-closures").send({
+      period_start: "2026-08-01",
+      period_end: "2026-08-31",
+      timezone: "Europe/Paris",
+      reason: "Clôture mensuelle validée",
+    });
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe("HR_ADMIN_REQUIRED");
+  });
+});

--- a/src/__tests__/temps-deplacements-operations.test.ts
+++ b/src/__tests__/temps-deplacements-operations.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-operations.repository", () => ({
+  repoFindActivePeriodClosure: vi.fn(),
+  repoCreateAbsence: vi.fn(),
+  repoGetAbsence: vi.fn(),
+  repoListAbsences: vi.fn(),
+  repoDecideAbsence: vi.fn(),
+  repoGetClosurePreflight: vi.fn(),
+  repoCreatePeriodClosure: vi.fn(),
+  repoGetPeriodClosure: vi.fn(),
+  repoReopenPeriodClosure: vi.fn(),
+  repoListPeriodClosures: vi.fn(),
+  repoGetCurrentKilometerRate: vi.fn(),
+  repoCreateKilometerRate: vi.fn(),
+  repoListKilometerRates: vi.fn(),
+  repoGetTeamOperationsQueue: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", () => ({
+  withTransaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn({ query: vi.fn() })),
+  insertAuditLog: vi.fn(async () => undefined),
+  repoGetEmployeeById: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/services/temps-deplacements.service", () => ({
+  resolveEmployeeFromUser: vi.fn(),
+}));
+
+import * as repository from "../module/temps-deplacements/repository/temps-deplacements-operations.repository";
+import * as base from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import * as time from "../module/temps-deplacements/services/temps-deplacements.service";
+import * as service from "../module/temps-deplacements/services/temps-deplacements-operations.service";
+import { isHrPrivileged } from "../module/temps-deplacements/domain/temps-deplacements-policy";
+
+const repo = vi.mocked(repository);
+const EMPLOYEE = "11111111-1111-4111-8111-111111111111";
+const AUDIT = { user_id: 1, ip: null, user_agent: null, device_type: null, os: null, browser: null, path: null, page_key: null, client_session_id: null };
+const absence = { id: "a", employee_id: EMPLOYEE, absence_date: "2026-08-14", minutes: 420, absence_type: "PAID_LEAVE" as const, timezone: "Europe/Paris", status: "REQUESTED" as const, reason: "Congé validable", source_ref: null, requested_by: 1, decided_by: null, decided_at: null, created_at: "t", updated_at: "t" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(time.resolveEmployeeFromUser).mockResolvedValue({ id: EMPLOYEE, user_id: 1, matricule: "E1", service: null, manager_user_id: 9, status: "ACTIVE" });
+  repo.repoFindActivePeriodClosure.mockResolvedValue(null);
+});
+
+describe("SOL-24 absences, clôture et RBAC", () => {
+  it("un accès module ordinaire ne transforme pas un employé en administrateur RH", () => {
+    expect(isHrPrivileged("Employee")).toBe(false);
+    expect(isHrPrivileged("Responsable RH")).toBe(true);
+  });
+
+  it("crée une absence uniquement pour l'employé du token et audite", async () => {
+    repo.repoCreateAbsence.mockResolvedValue(absence);
+    const result = await service.createMyAbsence({ id: 1, role: "Employee" }, {
+      absence_date: "2026-08-14", minutes: 420, absence_type: "PAID_LEAVE", timezone: "Europe/Paris", reason: "Congé validable",
+    }, AUDIT);
+    expect(result.employee_id).toBe(EMPLOYEE);
+    expect(repo.repoCreateAbsence.mock.calls[0][1].requested_by).toBe(1);
+    expect(vi.mocked(base.insertAuditLog)).toHaveBeenCalled();
+  });
+
+  it("interdit toute demande dans une période clôturée", async () => {
+    repo.repoFindActivePeriodClosure.mockResolvedValue({ id: "c", period_start: "2026-08-01", period_end: "2026-08-31" } as never);
+    await expect(service.createMyAbsence({ id: 1, role: "Employee" }, {
+      absence_date: "2026-08-14", minutes: 420, absence_type: "PAID_LEAVE", timezone: "Europe/Paris", reason: "Congé validable",
+    }, AUDIT)).rejects.toMatchObject({ status: 409, code: "HR_PERIOD_CLOSED" });
+  });
+
+  it("refuse l'auto-validation d'une absence", async () => {
+    repo.repoGetAbsence.mockResolvedValue(absence);
+    await expect(service.decideAbsence({ id: 1, role: "Responsable RH" }, "a", "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_SELF_APPROVAL_FORBIDDEN" });
+  });
+
+  it("bloque la clôture tant que le preflight contient des exceptions", async () => {
+    repo.repoGetClosurePreflight.mockResolvedValue({ unvalidated_days: 2, unvalidated_weeks: 0, unresolved_anomalies: 1, pending_adjustments: 0, pending_kilometers: 0, pending_absences: 0 });
+    await expect(service.createPeriodClosure({ id: 7, role: "Responsable RH" }, {
+      period_start: "2026-08-01", period_end: "2026-08-31", employee_id: null, timezone: "Europe/Paris", reason: "Clôture mensuelle",
+    }, AUDIT)).rejects.toMatchObject({ status: 409, code: "HR_PERIOD_PREFLIGHT_FAILED" });
+  });
+
+  it("refuse la clôture et les taux à un utilisateur standard", async () => {
+    await expect(service.createPeriodClosure({ id: 2, role: "Employee" }, {
+      period_start: "2026-08-01", period_end: "2026-08-31", employee_id: null, timezone: "Europe/Paris", reason: "Clôture mensuelle",
+    }, AUDIT)).rejects.toMatchObject({ status: 403, code: "HR_ADMIN_REQUIRED" });
+    await expect(service.createKilometerRate({ id: 2, role: "Employee" }, {
+      owner_type: "PERSONAL", rate_per_km: "0.50", currency: "EUR", effective_from: "2026-08-01",
+      definition: "Barème direction", source_type: "DECLARATION", source_ref: null,
+      observed_at: "2026-08-14T08:00:00.000Z", reliability: "DECLARED",
+    }, AUDIT)).rejects.toMatchObject({ status: 403, code: "HR_ADMIN_REQUIRED" });
+  });
+});

--- a/src/__tests__/temps-deplacements-t4.test.ts
+++ b/src/__tests__/temps-deplacements-t4.test.ts
@@ -14,6 +14,10 @@ vi.mock("../module/temps-deplacements/repository/temps-deplacements-corrections.
   repoListTeamAnomaliesForDate: vi.fn(),
   repoListTeamEmployees: vi.fn(),
 }));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-operations.repository", () => ({
+  repoFindActivePeriodClosure: vi.fn(async () => null),
+  repoResolveAdjustmentPeriod: vi.fn(async () => ({ employee_id: "emp-x", from: "2026-03-02", to: "2026-03-02" })),
+}));
 
 // Repository T2 : on garde le réel SAUF transaction/audit/lecture employé (pour ne pas toucher la DB).
 vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (importOriginal) => {
@@ -149,8 +153,15 @@ describe("T4 — validateTimesheetDay", () => {
     await expect(svc.validateTimesheetDay({ id: 5, role: "Responsable RH" }, UUID, AUDIT))
       .rejects.toMatchObject({ status: 409, code: "HR_ALREADY_VALIDATED" });
   });
+  it("interdit à un responsable de valider sa propre journée", async () => {
+    cor.repoGetTimesheetDayById.mockResolvedValue({ id: UUID, employee_id: "emp-self", validation_status: "DRAFT" });
+    base.repoGetEmployeeById.mockResolvedValue(emp({ user_id: 5 }));
+    await expect(svc.validateTimesheetDay({ id: 5, role: "Responsable RH" }, UUID, AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_SELF_APPROVAL_FORBIDDEN" });
+  });
   it("DRAFT → VALIDATED + audit 'day.validated'", async () => {
     cor.repoGetTimesheetDayById.mockResolvedValue({ id: UUID, employee_id: "emp-x", validation_status: "DRAFT" });
+    base.repoGetEmployeeById.mockResolvedValue(emp({ user_id: 1 }));
     cor.repoSetDayValidation.mockResolvedValue({ id: UUID, employee_id: "emp-x", validation_status: "VALIDATED" });
     const r = await svc.validateTimesheetDay({ id: 5, role: "Responsable RH" }, UUID, AUDIT);
     expect(r.validation_status).toBe("VALIDATED");

--- a/src/__tests__/temps-deplacements-t6-km.test.ts
+++ b/src/__tests__/temps-deplacements-t6-km.test.ts
@@ -10,6 +10,10 @@ vi.mock("../module/temps-deplacements/repository/temps-deplacements-km.repositor
   repoListVehicles: vi.fn(),
   repoCreateVehicle: vi.fn(),
 }));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-operations.repository", () => ({
+  repoFindActivePeriodClosure: vi.fn(async () => null),
+  repoGetEffectiveKilometerRate: vi.fn(async () => ({ id: "rate-1", currency: "EUR", rate_per_km: "0.50" })),
+}));
 vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (io) => {
   const actual = await io<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
   return {
@@ -26,6 +30,7 @@ vi.mock("../module/temps-deplacements/services/temps-deplacements.service", asyn
 
 import * as kmRepo from "../module/temps-deplacements/repository/temps-deplacements-km.repository";
 import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import * as operationsRepo from "../module/temps-deplacements/repository/temps-deplacements-operations.repository";
 import * as t2 from "../module/temps-deplacements/services/temps-deplacements.service";
 import * as svc from "../module/temps-deplacements/services/temps-deplacements-km.service";
 import { computeDistanceKm } from "../module/temps-deplacements/services/temps-deplacements-km.service";
@@ -82,6 +87,17 @@ describe("T6 — soumission & validation (ownership + périmètre + transitions)
     await expect(svc.decideKmEntry({ id: 5, role: "Employee" }, "k1", "VALIDATED", AUDIT)).rejects.toMatchObject({ status: 403 });
     km.repoDecideKmEntry.mockResolvedValue({ id: "k1", status: "VALIDATED" } as never);
     expect((await svc.decideKmEntry({ id: 5, role: "Responsable RH" }, "k1", "VALIDATED", AUDIT)).status).toBe("VALIDATED");
+  });
+  it("interdit l'auto-validation et exige un taux daté", async () => {
+    km.repoGetKmEntryById.mockResolvedValue({ id: "k1", employee_id: "E", status: "SUBMITTED", vehicle_id: "v1", date: "2026-03-02" } as never);
+    vi.mocked(baseRepo.repoGetEmployeeById).mockResolvedValue(emp({ user_id: 5 }));
+    await expect(svc.decideKmEntry({ id: 5, role: "Responsable RH" }, "k1", "VALIDATED", AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_SELF_APPROVAL_FORBIDDEN" });
+
+    vi.mocked(baseRepo.repoGetEmployeeById).mockResolvedValue(emp({ user_id: 1 }));
+    vi.mocked(operationsRepo.repoGetEffectiveKilometerRate).mockResolvedValueOnce(null);
+    await expect(svc.decideKmEntry({ id: 5, role: "Responsable RH" }, "k1", "VALIDATED", AUDIT))
+      .rejects.toMatchObject({ status: 409, code: "HR_KM_RATE_MISSING" });
   });
   it("valider une déclaration non soumise → 409", async () => {
     km.repoGetKmEntryById.mockResolvedValue({ id: "k1", employee_id: "E", status: "DRAFT" } as never);

--- a/src/module/project-office/controllers/project-office-operations.controller.ts
+++ b/src/module/project-office/controllers/project-office-operations.controller.ts
@@ -1,0 +1,32 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as service from "../services/project-office-operations.service";
+import {
+  createProjectBudgetSchema,
+  linkProjectAffaireSchema,
+  projectAffaireLinkParamsSchema,
+  projectIdParamsSchema,
+} from "../validators/project-office.validators";
+import { buildAuditContext, requireUser } from "./project-office.controller";
+
+export const getOperations = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = projectIdParamsSchema.parse(req.params);
+  res.json(await service.getProjectOperations(requireUser(req), id));
+});
+
+export const postBudget = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = projectIdParamsSchema.parse(req.params);
+  const input = createProjectBudgetSchema.parse(req.body);
+  res.status(201).json(await service.createProjectBudget(requireUser(req), id, input, buildAuditContext(req)));
+});
+
+export const postAffaireLink = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = projectIdParamsSchema.parse(req.params);
+  const input = linkProjectAffaireSchema.parse(req.body);
+  res.status(201).json(await service.linkProjectAffaire(requireUser(req), id, input, buildAuditContext(req)));
+});
+
+export const deleteAffaireLink = asyncHandler(async (req: Request, res: Response) => {
+  const { id, linkId } = projectAffaireLinkParamsSchema.parse(req.params);
+  res.json(await service.unlinkProjectAffaire(requireUser(req), id, linkId, buildAuditContext(req)));
+});

--- a/src/module/project-office/repository/project-office-operations.repository.ts
+++ b/src/module/project-office/repository/project-office-operations.repository.ts
@@ -1,0 +1,261 @@
+import pool from "../../../config/database";
+import type { DbQueryer } from "./project-office.repository";
+
+export type ProjectBudgetVersion = {
+  id: string;
+  project_id: string;
+  amount: string;
+  currency: string;
+  effective_from: string;
+  effective_to: string | null;
+  definition: string;
+  source_type: "DECLARATION" | "CONTRACT" | "DOCUMENT" | "OTHER";
+  source_ref: string | null;
+  observed_at: string;
+  reliability: "DECLARED" | "VERIFIED" | "ESTIMATED";
+  supersedes_id: string | null;
+  created_by: number;
+  created_at: string;
+};
+
+export type ProjectAffaireLink = {
+  id: string;
+  project_id: string;
+  affaire_id: number;
+  affaire_reference: string;
+  affaire_status: string;
+  source_ref: string | null;
+  created_by: number;
+  created_at: string;
+};
+
+export type ProjectTimeBudget = {
+  work_package_count: number;
+  planned_hours: string | null;
+  consumed_hours: string | null;
+  planned_missing_count: number;
+  consumed_missing_count: number;
+  freshness_at: string | null;
+};
+
+const BUDGET_COLUMNS = `id::text, project_id::text, amount::text, currency,
+  effective_from::text, effective_to::text, definition, source_type, source_ref,
+  observed_at::text, reliability, supersedes_id::text, created_by, created_at::text`;
+
+function mapBudget(row: Record<string, unknown>): ProjectBudgetVersion {
+  return {
+    id: String(row.id), project_id: String(row.project_id), amount: String(row.amount),
+    currency: String(row.currency).trim(), effective_from: String(row.effective_from),
+    effective_to: row.effective_to == null ? null : String(row.effective_to),
+    definition: String(row.definition), source_type: row.source_type as ProjectBudgetVersion["source_type"],
+    source_ref: row.source_ref == null ? null : String(row.source_ref), observed_at: String(row.observed_at),
+    reliability: row.reliability as ProjectBudgetVersion["reliability"],
+    supersedes_id: row.supersedes_id == null ? null : String(row.supersedes_id),
+    created_by: Number(row.created_by), created_at: String(row.created_at),
+  };
+}
+
+export async function repoGetCurrentProjectBudget(
+  projectId: string,
+  q: DbQueryer = pool,
+): Promise<ProjectBudgetVersion | null> {
+  const result = await q.query(
+    `SELECT ${BUDGET_COLUMNS}
+       FROM public.project_budget_versions
+      WHERE project_id=$1::uuid AND effective_to IS NULL
+      ORDER BY effective_from DESC, created_at DESC LIMIT 1`,
+    [projectId],
+  );
+  return result.rows[0] ? mapBudget(result.rows[0]) : null;
+}
+
+export async function repoCreateProjectBudgetVersion(
+  q: DbQueryer,
+  input: Omit<ProjectBudgetVersion, "id" | "project_id" | "effective_to" | "supersedes_id" | "created_at"> & {
+    project_id: string;
+    supersedes_id: string | null;
+  },
+): Promise<ProjectBudgetVersion> {
+  if (input.supersedes_id) {
+    await q.query(
+      `UPDATE public.project_budget_versions
+          SET effective_to=($2::date - INTERVAL '1 day')::date
+        WHERE id=$1::uuid AND effective_to IS NULL`,
+      [input.supersedes_id, input.effective_from],
+    );
+  }
+  const result = await q.query(
+    `INSERT INTO public.project_budget_versions
+       (project_id, amount, currency, effective_from, definition, source_type, source_ref,
+        observed_at, reliability, supersedes_id, created_by)
+     VALUES ($1::uuid,$2::numeric,$3,$4::date,$5,$6,$7,$8::timestamptz,$9,$10::uuid,$11)
+     RETURNING ${BUDGET_COLUMNS}`,
+    [input.project_id, input.amount, input.currency, input.effective_from, input.definition,
+      input.source_type, input.source_ref, input.observed_at, input.reliability,
+      input.supersedes_id, input.created_by],
+  );
+  return mapBudget(result.rows[0]);
+}
+
+export async function repoAffaireExists(affaireId: number, q: DbQueryer = pool): Promise<boolean> {
+  const result = await q.query(`SELECT 1 FROM public.affaire WHERE id=$1::bigint LIMIT 1`, [affaireId]);
+  return Boolean(result.rows[0]);
+}
+
+export async function repoCreateProjectAffaireLink(
+  q: DbQueryer,
+  input: { project_id: string; affaire_id: number; source_ref: string | null; created_by: number },
+): Promise<ProjectAffaireLink> {
+  const result = await q.query(
+    `WITH inserted AS (
+       INSERT INTO public.project_affaire_links(project_id, affaire_id, source_ref, created_by)
+       VALUES ($1::uuid,$2::bigint,$3,$4)
+       RETURNING *
+     )
+     SELECT i.id::text, i.project_id::text, i.affaire_id, a.reference AS affaire_reference,
+            a.statut AS affaire_status, i.source_ref, i.created_by, i.created_at::text
+       FROM inserted i JOIN public.affaire a ON a.id=i.affaire_id`,
+    [input.project_id, input.affaire_id, input.source_ref, input.created_by],
+  );
+  const row = result.rows[0];
+  return {
+    id: String(row.id), project_id: String(row.project_id), affaire_id: Number(row.affaire_id),
+    affaire_reference: String(row.affaire_reference), affaire_status: String(row.affaire_status),
+    source_ref: row.source_ref == null ? null : String(row.source_ref),
+    created_by: Number(row.created_by), created_at: String(row.created_at),
+  };
+}
+
+export async function repoDeleteProjectAffaireLink(q: DbQueryer, projectId: string, linkId: string): Promise<boolean> {
+  const result = await q.query(
+    `DELETE FROM public.project_affaire_links WHERE id=$1::uuid AND project_id=$2::uuid RETURNING id`,
+    [linkId, projectId],
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
+export async function repoListProjectAffaireLinks(
+  projectId: string,
+  q: DbQueryer = pool,
+): Promise<ProjectAffaireLink[]> {
+  const result = await q.query(
+    `SELECT l.id::text, l.project_id::text, l.affaire_id, a.reference AS affaire_reference,
+            a.statut AS affaire_status, l.source_ref, l.created_by, l.created_at::text
+       FROM public.project_affaire_links l
+       JOIN public.affaire a ON a.id=l.affaire_id
+      WHERE l.project_id=$1::uuid
+      ORDER BY a.reference, l.created_at`,
+    [projectId],
+  );
+  return result.rows.map((row: Record<string, unknown>) => ({
+    id: String(row.id), project_id: String(row.project_id), affaire_id: Number(row.affaire_id),
+    affaire_reference: String(row.affaire_reference), affaire_status: String(row.affaire_status),
+    source_ref: row.source_ref == null ? null : String(row.source_ref),
+    created_by: Number(row.created_by), created_at: String(row.created_at),
+  }));
+}
+
+export async function repoGetProjectTimeBudget(projectId: string, q: DbQueryer = pool): Promise<ProjectTimeBudget> {
+  const result = await q.query(
+    `SELECT COUNT(*) FILTER (WHERE status <> 'CANCELLED')::int AS work_package_count,
+            SUM(estimated_hours) FILTER (WHERE status <> 'CANCELLED')::text AS planned_hours,
+            SUM(spent_hours) FILTER (WHERE status <> 'CANCELLED')::text AS consumed_hours,
+            COUNT(*) FILTER (WHERE status <> 'CANCELLED' AND estimated_hours IS NULL)::int AS planned_missing_count,
+            COUNT(*) FILTER (WHERE status NOT IN ('BACKLOG','CANCELLED') AND spent_hours IS NULL)::int AS consumed_missing_count,
+            MAX(updated_at)::text AS freshness_at
+       FROM public.project_work_packages
+      WHERE project_id=$1::uuid`,
+    [projectId],
+  );
+  const row = result.rows[0];
+  return {
+    work_package_count: Number(row.work_package_count ?? 0),
+    planned_hours: row.planned_hours == null ? null : String(row.planned_hours),
+    consumed_hours: row.consumed_hours == null ? null : String(row.consumed_hours),
+    planned_missing_count: Number(row.planned_missing_count ?? 0),
+    consumed_missing_count: Number(row.consumed_missing_count ?? 0),
+    freshness_at: row.freshness_at == null ? null : String(row.freshness_at),
+  };
+}
+
+export async function repoListOverdueMilestones(projectId: string, q: DbQueryer = pool) {
+  const result = await q.query(
+    `SELECT id::text, name, due_date::text, status::text, updated_at::text,
+            (CURRENT_DATE-due_date)::int AS overdue_days
+       FROM public.project_milestones
+      WHERE project_id=$1::uuid AND due_date<CURRENT_DATE AND status='PLANNED'
+      ORDER BY due_date, name`,
+    [projectId],
+  );
+  return result.rows.map((row: Record<string, unknown>) => ({
+    id: String(row.id), name: String(row.name), due_date: String(row.due_date),
+    status: String(row.status), overdue_days: Number(row.overdue_days), updated_at: String(row.updated_at),
+  }));
+}
+
+export async function repoListBlockingDependencies(projectId: string, q: DbQueryer = pool) {
+  const result = await q.query(
+    `SELECT d.id::text, d.dependency_type::text,
+            source.id::text AS source_id, source.code AS source_code, source.title AS source_title,
+            source.assignee_id AS owner_id, source.due_date::text AS due_date,
+            target.id::text AS target_id, target.code AS target_code, target.title AS target_title,
+            target.status::text AS target_status
+       FROM public.project_dependencies d
+       JOIN public.project_work_packages source ON source.id=d.source_work_package_id
+       JOIN public.project_work_packages target ON target.id=d.target_work_package_id
+      WHERE source.project_id=$1::uuid
+        AND target.project_id=$1::uuid
+        AND d.dependency_type IN ('BLOCKS','REQUIRES')
+        AND source.status NOT IN ('DONE','CANCELLED')
+        AND target.status NOT IN ('DONE','CANCELLED')
+      ORDER BY source.due_date NULLS LAST, source.priority DESC, source.code`,
+    [projectId],
+  );
+  return result.rows.map((row: Record<string, unknown>) => ({
+    id: String(row.id), dependency_type: String(row.dependency_type),
+    source: { id: String(row.source_id), code: String(row.source_code), title: String(row.source_title) },
+    blocking: { id: String(row.target_id), code: String(row.target_code), title: String(row.target_title), status: String(row.target_status) },
+    owner_id: row.owner_id == null ? null : Number(row.owner_id),
+    due_date: row.due_date == null ? null : String(row.due_date),
+    cause: `${String(row.dependency_type)}:${String(row.target_code)}:${String(row.target_status)}`,
+  }));
+}
+
+export async function repoGetProjectBurnUp(projectId: string, q: DbQueryer = pool) {
+  const result = await q.query(
+    `WITH weeks AS (
+       SELECT generate_series(
+         date_trunc('week', CURRENT_DATE)::date - INTERVAL '11 weeks',
+         date_trunc('week', CURRENT_DATE)::date,
+         INTERVAL '1 week'
+       )::date AS week_start
+     )
+     SELECT w.week_start::text,
+            (w.week_start + 6)::date::text AS week_end,
+            COUNT(p.id) FILTER (WHERE p.due_date IS NOT NULL AND p.due_date <= w.week_start + 6)::int AS planned_cumulative,
+            COUNT(p.id) FILTER (WHERE p.status='DONE' AND p.updated_at::date <= w.week_start + 6)::int AS completed_cumulative
+       FROM weeks w
+       LEFT JOIN public.project_work_packages p ON p.project_id=$1::uuid AND p.status<>'CANCELLED'
+      GROUP BY w.week_start ORDER BY w.week_start`,
+    [projectId],
+  );
+  return result.rows.map((row: Record<string, unknown>) => ({
+    week_start: String(row.week_start), week_end: String(row.week_end),
+    planned_cumulative: Number(row.planned_cumulative), completed_cumulative: Number(row.completed_cumulative),
+  }));
+}
+
+export async function repoGetProjectRiskMatrix(projectId: string, q: DbQueryer = pool) {
+  const result = await q.query(
+    `SELECT probability, impact, COUNT(*)::int AS count,
+            jsonb_agg(jsonb_build_object('id',id::text,'title',title,'severity',severity,'owner_id',owner_id,'updated_at',updated_at)
+                      ORDER BY severity DESC, title) AS risks
+       FROM public.project_risks
+      WHERE project_id=$1::uuid AND status IN ('OPEN','MITIGATED','ACCEPTED')
+      GROUP BY probability, impact ORDER BY probability DESC, impact DESC`,
+    [projectId],
+  );
+  return result.rows.map((row: Record<string, unknown>) => ({
+    probability: Number(row.probability), impact: Number(row.impact), count: Number(row.count), risks: row.risks,
+  }));
+}

--- a/src/module/project-office/repository/project-office.repository.ts
+++ b/src/module/project-office/repository/project-office.repository.ts
@@ -224,13 +224,15 @@ export async function repoListProjects(
   opts: { q?: string; status?: string; page: number; pageSize: number },
   q: DbQueryer = pool
 ): Promise<{ items: ProjectRow[]; total: number }> {
-  const conds: string[] = [
-    hasGrantedAccountModuleAccess()
-      ? "TRUE"
-      : `(p.owner_id = $1 OR p.visibility = 'INTERNAL' OR EXISTS (
-        SELECT 1 FROM public.project_members m WHERE m.project_id = p.id AND m.user_id = $1))`,
-  ];
-  const params: unknown[] = [userId];
+  const params: unknown[] = [];
+  const conds: string[] = [];
+  if (hasGrantedAccountModuleAccess()) {
+    conds.push("TRUE");
+  } else {
+    params.push(userId);
+    conds.push(`(p.owner_id = $1 OR p.visibility = 'INTERNAL' OR EXISTS (
+      SELECT 1 FROM public.project_members m WHERE m.project_id = p.id AND m.user_id = $1))`);
+  }
   if (opts.q) {
     params.push(`%${opts.q}%`);
     conds.push(`(p.name ILIKE $${params.length} OR p.code ILIKE $${params.length})`);
@@ -241,13 +243,13 @@ export async function repoListProjects(
   }
   const where = conds.join(" AND ");
   const totalRes = await q.query(`SELECT COUNT(*)::int AS n FROM public.project_projects p WHERE ${where}`, params);
-  params.push(opts.pageSize, (opts.page - 1) * opts.pageSize);
+  const listParams = [...params, opts.pageSize, (opts.page - 1) * opts.pageSize];
   const res = await q.query(
     `SELECT ${PROJECT_COLS} FROM public.project_projects p
       WHERE ${where}
       ORDER BY p.updated_at DESC
-      LIMIT $${params.length - 1} OFFSET $${params.length}`,
-    params
+      LIMIT $${listParams.length - 1} OFFSET $${listParams.length}`,
+    listParams
   );
   return { items: res.rows.map(mapProject), total: Number(totalRes.rows[0]?.n ?? 0) };
 }

--- a/src/module/project-office/routes/project-office.routes.ts
+++ b/src/module/project-office/routes/project-office.routes.ts
@@ -6,6 +6,7 @@ import * as projects from "../controllers/project-office-projects.controller";
 import * as work from "../controllers/project-office-work.controller";
 import * as registers from "../controllers/project-office-registers.controller";
 import * as report from "../controllers/project-office-report.controller";
+import * as operations from "../controllers/project-office-operations.controller";
 
 // Monté après le socle authenticateToken (v1.routes.ts) → JWT requis d'office.
 // Feature gate PROJECT_OFFICE (fail-closed) : /access est la SEULE route hors gate — elle répond
@@ -24,6 +25,10 @@ router.get("/projects/:id", projects.getProject);
 router.patch("/projects/:id", projects.patchProject);
 router.post("/projects/:id/members", projects.postMember);
 router.delete("/projects/:id/members/:userId", projects.deleteMember);
+router.get("/projects/:id/operations", operations.getOperations);
+router.post("/projects/:id/budget-versions", operations.postBudget);
+router.post("/projects/:id/affaire-links", operations.postAffaireLink);
+router.delete("/projects/:id/affaire-links/:linkId", operations.deleteAffaireLink);
 
 // Work packages (lots / tâches)
 router.get("/work-packages", work.getWorkPackages);

--- a/src/module/project-office/services/project-office-operations.service.ts
+++ b/src/module/project-office/services/project-office-operations.service.ts
@@ -1,0 +1,209 @@
+import { HttpError } from "../../../utils/httpError";
+import { decimal, money } from "../../margin-engine/domain/margin-engine";
+import { svcGetMargin } from "../../margin-engine/services/margin-engine.service";
+import {
+  insertAuditLog,
+  insertProjectActivity,
+  isPgUniqueViolation,
+  withTransaction,
+  type AuditContext,
+} from "../repository/project-office.repository";
+import {
+  repoAffaireExists,
+  repoCreateProjectAffaireLink,
+  repoCreateProjectBudgetVersion,
+  repoDeleteProjectAffaireLink,
+  repoGetCurrentProjectBudget,
+  repoGetProjectBurnUp,
+  repoGetProjectRiskMatrix,
+  repoGetProjectTimeBudget,
+  repoListBlockingDependencies,
+  repoListOverdueMilestones,
+  repoListProjectAffaireLinks,
+} from "../repository/project-office-operations.repository";
+import type { Actor } from "../types/project-office.types";
+import type { CreateProjectBudgetDTO, LinkProjectAffaireDTO } from "../validators/project-office.validators";
+import { canManage, requireProjectAccess } from "./project-office-access.service";
+
+function addMoney(values: string[]): string {
+  return money(values.reduce((sum, value) => sum + decimal(value), 0n));
+}
+
+export async function getProjectOperations(actor: Actor, projectId: string) {
+  const access = await requireProjectAccess(actor, projectId, "read");
+  const [budget, links, timeBudget, overdueMilestones, blockingDependencies, burnUp, riskMatrix] = await Promise.all([
+    repoGetCurrentProjectBudget(projectId),
+    repoListProjectAffaireLinks(projectId),
+    repoGetProjectTimeBudget(projectId),
+    repoListOverdueMilestones(projectId),
+    repoListBlockingDependencies(projectId),
+    repoGetProjectBurnUp(projectId),
+    repoGetProjectRiskMatrix(projectId),
+  ]);
+
+  const affairCosts = await Promise.all(links.map(async (link) => {
+    const comparison = await svcGetMargin("AFFAIRE", String(link.affaire_id));
+    return {
+      ...link,
+      cost_total_ht: comparison.actual.cost_total_ht,
+      partial_cost_total_ht: comparison.actual.partial_cost_total_ht,
+      reliability: comparison.actual.reliability,
+      freshness_at: comparison.actual.freshness_at,
+      missing_inputs: comparison.actual.missing_inputs,
+      calculation_hash: comparison.actual.calculation_hash,
+    };
+  }));
+
+  const completeCosts = affairCosts.every((row) => row.cost_total_ht !== null);
+  const consumed = affairCosts.length === 0
+    ? null
+    : completeCosts
+      ? addMoney(affairCosts.map((row) => row.cost_total_ht!))
+      : null;
+  const partialConsumed = affairCosts.length === 0
+    ? null
+    : addMoney(affairCosts.map((row) => row.partial_cost_total_ht));
+  const comparable = Boolean(budget && budget.currency === "EUR" && consumed !== null);
+  const remaining = comparable ? money(decimal(budget!.amount) - decimal(consumed!)) : null;
+  const quality: string[] = [];
+  if (!budget) quality.push("PROJECT_BUDGET_MISSING");
+  if (links.length === 0) quality.push("PROJECT_AFFAIRE_LINK_MISSING");
+  if (links.length > 0 && !completeCosts) quality.push("ACTUAL_COSTS_PARTIAL");
+  if (budget && budget.currency !== "EUR") quality.push("BUDGET_CURRENCY_NOT_COMPARABLE");
+  if (timeBudget.planned_missing_count > 0) quality.push("PLANNED_HOURS_PARTIAL");
+  if (timeBudget.consumed_missing_count > 0) quality.push("CONSUMED_HOURS_PARTIAL");
+
+  return {
+    generated_at: new Date().toISOString(),
+    permissions: { can_manage: canManage(access) },
+    financial: {
+      budget,
+      consumed_ht: consumed,
+      partial_consumed_ht: partialConsumed,
+      remaining_ht: remaining,
+      currency: budget?.currency ?? "EUR",
+      reliability: !budget || links.length === 0 ? "UNAVAILABLE" : completeCosts ? "ACTUAL" : "PARTIAL",
+      definition: "Budget courant moins coûts constatés complets des affaires liées. Un coût partiel n'est jamais soustrait comme s'il était complet.",
+      period: budget ? { start: budget.effective_from, end: budget.effective_to } : null,
+      source: "project_budget_versions + margin-engine(AFFAIRE, ACTUAL)",
+      freshness_at: affairCosts.map((row) => row.freshness_at).filter(Boolean).sort()[0] ?? budget?.observed_at ?? null,
+      affaires: affairCosts,
+    },
+    source_links: affairCosts.map((row) => ({
+      entity_type: "AFFAIRE" as const,
+      entity_id: String(row.affaire_id),
+      label: row.affaire_reference,
+      href: `/affaires/${row.affaire_id}`,
+      source_ref: row.source_ref,
+      calculation_hash: row.calculation_hash,
+    })),
+    hours: {
+      ...timeBudget,
+      unit: "hour",
+      reliability: timeBudget.planned_missing_count === 0 && timeBudget.consumed_missing_count === 0 ? "VERIFIED" : "PARTIAL",
+      definition: "Somme des heures prévues et consommées renseignées sur les lots de travail non annulés.",
+      source: "project_work_packages",
+    },
+    overdue_milestones: overdueMilestones,
+    blocking_dependencies: blockingDependencies,
+    burn_up: {
+      points: burnUp,
+      unit: "work_package",
+      reliability: "ESTIMATED",
+      definition: "Cumul prévu par échéance et cumul terminé selon la dernière date de mise à jour; l'historique de terminaison antérieur n'est pas reconstruit.",
+      source: "project_work_packages",
+    },
+    risk_matrix: riskMatrix,
+    data_quality: quality,
+  };
+}
+
+export async function createProjectBudget(
+  actor: Actor,
+  projectId: string,
+  input: CreateProjectBudgetDTO,
+  audit: AuditContext,
+) {
+  await requireProjectAccess(actor, projectId, "manage");
+  return withTransaction(async (tx) => {
+    const current = await repoGetCurrentProjectBudget(projectId, tx);
+    if (current && input.effective_from <= current.effective_from) {
+      throw new HttpError(409, "PO_BUDGET_EFFECTIVE_DATE_INVALID", "La nouvelle version doit commencer après la version courante.");
+    }
+    const created = await repoCreateProjectBudgetVersion(tx, {
+      project_id: projectId,
+      amount: input.amount,
+      currency: input.currency,
+      effective_from: input.effective_from,
+      definition: input.definition,
+      source_type: input.source_type,
+      source_ref: input.source_ref ?? null,
+      observed_at: input.observed_at,
+      reliability: input.reliability,
+      supersedes_id: current?.id ?? null,
+      created_by: actor.id,
+    });
+    await insertProjectActivity(tx, {
+      project_id: projectId, entity_type: "budget", entity_id: created.id, action: "version.create",
+      actor_id: actor.id, before_json: current, after_json: created,
+    });
+    await insertAuditLog(tx, audit, {
+      action: "project-office.budget.version.create", entity_type: "project_budget_versions", entity_id: created.id,
+      details: { project_id: projectId, currency: created.currency, effective_from: created.effective_from, supersedes_id: created.supersedes_id },
+    });
+    return created;
+  });
+}
+
+export async function linkProjectAffaire(
+  actor: Actor,
+  projectId: string,
+  input: LinkProjectAffaireDTO,
+  audit: AuditContext,
+) {
+  await requireProjectAccess(actor, projectId, "manage");
+  if (!(await repoAffaireExists(input.affaire_id))) {
+    throw new HttpError(404, "PO_AFFAIRE_NOT_FOUND", "Affaire introuvable.");
+  }
+  try {
+    return await withTransaction(async (tx) => {
+      const link = await repoCreateProjectAffaireLink(tx, {
+        project_id: projectId, affaire_id: input.affaire_id, source_ref: input.source_ref ?? null, created_by: actor.id,
+      });
+      await insertProjectActivity(tx, {
+        project_id: projectId, entity_type: "affaire_link", entity_id: link.id, action: "create",
+        actor_id: actor.id, after_json: { affaire_id: link.affaire_id, affaire_reference: link.affaire_reference },
+      });
+      await insertAuditLog(tx, audit, {
+        action: "project-office.affaire.link", entity_type: "project_affaire_links", entity_id: link.id,
+        details: { project_id: projectId, affaire_id: link.affaire_id },
+      });
+      return link;
+    });
+  } catch (error) {
+    if (isPgUniqueViolation(error)) throw new HttpError(409, "PO_AFFAIRE_ALREADY_LINKED", "Cette affaire est déjà liée au projet.");
+    throw error;
+  }
+}
+
+export async function unlinkProjectAffaire(
+  actor: Actor,
+  projectId: string,
+  linkId: string,
+  audit: AuditContext,
+) {
+  await requireProjectAccess(actor, projectId, "manage");
+  return withTransaction(async (tx) => {
+    const removed = await repoDeleteProjectAffaireLink(tx, projectId, linkId);
+    if (!removed) throw new HttpError(404, "PO_AFFAIRE_LINK_NOT_FOUND", "Lien affaire introuvable.");
+    await insertProjectActivity(tx, {
+      project_id: projectId, entity_type: "affaire_link", entity_id: linkId, action: "delete",
+      actor_id: actor.id, before_json: { link_id: linkId },
+    });
+    await insertAuditLog(tx, audit, {
+      action: "project-office.affaire.unlink", entity_type: "project_affaire_links", entity_id: linkId,
+      details: { project_id: projectId },
+    });
+    return { removed: true };
+  });
+}

--- a/src/module/project-office/validators/project-office.validators.ts
+++ b/src/module/project-office/validators/project-office.validators.ts
@@ -31,6 +31,28 @@ const httpUrl = z.string().trim().url().max(2048).refine((u) => /^https?:\/\//i.
 
 export const uuidParamsSchema = z.object({ id: z.string().uuid() }).strict();
 export const projectIdParamsSchema = z.object({ id: z.string().uuid() }).strict();
+export const projectAffaireLinkParamsSchema = z.object({
+  id: z.string().uuid(),
+  linkId: z.string().uuid(),
+}).strict();
+
+export const createProjectBudgetSchema = z.object({
+  amount: z.string().regex(/^\d{1,12}(?:\.\d{1,6})?$/, "Montant décimal positif attendu"),
+  currency: z.string().trim().toUpperCase().regex(/^[A-Z]{3}$/).default("EUR"),
+  effective_from: isoDate,
+  definition: trimmed(500),
+  source_type: z.enum(["DECLARATION", "CONTRACT", "DOCUMENT", "OTHER"]),
+  source_ref: z.string().trim().max(500).nullish(),
+  observed_at: z.string().datetime({ offset: true }),
+  reliability: z.enum(["DECLARED", "VERIFIED", "ESTIMATED"]),
+}).strict();
+export type CreateProjectBudgetDTO = z.infer<typeof createProjectBudgetSchema>;
+
+export const linkProjectAffaireSchema = z.object({
+  affaire_id: z.number().int().positive(),
+  source_ref: z.string().trim().max(500).nullish(),
+}).strict();
+export type LinkProjectAffaireDTO = z.infer<typeof linkProjectAffaireSchema>;
 
 export const paginationQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),

--- a/src/module/temps-deplacements/controllers/temps-deplacements-operations.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-operations.controller.ts
@@ -1,0 +1,62 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as service from "../services/temps-deplacements-operations.service";
+import {
+  absenceStatusQuerySchema,
+  createAbsenceSchema,
+  createKilometerRateSchema,
+  createPeriodClosureSchema,
+  uuidParamsSchema,
+} from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+export const postAbsence = asyncHandler(async (req: Request, res: Response) => {
+  const input = createAbsenceSchema.parse(req.body);
+  res.status(201).json(await service.createMyAbsence(requireUser(req), input, buildAuditContext(req)));
+});
+
+export const getMyAbsences = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await service.listMyAbsences(requireUser(req)));
+});
+
+export const getTeamAbsences = asyncHandler(async (req: Request, res: Response) => {
+  const { status } = absenceStatusQuerySchema.parse(req.query);
+  res.json(await service.listTeamAbsences(requireUser(req), status));
+});
+
+export const approveAbsence = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await service.decideAbsence(requireUser(req), id, "APPROVED", buildAuditContext(req)));
+});
+
+export const rejectAbsence = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await service.decideAbsence(requireUser(req), id, "REJECTED", buildAuditContext(req)));
+});
+
+export const getOperationsQueue = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await service.getOperationsQueue(requireUser(req)));
+});
+
+export const getClosures = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await service.listClosures(requireUser(req)));
+});
+
+export const postClosure = asyncHandler(async (req: Request, res: Response) => {
+  const input = createPeriodClosureSchema.parse(req.body);
+  res.status(201).json(await service.createPeriodClosure(requireUser(req), input, buildAuditContext(req)));
+});
+
+export const reopenClosure = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await service.reopenPeriodClosure(requireUser(req), id, buildAuditContext(req)));
+});
+
+export const getKilometerRates = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await service.listKilometerRates(requireUser(req)));
+});
+
+export const postKilometerRate = asyncHandler(async (req: Request, res: Response) => {
+  const input = createKilometerRateSchema.parse(req.body);
+  res.status(201).json(await service.createKilometerRate(requireUser(req), input, buildAuditContext(req)));
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { asyncHandler } from "../../../utils/asyncHandler";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import { isHrPrivileged } from "../domain/temps-deplacements-policy";
 import type { AuditContext } from "../repository/temps-deplacements.repository";
 import * as repo from "../repository/temps-deplacements.repository";
 import * as svc from "../services/temps-deplacements.service";
@@ -52,11 +52,7 @@ export function requireUser(req: Request): { id: number; role: string } {
 }
 
 // RBAC lecture d'un employé : soi-même, OU son manager, OU un rôle RH/Direction/Admin.
-export function isHrPrivileged(role: string): boolean {
-  if (hasGrantedAccountModuleAccess()) return true;
-  const r = role.toLowerCase();
-  return r.includes("rh") || r.includes("directeur") || r.includes("direction") || r.includes("administrateur");
-}
+export { isHrPrivileged };
 export function validateManagerScope(reqUser: { id: number; role: string }, target: HrEmployeeLite): boolean {
   return target.manager_user_id !== null && target.manager_user_id === reqUser.id;
 }

--- a/src/module/temps-deplacements/domain/temps-deplacements-policy.ts
+++ b/src/module/temps-deplacements/domain/temps-deplacements-policy.ts
@@ -1,0 +1,25 @@
+import { getAccountModuleAccessContext } from "../../access-control/context/account-module-access.context";
+import { HttpError } from "../../../utils/httpError";
+import { repoFindActivePeriodClosure } from "../repository/temps-deplacements-operations.repository";
+
+export type HrActor = { id: number; role: string };
+
+export function isHrPrivileged(role: string): boolean {
+  if (getAccountModuleAccessContext()?.elevated === true) return true;
+  const normalized = role.toLowerCase();
+  return normalized.includes("rh")
+    || normalized.includes("directeur")
+    || normalized.includes("direction")
+    || normalized.includes("administrateur");
+}
+
+export async function assertPeriodOpen(employeeId: string, from: string, to = from): Promise<void> {
+  const closure = await repoFindActivePeriodClosure(employeeId, from, to);
+  if (closure) {
+    throw new HttpError(
+      409,
+      "HR_PERIOD_CLOSED",
+      `Période clôturée du ${closure.period_start} au ${closure.period_end}. Demandez une réouverture RH avant toute correction.`,
+    );
+  }
+}

--- a/src/module/temps-deplacements/repository/temps-deplacements-km.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-km.repository.ts
@@ -23,6 +23,9 @@ export interface KmEntry {
   created_at: string;
   validated_by: number | null;
   validated_at: string | null;
+  rate_version_id: string | null;
+  cost_amount: number | null;
+  cost_currency: string | null;
 }
 export type KmEntryWithEmployee = KmEntry & { matricule: string };
 
@@ -44,7 +47,8 @@ export interface KmEntryInput {
 
 const KM_COLS = `id::text, employee_id::text, date::text, type::text, vehicle_id::text,
   start_location, end_location, start_odometer, end_odometer, distance_km,
-  affaire_id, client_id, fournisseur_id, status::text, created_at::text, validated_by, validated_at::text`;
+  affaire_id, client_id, fournisseur_id, status::text, created_at::text, validated_by, validated_at::text,
+  rate_version_id::text, cost_amount, cost_currency`;
 
 function num(v: unknown): number | null {
   if (v === null || v === undefined) return null;
@@ -70,6 +74,9 @@ function mapKm(r: Record<string, unknown>): KmEntry {
     created_at: String(r.created_at),
     validated_by: num(r.validated_by),
     validated_at: (r.validated_at as string | null) ?? null,
+    rate_version_id: (r.rate_version_id as string | null) ?? null,
+    cost_amount: num(r.cost_amount),
+    cost_currency: r.cost_currency == null ? null : String(r.cost_currency).trim(),
   };
 }
 
@@ -116,11 +123,23 @@ export async function repoSubmitKmEntry(q: DbQueryer, id: string): Promise<KmEnt
 }
 
 // SUBMITTED → VALIDATED | REJECTED (par le responsable). Ne modifie que si SUBMITTED.
-export async function repoDecideKmEntry(q: DbQueryer, id: string, status: "VALIDATED" | "REJECTED", validatedBy: number): Promise<KmEntry | null> {
+export async function repoDecideKmEntry(
+  q: DbQueryer,
+  id: string,
+  status: "VALIDATED" | "REJECTED",
+  validatedBy: number,
+  rate: { id: string; currency: string } | null,
+): Promise<KmEntry | null> {
   const res = await q.query(
-    `UPDATE public.hr_kilometer_entries SET status=$2::hr_km_status, validated_by=$3, validated_at=now()
-      WHERE id=$1::uuid AND status='SUBMITTED'::hr_km_status RETURNING ${KM_COLS}`,
-    [id, status, validatedBy]
+    `UPDATE public.hr_kilometer_entries k
+        SET status=$2::hr_km_status, validated_by=$3, validated_at=now(),
+            rate_version_id=CASE WHEN $2='VALIDATED' THEN $4::uuid ELSE NULL END,
+            cost_amount=CASE WHEN $2='VALIDATED' THEN round(k.distance_km*(
+              SELECT r.rate_per_km FROM public.hr_kilometer_rate_versions r WHERE r.id=$4::uuid
+            ),6) ELSE NULL END,
+            cost_currency=CASE WHEN $2='VALIDATED' THEN $5 ELSE NULL END
+      WHERE k.id=$1::uuid AND k.status='SUBMITTED'::hr_km_status RETURNING ${KM_COLS}`,
+    [id, status, validatedBy, rate?.id ?? null, rate?.currency ?? null]
   );
   return res.rows[0] ? mapKm(res.rows[0]) : null;
 }

--- a/src/module/temps-deplacements/repository/temps-deplacements-operations.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-operations.repository.ts
@@ -1,0 +1,361 @@
+import pool from "../../../config/database";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+export type HrAbsenceStatus = "REQUESTED" | "APPROVED" | "REJECTED" | "CANCELLED";
+export type HrAbsenceRecord = {
+  id: string;
+  employee_id: string;
+  absence_date: string;
+  minutes: number;
+  absence_type: "PAID_LEAVE" | "SICK_LEAVE" | "RTT" | "TRAINING" | "OTHER";
+  timezone: string;
+  status: HrAbsenceStatus;
+  reason: string;
+  source_ref: string | null;
+  requested_by: number;
+  decided_by: number | null;
+  decided_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type HrPeriodClosure = {
+  id: string;
+  period_start: string;
+  period_end: string;
+  employee_id: string | null;
+  timezone: string;
+  status: "CLOSED" | "REOPENED";
+  reason: string;
+  closed_by: number;
+  closed_at: string;
+  reopened_by: number | null;
+  reopened_at: string | null;
+};
+
+export type HrKilometerRate = {
+  id: string;
+  owner_type: "COMPANY" | "PERSONAL";
+  rate_per_km: string;
+  currency: string;
+  effective_from: string;
+  effective_to: string | null;
+  definition: string;
+  source_type: "DECLARATION" | "LEGAL_SCALE" | "CONTRACT" | "OTHER";
+  source_ref: string | null;
+  observed_at: string;
+  reliability: "DECLARED" | "VERIFIED" | "ESTIMATED";
+  supersedes_id: string | null;
+  created_by: number;
+  created_at: string;
+};
+
+const ABSENCE_COLUMNS = `id::text, employee_id::text, absence_date::text, minutes, absence_type,
+  timezone, status, reason, source_ref, requested_by, decided_by, decided_at::text,
+  created_at::text, updated_at::text`;
+const ABSENCE_COLUMNS_A = `a.id::text, a.employee_id::text, a.absence_date::text, a.minutes, a.absence_type,
+  a.timezone, a.status, a.reason, a.source_ref, a.requested_by, a.decided_by, a.decided_at::text,
+  a.created_at::text, a.updated_at::text`;
+const CLOSURE_COLUMNS = `id::text, period_start::text, period_end::text, employee_id::text,
+  timezone, status, reason, closed_by, closed_at::text, reopened_by, reopened_at::text`;
+const RATE_COLUMNS = `id::text, owner_type::text, rate_per_km::text, currency, effective_from::text,
+  effective_to::text, definition, source_type, source_ref, observed_at::text, reliability,
+  supersedes_id::text, created_by, created_at::text`;
+const RATE_COLUMNS_R = `r.id::text, r.owner_type::text, r.rate_per_km::text, r.currency, r.effective_from::text,
+  r.effective_to::text, r.definition, r.source_type, r.source_ref, r.observed_at::text, r.reliability,
+  r.supersedes_id::text, r.created_by, r.created_at::text`;
+
+function mapAbsence(row: Record<string, unknown>): HrAbsenceRecord {
+  return {
+    id: String(row.id), employee_id: String(row.employee_id), absence_date: String(row.absence_date),
+    minutes: Number(row.minutes), absence_type: row.absence_type as HrAbsenceRecord["absence_type"],
+    timezone: String(row.timezone), status: row.status as HrAbsenceStatus, reason: String(row.reason),
+    source_ref: row.source_ref == null ? null : String(row.source_ref), requested_by: Number(row.requested_by),
+    decided_by: row.decided_by == null ? null : Number(row.decided_by),
+    decided_at: row.decided_at == null ? null : String(row.decided_at), created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  };
+}
+
+function mapClosure(row: Record<string, unknown>): HrPeriodClosure {
+  return {
+    id: String(row.id), period_start: String(row.period_start), period_end: String(row.period_end),
+    employee_id: row.employee_id == null ? null : String(row.employee_id), timezone: String(row.timezone),
+    status: row.status as HrPeriodClosure["status"], reason: String(row.reason), closed_by: Number(row.closed_by),
+    closed_at: String(row.closed_at), reopened_by: row.reopened_by == null ? null : Number(row.reopened_by),
+    reopened_at: row.reopened_at == null ? null : String(row.reopened_at),
+  };
+}
+
+function mapRate(row: Record<string, unknown>): HrKilometerRate {
+  return {
+    id: String(row.id), owner_type: row.owner_type as HrKilometerRate["owner_type"],
+    rate_per_km: String(row.rate_per_km), currency: String(row.currency).trim(),
+    effective_from: String(row.effective_from), effective_to: row.effective_to == null ? null : String(row.effective_to),
+    definition: String(row.definition), source_type: row.source_type as HrKilometerRate["source_type"],
+    source_ref: row.source_ref == null ? null : String(row.source_ref), observed_at: String(row.observed_at),
+    reliability: row.reliability as HrKilometerRate["reliability"],
+    supersedes_id: row.supersedes_id == null ? null : String(row.supersedes_id),
+    created_by: Number(row.created_by), created_at: String(row.created_at),
+  };
+}
+
+export async function repoFindActivePeriodClosure(
+  employeeId: string,
+  from: string,
+  to = from,
+  q: DbQueryer = pool,
+): Promise<HrPeriodClosure | null> {
+  const result = await q.query(
+    `SELECT ${CLOSURE_COLUMNS}
+       FROM public.hr_period_closures
+      WHERE status='CLOSED'
+        AND (employee_id IS NULL OR employee_id=$1::uuid)
+        AND period_start <= $3::date AND period_end >= $2::date
+      ORDER BY employee_id NULLS LAST, closed_at DESC LIMIT 1`,
+    [employeeId, from, to],
+  );
+  return result.rows[0] ? mapClosure(result.rows[0]) : null;
+}
+
+export async function repoResolveAdjustmentPeriod(
+  targetType: "EVENT" | "DAY" | "WEEK",
+  targetId: string,
+  q: DbQueryer = pool,
+): Promise<{ employee_id: string; from: string; to: string } | null> {
+  const queries = {
+    EVENT: `SELECT employee_id::text, (event_time AT TIME ZONE 'Europe/Paris')::date::text AS from,
+                   (event_time AT TIME ZONE 'Europe/Paris')::date::text AS to
+              FROM public.hr_time_events WHERE id=$1::uuid`,
+    DAY: `SELECT employee_id::text, date::text AS from, date::text AS to
+            FROM public.hr_timesheet_days WHERE id=$1::uuid`,
+    WEEK: `SELECT employee_id::text, week_start::text AS from, week_end::text AS to
+             FROM public.hr_timesheet_weeks WHERE id=$1::uuid`,
+  } as const;
+  const result = await q.query(queries[targetType], [targetId]);
+  const row = result.rows[0];
+  return row ? { employee_id: String(row.employee_id), from: String(row.from), to: String(row.to) } : null;
+}
+
+export async function repoGetClosurePreflight(
+  input: { employee_id: string | null; period_start: string; period_end: string },
+  q: DbQueryer = pool,
+) {
+  const params = [input.employee_id, input.period_start, input.period_end];
+  const scope = `($1::uuid IS NULL OR employee_id=$1::uuid)`;
+  const dayScope = `($1::uuid IS NULL OR d.employee_id=$1::uuid)`;
+  const weekScope = `($1::uuid IS NULL OR w.employee_id=$1::uuid)`;
+  const eventScope = `($1::uuid IS NULL OR e.employee_id=$1::uuid)`;
+  const [days, weeks, anomalies, adjustments, km, absences] = await Promise.all([
+    q.query(`SELECT COUNT(*)::int AS count FROM public.hr_timesheet_days WHERE ${scope} AND date BETWEEN $2::date AND $3::date AND validation_status NOT IN ('VALIDATED','EXPORTED')`, params),
+    q.query(`SELECT COUNT(*)::int AS count FROM public.hr_timesheet_weeks WHERE ${scope} AND week_start <= $3::date AND week_end >= $2::date AND validation_status NOT IN ('VALIDATED','EXPORTED')`, params),
+    q.query(`SELECT COUNT(*)::int AS count FROM public.hr_time_anomalies WHERE ${scope} AND date BETWEEN $2::date AND $3::date AND resolved_at IS NULL`, params),
+    q.query(`SELECT COUNT(*)::int AS count FROM public.hr_time_adjustments a WHERE a.status='REQUESTED' AND EXISTS (
+      SELECT 1 FROM public.hr_timesheet_days d WHERE a.target_type='DAY' AND d.id=a.target_id AND ${dayScope} AND d.date BETWEEN $2::date AND $3::date
+      UNION ALL SELECT 1 FROM public.hr_timesheet_weeks w WHERE a.target_type='WEEK' AND w.id=a.target_id AND ${weekScope} AND w.week_start <= $3::date AND w.week_end >= $2::date
+      UNION ALL SELECT 1 FROM public.hr_time_events e WHERE a.target_type='EVENT' AND e.id=a.target_id AND ${eventScope} AND (e.event_time AT TIME ZONE 'Europe/Paris')::date BETWEEN $2::date AND $3::date
+    )`, params),
+    q.query(`SELECT COUNT(*)::int AS count FROM public.hr_kilometer_entries WHERE ${scope} AND date BETWEEN $2::date AND $3::date AND status IN ('DRAFT','SUBMITTED')`, params),
+    q.query(`SELECT COUNT(*)::int AS count FROM public.hr_absence_records WHERE ${scope} AND absence_date BETWEEN $2::date AND $3::date AND status='REQUESTED'`, params),
+  ]);
+  return {
+    unvalidated_days: Number(days.rows[0]?.count ?? 0), unvalidated_weeks: Number(weeks.rows[0]?.count ?? 0),
+    unresolved_anomalies: Number(anomalies.rows[0]?.count ?? 0), pending_adjustments: Number(adjustments.rows[0]?.count ?? 0),
+    pending_kilometers: Number(km.rows[0]?.count ?? 0), pending_absences: Number(absences.rows[0]?.count ?? 0),
+  };
+}
+
+export async function repoCreatePeriodClosure(
+  q: DbQueryer,
+  input: { period_start: string; period_end: string; employee_id: string | null; timezone: string; reason: string; closed_by: number },
+): Promise<HrPeriodClosure> {
+  const overlap = await q.query(
+    `SELECT id FROM public.hr_period_closures WHERE status='CLOSED'
+      AND (employee_id IS NULL OR $1::uuid IS NULL OR employee_id=$1::uuid)
+      AND period_start <= $3::date AND period_end >= $2::date LIMIT 1 FOR UPDATE`,
+    [input.employee_id, input.period_start, input.period_end],
+  );
+  if (overlap.rows[0]) throw Object.assign(new Error("period overlap"), { code: "HR_PERIOD_OVERLAP" });
+  const result = await q.query(
+    `INSERT INTO public.hr_period_closures(period_start,period_end,employee_id,timezone,reason,closed_by)
+     VALUES ($1::date,$2::date,$3::uuid,$4,$5,$6) RETURNING ${CLOSURE_COLUMNS}`,
+    [input.period_start, input.period_end, input.employee_id, input.timezone, input.reason, input.closed_by],
+  );
+  return mapClosure(result.rows[0]);
+}
+
+export async function repoListPeriodClosures(q: DbQueryer = pool): Promise<HrPeriodClosure[]> {
+  const result = await q.query(`SELECT ${CLOSURE_COLUMNS} FROM public.hr_period_closures ORDER BY period_start DESC, closed_at DESC LIMIT 500`);
+  return result.rows.map(mapClosure);
+}
+
+export async function repoGetPeriodClosure(id: string, q: DbQueryer = pool): Promise<HrPeriodClosure | null> {
+  const result = await q.query(`SELECT ${CLOSURE_COLUMNS} FROM public.hr_period_closures WHERE id=$1::uuid LIMIT 1`, [id]);
+  return result.rows[0] ? mapClosure(result.rows[0]) : null;
+}
+
+export async function repoReopenPeriodClosure(q: DbQueryer, id: string, actorId: number): Promise<HrPeriodClosure | null> {
+  const result = await q.query(
+    `UPDATE public.hr_period_closures SET status='REOPENED',reopened_by=$2,reopened_at=now()
+      WHERE id=$1::uuid AND status='CLOSED' RETURNING ${CLOSURE_COLUMNS}`,
+    [id, actorId],
+  );
+  return result.rows[0] ? mapClosure(result.rows[0]) : null;
+}
+
+export async function repoCreateAbsence(
+  q: DbQueryer,
+  input: Omit<HrAbsenceRecord, "id" | "status" | "decided_by" | "decided_at" | "created_at" | "updated_at">,
+): Promise<HrAbsenceRecord> {
+  const result = await q.query(
+    `INSERT INTO public.hr_absence_records(employee_id,absence_date,minutes,absence_type,timezone,reason,source_ref,requested_by)
+     VALUES ($1::uuid,$2::date,$3,$4,$5,$6,$7,$8) RETURNING ${ABSENCE_COLUMNS}`,
+    [input.employee_id, input.absence_date, input.minutes, input.absence_type, input.timezone, input.reason, input.source_ref, input.requested_by],
+  );
+  return mapAbsence(result.rows[0]);
+}
+
+export async function repoGetAbsence(id: string, q: DbQueryer = pool): Promise<HrAbsenceRecord | null> {
+  const result = await q.query(`SELECT ${ABSENCE_COLUMNS} FROM public.hr_absence_records WHERE id=$1::uuid LIMIT 1`, [id]);
+  return result.rows[0] ? mapAbsence(result.rows[0]) : null;
+}
+
+export async function repoListAbsences(
+  input: { employee_id?: string; manager_user_id?: number; privileged?: boolean; status?: HrAbsenceStatus },
+  q: DbQueryer = pool,
+): Promise<Array<HrAbsenceRecord & { matricule: string }>> {
+  const result = await q.query(
+    `SELECT ${ABSENCE_COLUMNS_A}, e.matricule
+       FROM public.hr_absence_records a JOIN public.hr_employees e ON e.id=a.employee_id
+      WHERE ($1::uuid IS NULL OR a.employee_id=$1::uuid)
+        AND ($2::int IS NULL OR $3::boolean OR e.manager_user_id=$2::int)
+        AND ($4::text IS NULL OR a.status=$4)
+      ORDER BY a.absence_date DESC,a.created_at DESC LIMIT 500`,
+    [input.employee_id ?? null, input.manager_user_id ?? null, input.privileged ?? false, input.status ?? null],
+  );
+  return result.rows.map((row: Record<string, unknown>) => ({ ...mapAbsence(row), matricule: String(row.matricule) }));
+}
+
+export async function repoDecideAbsence(
+  q: DbQueryer,
+  id: string,
+  status: "APPROVED" | "REJECTED",
+  actorId: number,
+): Promise<HrAbsenceRecord | null> {
+  const result = await q.query(
+    `UPDATE public.hr_absence_records SET status=$2,decided_by=$3,decided_at=now(),updated_at=now()
+      WHERE id=$1::uuid AND status='REQUESTED' RETURNING ${ABSENCE_COLUMNS}`,
+    [id, status, actorId],
+  );
+  return result.rows[0] ? mapAbsence(result.rows[0]) : null;
+}
+
+export async function repoSumApprovedAbsenceMinutes(
+  employeeId: string,
+  from: string,
+  to: string,
+  q: DbQueryer = pool,
+): Promise<number> {
+  const result = await q.query(
+    `SELECT COALESCE(SUM(minutes),0)::int AS minutes FROM public.hr_absence_records
+      WHERE employee_id=$1::uuid AND absence_date BETWEEN $2::date AND $3::date AND status='APPROVED'`,
+    [employeeId, from, to],
+  );
+  return Number(result.rows[0]?.minutes ?? 0);
+}
+
+export async function repoGetCurrentKilometerRate(ownerType: "COMPANY" | "PERSONAL", q: DbQueryer = pool) {
+  const result = await q.query(
+    `SELECT ${RATE_COLUMNS} FROM public.hr_kilometer_rate_versions
+      WHERE owner_type=$1::public.hr_vehicle_owner AND effective_to IS NULL ORDER BY effective_from DESC LIMIT 1`,
+    [ownerType],
+  );
+  return result.rows[0] ? mapRate(result.rows[0]) : null;
+}
+
+export async function repoGetEffectiveKilometerRate(vehicleId: string | null, date: string, q: DbQueryer = pool) {
+  if (!vehicleId) return null;
+  const result = await q.query(
+    `SELECT ${RATE_COLUMNS_R}
+       FROM public.hr_vehicles v
+       JOIN public.hr_kilometer_rate_versions r ON r.owner_type=v.owner_type
+      WHERE v.id=$1::uuid AND r.effective_from <= $2::date
+        AND (r.effective_to IS NULL OR r.effective_to >= $2::date)
+      ORDER BY r.effective_from DESC LIMIT 1`,
+    [vehicleId, date],
+  );
+  return result.rows[0] ? mapRate(result.rows[0]) : null;
+}
+
+export async function repoCreateKilometerRate(
+  q: DbQueryer,
+  input: Omit<HrKilometerRate, "id" | "effective_to" | "supersedes_id" | "created_at"> & { supersedes_id: string | null },
+) {
+  if (input.supersedes_id) {
+    await q.query(
+      `UPDATE public.hr_kilometer_rate_versions SET effective_to=($2::date-INTERVAL '1 day')::date
+        WHERE id=$1::uuid AND effective_to IS NULL`,
+      [input.supersedes_id, input.effective_from],
+    );
+  }
+  const result = await q.query(
+    `INSERT INTO public.hr_kilometer_rate_versions(owner_type,rate_per_km,currency,effective_from,definition,
+       source_type,source_ref,observed_at,reliability,supersedes_id,created_by)
+     VALUES ($1::public.hr_vehicle_owner,$2::numeric,$3,$4::date,$5,$6,$7,$8::timestamptz,$9,$10::uuid,$11)
+     RETURNING ${RATE_COLUMNS}`,
+    [input.owner_type, input.rate_per_km, input.currency, input.effective_from, input.definition,
+      input.source_type, input.source_ref, input.observed_at, input.reliability, input.supersedes_id, input.created_by],
+  );
+  return mapRate(result.rows[0]);
+}
+
+export async function repoListKilometerRates(q: DbQueryer = pool): Promise<HrKilometerRate[]> {
+  const result = await q.query(`SELECT ${RATE_COLUMNS} FROM public.hr_kilometer_rate_versions ORDER BY owner_type,effective_from DESC`);
+  return result.rows.map(mapRate);
+}
+
+export async function repoGetTeamOperationsQueue(
+  input: { manager_user_id: number; privileged: boolean },
+  q: DbQueryer = pool,
+) {
+  const params = [input.privileged, input.manager_user_id];
+  const employeeScope = `($1::boolean OR e.manager_user_id=$2::int)`;
+  const [days, anomalies, adjustments, absences, duplicates, unpriced] = await Promise.all([
+    q.query(`SELECT d.id::text,e.id::text AS employee_id,e.matricule,d.date::text,d.validation_status::text
+      FROM public.hr_timesheet_days d JOIN public.hr_employees e ON e.id=d.employee_id
+      WHERE ${employeeScope} AND d.date<=CURRENT_DATE AND d.validation_status IN ('DRAFT','TO_REVIEW')
+      ORDER BY d.date,e.matricule LIMIT 500`, params),
+    q.query(`SELECT a.id::text,e.id::text AS employee_id,e.matricule,a.date::text,a.anomaly_type::text,a.severity::text,a.message
+      FROM public.hr_time_anomalies a JOIN public.hr_employees e ON e.id=a.employee_id
+      WHERE ${employeeScope} AND a.resolved_at IS NULL ORDER BY a.date,a.severity DESC LIMIT 500`, params),
+    q.query(`SELECT a.id::text,e.id::text AS employee_id,e.matricule,a.created_at::text,a.reason
+      FROM public.hr_time_adjustments a
+      LEFT JOIN public.hr_time_events ev ON a.target_type='EVENT' AND ev.id=a.target_id
+      LEFT JOIN public.hr_timesheet_days d ON a.target_type='DAY' AND d.id=a.target_id
+      LEFT JOIN public.hr_timesheet_weeks w ON a.target_type='WEEK' AND w.id=a.target_id
+      JOIN public.hr_employees e ON e.id=COALESCE(ev.employee_id,d.employee_id,w.employee_id)
+      WHERE ${employeeScope} AND a.status='REQUESTED' ORDER BY a.created_at LIMIT 500`, params),
+    q.query(`SELECT a.id::text,e.id::text AS employee_id,e.matricule,a.absence_date::text AS date,a.minutes,a.absence_type,a.reason
+      FROM public.hr_absence_records a JOIN public.hr_employees e ON e.id=a.employee_id
+      WHERE ${employeeScope} AND a.status='REQUESTED' ORDER BY a.absence_date,e.matricule LIMIT 500`, params),
+    q.query(`SELECT (array_agg(k.id ORDER BY k.id))[1]::text AS id,e.id::text AS employee_id,e.matricule,k.date::text,k.distance_km::text,
+                    count(*)::int AS duplicate_count
+      FROM public.hr_kilometer_entries k JOIN public.hr_employees e ON e.id=k.employee_id
+      WHERE ${employeeScope} AND k.status<>'REJECTED'
+      GROUP BY e.id,e.matricule,k.date,k.distance_km,coalesce(k.start_location,''),coalesce(k.end_location,''),coalesce(k.affaire_id,0)
+      HAVING count(*)>1 ORDER BY k.date,e.matricule LIMIT 500`, params),
+    q.query(`SELECT k.id::text,e.id::text AS employee_id,e.matricule,k.date::text,k.distance_km::text
+      FROM public.hr_kilometer_entries k JOIN public.hr_employees e ON e.id=k.employee_id
+      WHERE ${employeeScope} AND k.status='VALIDATED' AND k.cost_amount IS NULL
+      ORDER BY k.date,e.matricule LIMIT 500`, params),
+  ]);
+  return {
+    generated_at: new Date().toISOString(),
+    unvalidated_timesheets: days.rows,
+    unresolved_time_anomalies: anomalies.rows,
+    pending_adjustments: adjustments.rows,
+    pending_absences: absences.rows,
+    duplicate_kilometers: duplicates.rows,
+    unpriced_kilometers: unpriced.rows,
+  };
+}

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -5,6 +5,7 @@ import * as dev from "../controllers/temps-deplacements-devices.controller";
 import * as exp from "../controllers/temps-deplacements-exports.controller";
 import * as km from "../controllers/temps-deplacements-km.controller";
 import * as c from "../controllers/temps-deplacements.controller";
+import * as ops from "../controllers/temps-deplacements-operations.controller";
 
 // Monté après le socle authenticateToken (v1.routes.ts) → JWT requis d'office.
 // Anti-IDOR : les routes salarié dérivent l'employé de req.user ; /employees/:id/* est gardé
@@ -36,6 +37,14 @@ router.get("/team/anomalies", cor.getTeamAnomalies); // anomalies équipe du jou
 router.patch("/days/:id/validate", cor.validateDay); // valide une journée
 router.patch("/weeks/:id/validate", cor.validateWeek); // valide une semaine
 
+// SOL-24 — absences explicites et file d'actions responsable.
+router.post("/absences", ops.postAbsence);
+router.get("/absences/me", ops.getMyAbsences);
+router.get("/team/absences", ops.getTeamAbsences);
+router.patch("/absences/:id/approve", ops.approveAbsence);
+router.patch("/absences/:id/reject", ops.rejectAbsence);
+router.get("/team/operations-queue", ops.getOperationsQueue);
+
 // T5 — administration RH (règles / contrats / horaires). Réservé aux rôles privilégiés (service).
 router.get("/admin/employees", adm.getEmployees);
 router.get("/admin/rule-sets", adm.getRuleSets);
@@ -65,6 +74,11 @@ router.get("/kilometers/team", km.getTeamKm);
 router.patch("/kilometers/:id/validate", km.validateKm);
 router.patch("/kilometers/:id/reject", km.rejectKm);
 router.post("/admin/vehicles", km.postVehicle);
+router.get("/admin/period-closures", ops.getClosures);
+router.post("/admin/period-closures", ops.postClosure);
+router.patch("/admin/period-closures/:id/reopen", ops.reopenClosure);
+router.get("/admin/kilometer-rates", ops.getKilometerRates);
+router.post("/admin/kilometer-rates", ops.postKilometerRate);
 
 // T8 — bornes & badges (provisioning). Réservé aux rôles privilégiés (service). Token borne renvoyé 1× à la création.
 router.get("/admin/devices", dev.getDevices);

--- a/src/module/temps-deplacements/services/temps-deplacements-corrections.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-corrections.service.ts
@@ -1,5 +1,5 @@
 import { HttpError } from "../../../utils/httpError";
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import { assertPeriodOpen, isHrPrivileged, type HrActor } from "../domain/temps-deplacements-policy";
 import {
   repoCreateAdjustment,
   repoDecideAdjustment,
@@ -23,16 +23,12 @@ import {
   type AuditContext,
 } from "../repository/temps-deplacements.repository";
 import type { CreateAdjustmentBody } from "../validators/temps-deplacements.validators";
+import { repoResolveAdjustmentPeriod } from "../repository/temps-deplacements-operations.repository";
 import { computeDailyTimesheet, todayParis } from "./temps-deplacements.service";
-
-export type Actor = { id: number; role: string };
+export type Actor = HrActor;
 
 // Miroir de isHrPrivileged du contrôleur T2 (rôle RH/Direction/Admin). Pur ⇒ testable directement.
-export function isHrPrivileged(role: string): boolean {
-  if (hasGrantedAccountModuleAccess()) return true;
-  const r = role.toLowerCase();
-  return r.includes("rh") || r.includes("directeur") || r.includes("direction") || r.includes("administrateur");
-}
+export { isHrPrivileged };
 
 // Lève 403 si l'appelant n'est ni le manager de l'employé ni un rôle privilégié (anti-IDOR périmètre).
 async function assertCanManageEmployee(actor: Actor, employeeId: string): Promise<void> {
@@ -53,6 +49,9 @@ export async function createAdjustment(
 ): Promise<HrAdjustment> {
   const targetEmployeeId = await repoResolveTargetEmployeeId(body.target_type, body.target_id);
   if (!targetEmployeeId) throw new HttpError(404, "HR_TARGET_NOT_FOUND", "Cible de correction introuvable.");
+  const targetPeriod = await repoResolveAdjustmentPeriod(body.target_type, body.target_id);
+  if (!targetPeriod) throw new HttpError(404, "HR_TARGET_NOT_FOUND", "Période de correction introuvable.");
+  await assertPeriodOpen(targetPeriod.employee_id, targetPeriod.from, targetPeriod.to);
 
   const emp = await repoGetEmployeeById(targetEmployeeId);
   const isSelf = emp?.user_id === actor.id;
@@ -95,6 +94,9 @@ export async function decideAdjustment(
   }
   const targetEmployeeId = await repoResolveTargetEmployeeId(adj.target_type, adj.target_id);
   if (!targetEmployeeId) throw new HttpError(404, "HR_TARGET_NOT_FOUND", "Cible de correction introuvable.");
+  const targetPeriod = await repoResolveAdjustmentPeriod(adj.target_type, adj.target_id);
+  if (!targetPeriod) throw new HttpError(404, "HR_TARGET_NOT_FOUND", "Période de correction introuvable.");
+  await assertPeriodOpen(targetPeriod.employee_id, targetPeriod.from, targetPeriod.to);
   await assertCanManageEmployee(actor, targetEmployeeId);
 
   return withTransaction(async (client) => {
@@ -118,7 +120,14 @@ export async function listTeamAdjustments(actor: Actor): Promise<HrAdjustmentWit
 export async function validateTimesheetDay(actor: Actor, dayId: string, audit: AuditContext): Promise<TimesheetRef> {
   const day = await repoGetTimesheetDayById(dayId);
   if (!day) throw new HttpError(404, "HR_TIMESHEET_NOT_FOUND", "Journée introuvable.");
+  const employee = await repoGetEmployeeById(day.employee_id);
+  if (employee?.user_id === actor.id) {
+    throw new HttpError(403, "HR_SELF_APPROVAL_FORBIDDEN", "Auto-validation de sa propre journée interdite.");
+  }
   await assertCanManageEmployee(actor, day.employee_id);
+  const targetPeriod = await repoResolveAdjustmentPeriod("DAY", dayId);
+  if (!targetPeriod) throw new HttpError(404, "HR_TIMESHEET_NOT_FOUND", "Journée introuvable.");
+  await assertPeriodOpen(day.employee_id, targetPeriod.from, targetPeriod.to);
   if (day.validation_status === "VALIDATED" || day.validation_status === "EXPORTED") {
     throw new HttpError(409, "HR_ALREADY_VALIDATED", "Journée déjà validée ou exportée.");
   }
@@ -138,7 +147,14 @@ export async function validateTimesheetDay(actor: Actor, dayId: string, audit: A
 export async function validateTimesheetWeek(actor: Actor, weekId: string, audit: AuditContext): Promise<TimesheetRef> {
   const week = await repoGetTimesheetWeekById(weekId);
   if (!week) throw new HttpError(404, "HR_TIMESHEET_NOT_FOUND", "Semaine introuvable.");
+  const employee = await repoGetEmployeeById(week.employee_id);
+  if (employee?.user_id === actor.id) {
+    throw new HttpError(403, "HR_SELF_APPROVAL_FORBIDDEN", "Auto-validation de sa propre semaine interdite.");
+  }
   await assertCanManageEmployee(actor, week.employee_id);
+  const targetPeriod = await repoResolveAdjustmentPeriod("WEEK", weekId);
+  if (!targetPeriod) throw new HttpError(404, "HR_TIMESHEET_NOT_FOUND", "Semaine introuvable.");
+  await assertPeriodOpen(week.employee_id, targetPeriod.from, targetPeriod.to);
   if (week.validation_status === "VALIDATED" || week.validation_status === "EXPORTED") {
     throw new HttpError(409, "HR_ALREADY_VALIDATED", "Semaine déjà validée ou exportée.");
   }

--- a/src/module/temps-deplacements/services/temps-deplacements-km.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-km.service.ts
@@ -15,6 +15,8 @@ import {
 import { insertAuditLog, repoGetEmployeeById, withTransaction, type AuditContext } from "../repository/temps-deplacements.repository";
 import { isHrPrivileged, type Actor } from "./temps-deplacements-corrections.service";
 import { resolveEmployeeFromUser } from "./temps-deplacements.service";
+import { assertPeriodOpen } from "../domain/temps-deplacements-policy";
+import { repoGetEffectiveKilometerRate } from "../repository/temps-deplacements-operations.repository";
 
 async function assertCanManageEmployee(actor: Actor, employeeId: string): Promise<void> {
   if (isHrPrivileged(actor.role)) return;
@@ -50,6 +52,7 @@ export interface CreateKmInput {
 export async function createMyKmEntry(actor: Actor, input: CreateKmInput, audit: AuditContext): Promise<KmEntry> {
   const emp = await resolveEmployeeFromUser(actor.id);
   const distance = computeDistanceKm(input);
+  await assertPeriodOpen(emp.id, input.date);
   return withTransaction(async (client) => {
     const entry = await repoCreateKmEntry(client, {
       employee_id: emp.id,
@@ -86,6 +89,7 @@ export async function submitMyKmEntry(actor: Actor, id: string, audit: AuditCont
   if (!entry) throw new HttpError(404, "HR_KM_NOT_FOUND", "Déclaration introuvable.");
   const emp = await resolveEmployeeFromUser(actor.id);
   if (entry.employee_id !== emp.id) throw new HttpError(403, "HR_FORBIDDEN", "Vous ne pouvez soumettre que vos déclarations.");
+  await assertPeriodOpen(entry.employee_id, entry.date);
   return withTransaction(async (client) => {
     const updated = await repoSubmitKmEntry(client, id);
     if (!updated) throw new HttpError(409, "HR_KM_NOT_DRAFT", "Déclaration déjà soumise ou traitée.");
@@ -97,15 +101,33 @@ export async function submitMyKmEntry(actor: Actor, id: string, audit: AuditCont
 export async function decideKmEntry(actor: Actor, id: string, decision: "VALIDATED" | "REJECTED", audit: AuditContext): Promise<KmEntry> {
   const entry = await repoGetKmEntryById(id);
   if (!entry) throw new HttpError(404, "HR_KM_NOT_FOUND", "Déclaration introuvable.");
+  const employee = await repoGetEmployeeById(entry.employee_id);
+  if (employee?.user_id === actor.id) {
+    throw new HttpError(403, "HR_SELF_APPROVAL_FORBIDDEN", "Auto-validation de ses propres déplacements interdite.");
+  }
   await assertCanManageEmployee(actor, entry.employee_id);
+  await assertPeriodOpen(entry.employee_id, entry.date);
+  const rate = decision === "VALIDATED" ? await repoGetEffectiveKilometerRate(entry.vehicle_id, entry.date) : null;
+  if (decision === "VALIDATED" && !rate) {
+    throw new HttpError(
+      409,
+      "HR_KM_RATE_MISSING",
+      "Validation impossible : aucun taux kilométrique daté ne couvre le véhicule et la date du déplacement.",
+    );
+  }
   return withTransaction(async (client) => {
-    const updated = await repoDecideKmEntry(client, id, decision, actor.id);
+    const updated = await repoDecideKmEntry(client, id, decision, actor.id, rate ? { id: rate.id, currency: rate.currency } : null);
     if (!updated) throw new HttpError(409, "HR_KM_NOT_SUBMITTED", "La déclaration doit être soumise pour être traitée.");
     await insertAuditLog(client, audit, {
       action: decision === "VALIDATED" ? "temps-deplacements.km.validate" : "temps-deplacements.km.reject",
       entity_type: "hr_kilometer_entries",
       entity_id: id,
-      details: { decision },
+      details: {
+        decision,
+        rate_version_id: updated.rate_version_id,
+        cost_amount: updated.cost_amount,
+        cost_currency: updated.cost_currency,
+      },
     });
     return updated;
   });

--- a/src/module/temps-deplacements/services/temps-deplacements-operations.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-operations.service.ts
@@ -1,0 +1,168 @@
+import { HttpError } from "../../../utils/httpError";
+import { assertPeriodOpen, isHrPrivileged, type HrActor as Actor } from "../domain/temps-deplacements-policy";
+import {
+  insertAuditLog,
+  repoGetEmployeeById,
+  withTransaction,
+  type AuditContext,
+} from "../repository/temps-deplacements.repository";
+import {
+  repoCreateAbsence,
+  repoCreateKilometerRate,
+  repoCreatePeriodClosure,
+  repoDecideAbsence,
+  repoGetAbsence,
+  repoGetClosurePreflight,
+  repoGetCurrentKilometerRate,
+  repoGetPeriodClosure,
+  repoGetTeamOperationsQueue,
+  repoListAbsences,
+  repoListKilometerRates,
+  repoListPeriodClosures,
+  repoReopenPeriodClosure,
+} from "../repository/temps-deplacements-operations.repository";
+import type {
+  CreateAbsenceBody,
+  CreateKilometerRateBody,
+  CreatePeriodClosureBody,
+} from "../validators/temps-deplacements.validators";
+import { resolveEmployeeFromUser } from "./temps-deplacements.service";
+
+async function assertCanManageEmployee(actor: Actor, employeeId: string): Promise<void> {
+  if (isHrPrivileged(actor.role)) return;
+  const employee = await repoGetEmployeeById(employeeId);
+  if (employee?.manager_user_id === actor.id) return;
+  throw new HttpError(403, "HR_FORBIDDEN", "Hors de votre périmètre de gestion.");
+}
+
+function assertPrivileged(actor: Actor): void {
+  if (!isHrPrivileged(actor.role)) throw new HttpError(403, "HR_ADMIN_REQUIRED", "Action réservée à l'administration RH.");
+}
+
+export async function createMyAbsence(actor: Actor, input: CreateAbsenceBody, audit: AuditContext) {
+  const employee = await resolveEmployeeFromUser(actor.id);
+  await assertPeriodOpen(employee.id, input.absence_date);
+  try {
+    return await withTransaction(async (tx) => {
+      const row = await repoCreateAbsence(tx, {
+        employee_id: employee.id, absence_date: input.absence_date, minutes: input.minutes,
+        absence_type: input.absence_type, timezone: input.timezone, reason: input.reason,
+        source_ref: input.source_ref ?? null, requested_by: actor.id,
+      });
+      await insertAuditLog(tx, audit, {
+        action: "temps-deplacements.absence.request", entity_type: "hr_absence_records", entity_id: row.id,
+        details: { absence_date: row.absence_date, minutes: row.minutes, absence_type: row.absence_type },
+      });
+      return row;
+    });
+  } catch (error) {
+    if ((error as { code?: string }).code === "23505") {
+      throw new HttpError(409, "HR_ABSENCE_DUPLICATE", "Une absence active du même type existe déjà pour cette date.");
+    }
+    throw error;
+  }
+}
+
+export async function listMyAbsences(actor: Actor) {
+  const employee = await resolveEmployeeFromUser(actor.id);
+  return repoListAbsences({ employee_id: employee.id });
+}
+
+export async function listTeamAbsences(actor: Actor, status?: "REQUESTED" | "APPROVED" | "REJECTED" | "CANCELLED") {
+  return repoListAbsences({ manager_user_id: actor.id, privileged: isHrPrivileged(actor.role), status });
+}
+
+export async function decideAbsence(
+  actor: Actor,
+  id: string,
+  decision: "APPROVED" | "REJECTED",
+  audit: AuditContext,
+) {
+  const absence = await repoGetAbsence(id);
+  if (!absence) throw new HttpError(404, "HR_ABSENCE_NOT_FOUND", "Absence introuvable.");
+  if (absence.requested_by === actor.id) throw new HttpError(403, "HR_SELF_APPROVAL_FORBIDDEN", "Auto-validation d'une absence interdite.");
+  await assertCanManageEmployee(actor, absence.employee_id);
+  await assertPeriodOpen(absence.employee_id, absence.absence_date);
+  return withTransaction(async (tx) => {
+    const updated = await repoDecideAbsence(tx, id, decision, actor.id);
+    if (!updated) throw new HttpError(409, "HR_ABSENCE_NOT_PENDING", "Absence déjà traitée.");
+    await insertAuditLog(tx, audit, {
+      action: decision === "APPROVED" ? "temps-deplacements.absence.approve" : "temps-deplacements.absence.reject",
+      entity_type: "hr_absence_records", entity_id: id,
+      details: { decision, absence_date: absence.absence_date, employee_id: absence.employee_id },
+    });
+    return updated;
+  });
+}
+
+export async function createPeriodClosure(actor: Actor, input: CreatePeriodClosureBody, audit: AuditContext) {
+  assertPrivileged(actor);
+  const normalized = { ...input, employee_id: input.employee_id ?? null };
+  const preflight = await repoGetClosurePreflight(normalized);
+  const blockerCount = Object.values(preflight).reduce((sum, value) => sum + value, 0);
+  if (blockerCount > 0) {
+    throw new HttpError(409, "HR_PERIOD_PREFLIGHT_FAILED", `Clôture refusée : ${blockerCount} élément(s) restent à traiter.`, preflight);
+  }
+  try {
+    return await withTransaction(async (tx) => {
+      const closure = await repoCreatePeriodClosure(tx, { ...normalized, closed_by: actor.id });
+      await insertAuditLog(tx, audit, {
+        action: "temps-deplacements.period.close", entity_type: "hr_period_closures", entity_id: closure.id,
+        details: { period_start: closure.period_start, period_end: closure.period_end, employee_id: closure.employee_id, timezone: closure.timezone },
+      });
+      return { closure, preflight };
+    });
+  } catch (error) {
+    if ((error as { code?: string }).code === "HR_PERIOD_OVERLAP") {
+      throw new HttpError(409, "HR_PERIOD_OVERLAP", "Une clôture active chevauche déjà cette période.");
+    }
+    throw error;
+  }
+}
+
+export async function reopenPeriodClosure(actor: Actor, id: string, audit: AuditContext) {
+  assertPrivileged(actor);
+  const before = await repoGetPeriodClosure(id);
+  if (!before) throw new HttpError(404, "HR_PERIOD_NOT_FOUND", "Période clôturée introuvable.");
+  return withTransaction(async (tx) => {
+    const reopened = await repoReopenPeriodClosure(tx, id, actor.id);
+    if (!reopened) throw new HttpError(409, "HR_PERIOD_ALREADY_REOPENED", "Cette période est déjà rouverte.");
+    await insertAuditLog(tx, audit, {
+      action: "temps-deplacements.period.reopen", entity_type: "hr_period_closures", entity_id: id,
+      details: { period_start: before.period_start, period_end: before.period_end, employee_id: before.employee_id },
+    });
+    return reopened;
+  });
+}
+
+export async function listClosures(actor: Actor) {
+  assertPrivileged(actor);
+  return repoListPeriodClosures();
+}
+
+export async function createKilometerRate(actor: Actor, input: CreateKilometerRateBody, audit: AuditContext) {
+  assertPrivileged(actor);
+  return withTransaction(async (tx) => {
+    const current = await repoGetCurrentKilometerRate(input.owner_type, tx);
+    if (current && input.effective_from <= current.effective_from) {
+      throw new HttpError(409, "HR_KM_RATE_DATE_INVALID", "La nouvelle version doit commencer après le taux courant.");
+    }
+    const created = await repoCreateKilometerRate(tx, {
+      ...input, source_ref: input.source_ref ?? null, supersedes_id: current?.id ?? null, created_by: actor.id,
+    });
+    await insertAuditLog(tx, audit, {
+      action: "temps-deplacements.km-rate.version.create", entity_type: "hr_kilometer_rate_versions", entity_id: created.id,
+      details: { owner_type: created.owner_type, effective_from: created.effective_from, currency: created.currency, supersedes_id: created.supersedes_id },
+    });
+    return created;
+  });
+}
+
+export async function listKilometerRates(actor: Actor) {
+  assertPrivileged(actor);
+  return repoListKilometerRates();
+}
+
+export async function getOperationsQueue(actor: Actor) {
+  return repoGetTeamOperationsQueue({ manager_user_id: actor.id, privileged: isHrPrivileged(actor.role) });
+}

--- a/src/module/temps-deplacements/services/temps-deplacements.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements.service.ts
@@ -4,6 +4,8 @@ import * as repo from "../repository/temps-deplacements.repository";
 import type { AuditContext } from "../repository/temps-deplacements.repository";
 import { repoGetEffectiveRuleSet, repoUpsertTimesheetWeek } from "../repository/temps-deplacements-rules.repository";
 import { effectiveDailyWorked, weeklyAggregate } from "./temps-deplacements-rules";
+import { assertPeriodOpen } from "../domain/temps-deplacements-policy";
+import { repoSumApprovedAbsenceMinutes } from "../repository/temps-deplacements-operations.repository";
 import type {
   CreateTimeEventInput,
   CreateTimeEventResult,
@@ -59,6 +61,8 @@ export async function resolveEmployeeFromBadge(badgeUid: string): Promise<HrEmpl
 
 // -------------------------------------------------------------- Création d'événement (append-only)
 export async function createTimeEvent(input: CreateTimeEventInput, audit: AuditContext): Promise<CreateTimeEventResult> {
+  const eventDate = parisDay(input.event_time ?? Date.now());
+  await assertPeriodOpen(input.employee_id, eventDate);
   const result = await repo.withTransaction(async (client) => {
     const evtTimeMs = input.event_time ? new Date(input.event_time).getTime() : Date.now();
 
@@ -100,8 +104,14 @@ export async function createTimeEvent(input: CreateTimeEventInput, audit: AuditC
   // Recalcul du jour (best-effort ; ne doit jamais faire échouer l'enregistrement de l'événement).
   try {
     await computeDailyTimesheet(input.employee_id, parisDay(result.event.event_time));
-  } catch {
-    /* noop */
+  } catch (error) {
+    console.error(JSON.stringify({
+      type: "hr_timesheet_recompute_failed",
+      employeeId: input.employee_id,
+      date: parisDay(result.event.event_time),
+      eventId: result.event.id,
+      error: error instanceof Error ? error.message : String(error),
+    }));
   }
   return result;
 }
@@ -178,7 +188,9 @@ export async function computeDailyTimesheet(employeeId: string, date: string): P
   // Pause minimale imposée + arrondi selon la règle (sinon temps brut).
   const workedMinutes = ruleSet ? effectiveDailyWorked(workedRaw, totalBreak, ruleSet) : workedRaw;
   const overtime = expected > 0 ? Math.max(0, workedMinutes - expected) : 0;
-  const missing = expected > 0 ? Math.max(0, expected - workedMinutes) : 0;
+  const approvedAbsence = await repoSumApprovedAbsenceMinutes(employeeId, date, date);
+  const absenceMinutes = Math.min(expected, approvedAbsence);
+  const missing = expected > 0 ? Math.max(0, expected - workedMinutes - absenceMinutes) : 0;
   const isPastDay = date < todayParis();
 
   const descriptors = detectTimeAnomalies(events, { openBreak, workedMinutes, totalBreak, isPastDay });
@@ -207,6 +219,7 @@ export async function computeDailyTimesheet(employeeId: string, date: string): P
     worked_minutes: workedMinutes,
     expected_minutes: expected,
     overtime_minutes: overtime,
+    absence_minutes: absenceMinutes,
     missing_minutes: missing,
     status,
     anomalies,
@@ -225,6 +238,8 @@ export async function computeWeeklyTimesheet(employeeId: string, weekStart: stri
   // Règles effectives de la semaine (contrat au lundi) → cible hebdo + découpe HS 25/50 configurable.
   const ruleSet = await repoGetEffectiveRuleSet(employeeId, weekStart);
   const agg = weeklyAggregate(worked, ruleSet);
+  const absenceMinutes = days.reduce((sum, day) => sum + day.absence_minutes, 0);
+  const unclassifiedMissingMinutes = days.reduce((sum, day) => sum + day.missing_minutes, 0);
 
   // Persistance de l'agrégat hebdo (nécessaire à la validation T4 ; DRAFT uniquement).
   try {
@@ -237,10 +252,16 @@ export async function computeWeeklyTimesheet(employeeId: string, weekStart: stri
         worked_minutes: worked,
         overtime_25_minutes: agg.overtime_25_minutes,
         overtime_50_minutes: agg.overtime_50_minutes,
-        absence_minutes: agg.absence_minutes,
+        absence_minutes: absenceMinutes,
       })
     );
-  } catch {
+  } catch (error) {
+    console.error(JSON.stringify({
+      type: "hr_timesheet_week_persist_failed",
+      employeeId,
+      weekStart,
+      error: error instanceof Error ? error.message : String(error),
+    }));
     /* best-effort : ne bloque jamais la lecture du relevé */
   }
 
@@ -253,7 +274,8 @@ export async function computeWeeklyTimesheet(employeeId: string, weekStart: stri
     overtime_minutes: agg.overtime_25_minutes + agg.overtime_50_minutes,
     overtime_25_minutes: agg.overtime_25_minutes,
     overtime_50_minutes: agg.overtime_50_minutes,
-    absence_minutes: agg.absence_minutes,
+    absence_minutes: absenceMinutes,
+    unclassified_missing_minutes: unclassifiedMissingMinutes,
     rule_set_name: agg.rule_set_name,
     days,
   };

--- a/src/module/temps-deplacements/types/temps-deplacements.types.ts
+++ b/src/module/temps-deplacements/types/temps-deplacements.types.ts
@@ -55,6 +55,7 @@ export interface HrDailyTimesheet {
   worked_minutes: number;
   expected_minutes: number;
   overtime_minutes: number;
+  absence_minutes: number;
   missing_minutes: number;
   status: "OK" | "ANOMALY" | "MANUAL_REVIEW" | "VALIDATED";
   anomalies: HrTimeAnomaly[];
@@ -70,6 +71,7 @@ export interface HrWeeklyTimesheet {
   overtime_25_minutes: number; // T5 — HS taux 1 (règle configurable)
   overtime_50_minutes: number; // T5 — HS taux 2
   absence_minutes: number;
+  unclassified_missing_minutes: number;
   rule_set_name: string | null; // règle appliquée (traçabilité)
   days: HrDailyTimesheet[];
 }

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -8,6 +8,15 @@ export const HR_EVENT_TYPES = ["IN", "OUT", "BREAK_START", "BREAK_END", "MISSION
 
 const eventTime = z.string().datetime({ offset: true }).optional(); // ISO 8601 ; défaut = now serveur
 const dateOnly = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format YYYY-MM-DD");
+const timezone = z.string().trim().min(1).max(100).refine((value) => {
+  try {
+    new Intl.DateTimeFormat("fr-FR", { timeZone: value });
+    return true;
+  } catch {
+    return false;
+  }
+}, "Fuseau horaire IANA invalide");
+const decimalMoney = z.string().regex(/^\d{1,9}(?:\.\d{1,6})?$/, "Montant décimal positif attendu");
 
 // POST /time-clock/events (salarié) — aucun employee_id.
 export const createTimeEventSchema = z
@@ -191,3 +200,42 @@ export const exportBodySchema = z
 export type ExportBody = z.infer<typeof exportBodySchema>;
 export const listContractsQuerySchema = z.object({ employee_id: z.string().uuid().optional() });
 export const listSchedulesQuerySchema = z.object({ employee_id: z.string().uuid("employee_id (uuid) requis") });
+
+export const HR_ABSENCE_TYPES = ["PAID_LEAVE", "SICK_LEAVE", "RTT", "TRAINING", "OTHER"] as const;
+export const HR_ABSENCE_STATUSES = ["REQUESTED", "APPROVED", "REJECTED", "CANCELLED"] as const;
+
+export const createAbsenceSchema = z.object({
+  absence_date: dateOnly,
+  minutes: z.number().int().positive().max(1440),
+  absence_type: z.enum(HR_ABSENCE_TYPES),
+  timezone: timezone.default("Europe/Paris"),
+  reason: z.string().trim().min(3).max(2000),
+  source_ref: z.string().trim().max(500).nullish(),
+}).strict();
+export type CreateAbsenceBody = z.infer<typeof createAbsenceSchema>;
+
+export const absenceStatusQuerySchema = z.object({ status: z.enum(HR_ABSENCE_STATUSES).optional() }).strict();
+
+export const createPeriodClosureSchema = z.object({
+  period_start: dateOnly,
+  period_end: dateOnly,
+  employee_id: z.string().uuid().nullish(),
+  timezone: timezone.default("Europe/Paris"),
+  reason: z.string().trim().min(5).max(2000),
+}).strict().refine((value) => value.period_end >= value.period_start, {
+  message: "La fin de période doit suivre son début.", path: ["period_end"],
+});
+export type CreatePeriodClosureBody = z.infer<typeof createPeriodClosureSchema>;
+
+export const createKilometerRateSchema = z.object({
+  owner_type: z.enum(["COMPANY", "PERSONAL"]),
+  rate_per_km: decimalMoney,
+  currency: z.string().trim().toUpperCase().regex(/^[A-Z]{3}$/).default("EUR"),
+  effective_from: dateOnly,
+  definition: z.string().trim().min(5).max(500),
+  source_type: z.enum(["DECLARATION", "LEGAL_SCALE", "CONTRACT", "OTHER"]),
+  source_ref: z.string().trim().max(500).nullish(),
+  observed_at: z.string().datetime({ offset: true }),
+  reliability: z.enum(["DECLARED", "VERIFIED", "ESTIMATED"]),
+}).strict();
+export type CreateKilometerRateBody = z.infer<typeof createKilometerRateSchema>;


### PR DESCRIPTION
## Promotion SOL-24
Promeut la branche dev validée vers main après recette complète.

- backend: 306 fichiers / 4621 tests
- migration PostgreSQL isolée: backup/rollback/restore/replay
- E2E: 3/3
- patch additif à appliquer après sauvegarde avant déploiement

## Summary by Sourcery

Introduce SOL-24 project operations and HR control features, including additive database schema changes, new backend services, and strengthened RBAC and period control for time, absences, and kilometer entries.

New Features:
- Expose project operations API aggregating budget versions, affaire links, time budgets, burn-up, risks, and blocking dependencies for Project Office.
- Add explicit HR absence management, period closures, kilometer rate versioning, and a manager/RH operations queue to the time & travel module.
- Provide new REST endpoints for project operations, absences, closures, kilometer rates, and HR operations queues, wired into existing routing.

Bug Fixes:
- Fix Project Office project listing to avoid unused SQL parameters under elevated access and correct duplicate kilometer detection to not rely on unavailable PostgreSQL functions.

Enhancements:
- Factor HR privilege and period-closure policies into a shared domain layer and enforce anti self-approval rules for absences, corrections, timesheets, and kilometer validations.
- Adjust daily and weekly timesheet computation to account for approved absences separately from missing time and to persist additional diagnostics with structured error logs.
- Extend kilometer entry validation to snapshot applied kilometer rate versions and computed costs at approval time, with audit trail details.
- Refine E2E isolated seed data to include deterministic SOL-24 fixtures for Project Office and HR entities.
- Update release gate and migration rehearsal scripts to include SOL-24 patch checks, rollback proofs, and verification of additive schema objects.

Build:
- Register the SOL-24 project operations database patch and its immutable checksum in the patch runner and release tooling.

Documentation:
- Add ADR-0070 documenting the design boundary for project operations, time, and travel control, and an execution report for SOL-24 covering architecture, migration, and testing.
- Refresh SOL-06 migration rehearsal documentation and JSON report to reflect the latest rehearsal including the SOL-24 patch.

Tests:
- Add SOL-24-focused unit, repository-contract, migration-guard, and route/RBAC tests for project operations and HR operations, and update existing time & travel tests (T4/T6) for new rules and behaviors.