### PR TITLE
release: promote SOL-28 portable OpenAPI hash

### DIFF
--- a/docs/http/openapi-route-coverage.json
+++ b/docs/http/openapi-route-coverage.json
@@ -1,6 +1,6 @@
 {
   "scope": "/api/v1",
-  "source_sha256": "30045f1531d140aa32d55c9c36a5c6a3df8b1407d54ea501f0dad2dccc4b079f",
+  "source_sha256": "d82d666b7244413a8c33839fd7bd8817f881d4c56ffcdb3c6529b76ca4dd21fb",
   "discovered_operations": 1024,
   "documented_operations": 1024,
   "coverage_percent": 100,

--- a/scripts/openapi/generate-route-inventory.mjs
+++ b/scripts/openapi/generate-route-inventory.mjs
@@ -259,7 +259,11 @@ try {
   const routes = generatedInventory();
   const sources = [...moduleCache.keys()].sort();
   const sourceHash = crypto.createHash("sha256")
-    .update(sources.map((file) => `${path.relative(root, file)}\n${fs.readFileSync(file, "utf8")}`).join("\n"))
+    .update(sources.map((file) => {
+      const portablePath = path.relative(root, file).replace(/\\/g, "/");
+      const portableSource = fs.readFileSync(file, "utf8").replace(/\r\n?/g, "\n");
+      return `${portablePath}\n${portableSource}`;
+    }).join("\n"))
     .digest("hex");
   const outputs = [
     [outputFile, renderTypeScript(routes, sourceHash)],

--- a/src/swagger/generated-route-inventory.ts
+++ b/src/swagger/generated-route-inventory.ts
@@ -8,7 +8,7 @@ export type GeneratedRouteContract = {
   rbac: readonly string[];
 };
 
-export const GENERATED_ROUTE_SOURCE_SHA256 = "30045f1531d140aa32d55c9c36a5c6a3df8b1407d54ea501f0dad2dccc4b079f";
+export const GENERATED_ROUTE_SOURCE_SHA256 = "d82d666b7244413a8c33839fd7bd8817f881d4c56ffcdb3c6529b76ca4dd21fb";
 export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",


### PR DESCRIPTION
Promotes the cross-platform route inventory digest fix discovered by the Linux release build. Build and OpenAPI parser pass locally; Linux build will be the deployment gate.

## Summary by Sourcery

Normalize route inventory source hashing for cross-platform consistency and refresh generated artifacts.

Enhancements:
- Make the OpenAPI route inventory source hash portable by normalizing file paths and line endings before hashing.

Documentation:
- Regenerate OpenAPI route coverage documentation to align with the new portable route inventory digest.

Chores:
- Update the generated route inventory SHA-256 constant to match the new source hash.