### PR TITLE
release: promouvoir le gate migration SOL-26

### DIFF
--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -55,6 +55,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "e978abeb2b6758744d3824540b2552ef6b6ca90f0c634bc49dd7af403d4e8cd9",
   "20260814_admin_operations_sol25.sql":
     "741a16b710835f4bc05dcac52c7ba5ceb74504c962bfe4307805d2071142d3f3",
+  "20260814_electronic_invoicing_sol26.sql":
+    "03da2f92e7c99e1ffe437fb5443517585a9c20765322d85ab0cb83e378f7968e",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -92,6 +92,10 @@ const recentSolPatchChecksums = new Map([
     "20260814_admin_operations_sol25.sql",
     "741a16b710835f4bc05dcac52c7ba5ceb74504c962bfe4307805d2071142d3f3",
   ],
+  [
+    "20260814_electronic_invoicing_sol26.sql",
+    "03da2f92e7c99e1ffe437fb5443517585a9c20765322d85ab0cb83e378f7968e",
+  ],
 ]);
 const wave9PatchChecksums = new Map([
   [

--- a/src/__tests__/electronic-invoicing-sol26.migration-guards.test.ts
+++ b/src/__tests__/electronic-invoicing-sol26.migration-guards.test.ts
@@ -1,0 +1,40 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "../..");
+const patchPath = path.join(root, "db/patches/20260814_electronic_invoicing_sol26.sql");
+const patch = fs.readFileSync(patchPath, "utf8");
+const preflight = fs.readFileSync(
+  path.join(root, "db/patches/support/20260814_electronic_invoicing_sol26.preflight.sql"),
+  "utf8"
+);
+const verify = fs.readFileSync(
+  path.join(root, "db/patches/support/20260814_electronic_invoicing_sol26.verify.sql"),
+  "utf8"
+);
+const rollback = fs.readFileSync(
+  path.join(root, "db/patches/support/20260814_electronic_invoicing_sol26.rollback.sql"),
+  "utf8"
+);
+const runner = fs.readFileSync(path.join(root, "scripts/db-patches.js"), "utf8");
+const patchSha256 = crypto.createHash("sha256").update(patch.replace(/\r\n?/g, "\n")).digest("hex");
+
+describe("SOL-26 migration guards", () => {
+  it("registers the exact immutable patch checksum in the production runner", () => {
+    expect(patchSha256).toBe("03da2f92e7c99e1ffe437fb5443517585a9c20765322d85ab0cb83e378f7968e");
+    expect(runner).toContain('"20260814_electronic_invoicing_sol26.sql"');
+    expect(runner).toContain(patchSha256);
+  });
+
+  it("ships a preflight, post-migration verification and guarded rollback", () => {
+    expect(preflight).toContain("SOL-26 missing prerequisites");
+    expect(verify).toContain("SOL-26 verification failed");
+    expect(rollback).toContain("allowed only on an isolated/test database");
+    expect(rollback).toContain("rollback refused because electronic-invoice evidence exists");
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+  });
+});


### PR DESCRIPTION
## Promotion corrective

Promouvoit le correctif du gate de migration découvert avant toute écriture réelle.

- PR d’intégration : #476
- SHA immuable SOL-26 enregistré et testé
- tests runner/garde : 23/23
- typecheck et build : OK

La migration réelle reste suspendue jusqu’à cette promotion.

## Summary by Sourcery

Promote the SOL-26 electronic invoicing database migration patch as an immutable, guarded production migration.

Enhancements:
- Register the SOL-26 electronic invoicing migration patch checksum in the immutable-only production runner configuration.

Tests:
- Add dedicated migration guard tests for SOL-26, covering checksum registration, preflight, verification, rollback protections, and transactional wrapping.
- Extend the db-patches runner checksum tests to include the SOL-26 electronic invoicing patch.