### PR TITLE
fix(openapi): normalize generated file line endings

### DIFF
--- a/scripts/openapi/generate-route-inventory.mjs
+++ b/scripts/openapi/generate-route-inventory.mjs
@@ -271,7 +271,10 @@ try {
   ];
   for (const [file, content] of outputs) {
     if (checkOnly) {
-      if (!fs.existsSync(file) || fs.readFileSync(file, "utf8") !== content) {
+      const committed = fs.existsSync(file)
+        ? fs.readFileSync(file, "utf8").replace(/\r\n?/g, "\n")
+        : null;
+      if (committed !== content) {
         fail(`${path.relative(root, file)} is stale; run pnpm openapi:generate`);
       }
     } else {


### PR DESCRIPTION
Second portable-build follow-up: compare generated contract files after canonical LF normalization. Route content and source digest remain strict; CRLF/LF alone no longer marks the contract stale.

Validation: build and OpenAPI parser passed on Windows. The final Linux release archive build is the next blocking check.

## Summary by Sourcery

Bug Fixes:
- Adjust OpenAPI route inventory staleness detection to ignore line-ending differences between committed and generated files.