### PR TITLE
fix(release): ship migration runner in backend image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,12 @@ RUN sed -i 's/\r$//' \
 COPY package*.json ./
 RUN npm ci --omit=dev
 
+# Ship the exact migration inventory and runner with the release image. This
+# keeps operator-driven preflight/apply/status commands pinned to SOURCE_COMMIT
+# instead of relying on an unrelated host checkout.
+COPY scripts/db-patches.js ./scripts/db-patches.js
+COPY db/patches ./db/patches
+
 # ...
 COPY --from=builder /app/dist ./dist
 RUN mkdir -p \

--- a/src/__tests__/dockerfile.storage.test.ts
+++ b/src/__tests__/dockerfile.storage.test.ts
@@ -51,6 +51,13 @@ describe("Dockerfile storage permissions", () => {
     expect(dockerfile).toContain("ENV CERP_RELEASE_VERSION=${SOURCE_COMMIT}");
   });
 
+  it("ships the commit-pinned migration runner and canonical patch inventory", () => {
+    expect(dockerfile).toContain("COPY scripts/db-patches.js ./scripts/db-patches.js");
+    expect(dockerfile).toContain("COPY db/patches ./db/patches");
+    expect(dockerfile.indexOf("COPY scripts/db-patches.js ./scripts/db-patches.js"))
+      .toBeLessThan(dockerfile.indexOf("COPY --from=builder /app/dist ./dist"));
+  });
+
   it("normalizes shell entrypoints for images built from a Windows checkout", () => {
     expect(gitAttributes).toContain("*.sh text eol=lf");
     expect(gitAttributes).toContain("docker/*.conf text eol=lf");


### PR DESCRIPTION
Follow-up SOL-24 deployment hardening.

- packages `scripts/db-patches.js` and the canonical `db/patches` inventory in the runtime image
- pins operator migration commands to the deployed commit
- adds a Dockerfile contract test

Validation: `npm run test:run -- src/__tests__/dockerfile.storage.test.ts` (7/7).

## Summary by Sourcery

Ship the database migration runner and canonical patch inventory in the backend release image and validate this contract via a Dockerfile test.

New Features:
- Include scripts/db-patches.js and db/patches in the runtime Docker image to pin operator migration commands to the deployed commit.

Tests:
- Add a Dockerfile contract test asserting that the migration runner and patch inventory are copied into the release image before the built distribution.