### PR TITLE
release: promote historical migration evidence gate

### DIFF
--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -25,6 +25,9 @@ const API_WEBHOOKS_PATCH = "20260814_api_contract_webhooks_sol28.sql";
 const SOL06_SUPPORT = path.join(SUPPORT_DIR, "20260810_system_reference_data_readiness");
 const POSTGRES_IMAGE = "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229";
 const DEFAULT_REPORT_DIR = path.join(ROOT, "docs", "release");
+const KNOWN_EXTERNAL_APPLIED_PATCHES = Object.freeze({
+  "20260731_ged_fiches_360.sql": "bae97fdcb9629c67078cc3ff8da25bc84fa4d2749ee682678519992bea403ee3",
+});
 
 function databaseClient(options) {
   const { Client } = require("pg");
@@ -211,19 +214,51 @@ async function runSqlFile(client, sql) {
   return client.query(executable);
 }
 
+function classifyPatchLedgerRows(appliedRows, localPatches = inventory().patches) {
+  const local = new Map(localPatches.map((patch) => [patch.filename, patch.sha256]));
+  const applied = new Map(appliedRows.map((row) => [row.filename, row]));
+  const checksumMismatches = appliedRows
+    .filter((row) => {
+      const expected = local.get(row.filename) ?? KNOWN_EXTERNAL_APPLIED_PATCHES[row.filename];
+      return expected !== undefined && expected !== row.sha256;
+    })
+    .map((row) => row.filename);
+  const pending = [...local.keys()].filter((filename) => !applied.has(filename));
+  const knownExternalApplied = appliedRows
+    .filter((row) => !local.has(row.filename) && KNOWN_EXTERNAL_APPLIED_PATCHES[row.filename] === row.sha256)
+    .map((row) => row.filename);
+  const unknownApplied = appliedRows
+    .filter((row) => !local.has(row.filename) && KNOWN_EXTERNAL_APPLIED_PATCHES[row.filename] === undefined)
+    .map((row) => row.filename);
+  return {
+    applied: appliedRows.length,
+    pending,
+    checksum_mismatches: checksumMismatches,
+    known_external_applied: knownExternalApplied,
+    unknown_applied: unknownApplied,
+  };
+}
+
 async function patchLedger(client) {
   const appliedResult = await client.query(
     `SELECT filename,sha256,applied_at::text AS applied_at
      FROM public.cerp_schema_migrations ORDER BY filename`
   );
-  const local = new Map(inventory().patches.map((patch) => [patch.filename, patch.sha256]));
-  const applied = new Map(appliedResult.rows.map((row) => [row.filename, row]));
-  const checksumMismatches = appliedResult.rows
-    .filter((row) => local.has(row.filename) && local.get(row.filename) !== row.sha256)
-    .map((row) => row.filename);
-  const pending = [...local.keys()].filter((filename) => !applied.has(filename));
-  const unknownApplied = appliedResult.rows.filter((row) => !local.has(row.filename)).map((row) => row.filename);
-  return { applied: appliedResult.rows.length, pending, checksum_mismatches: checksumMismatches, unknown_applied: unknownApplied };
+  return classifyPatchLedgerRows(appliedResult.rows);
+}
+
+async function verifyKnownExternalAppliedPatches(client, ledger) {
+  if (!ledger.known_external_applied.includes("20260731_ged_fiches_360.sql")) return;
+  const state = await client.query(
+    `SELECT to_regclass('public.ged_entity_types') IS NOT NULL AS entity_types,
+            to_regclass('public.ged_entity_class_bindings') IS NOT NULL AS class_bindings,
+            to_regprocedure('public.fn_ged_link_guard()') IS NOT NULL AS link_guard,
+            EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='trg_ged_link_guard' AND NOT tgisinternal) AS link_trigger`
+  );
+  if (!state.rows[0]?.entity_types || !state.rows[0]?.class_bindings
+      || !state.rows[0]?.link_guard || !state.rows[0]?.link_trigger) {
+    fail("known external patch 20260731_ged_fiches_360.sql has incomplete database evidence");
+  }
 }
 
 async function preflight(options = {}) {
@@ -246,6 +281,7 @@ async function preflight(options = {}) {
     if (ledger.checksum_mismatches.length || ledger.unknown_applied.length) {
       fail(`migration ledger divergence: ${JSON.stringify(ledger)}`);
     }
+    await verifyKnownExternalAppliedPatches(client, ledger);
     await runSqlFile(client, supportSql("preflight"));
     return {
       status: "passed",
@@ -836,4 +872,6 @@ module.exports = {
   inventory,
   inventoryMarkdown,
   validateBackup,
+  classifyPatchLedgerRows,
+  KNOWN_EXTERNAL_APPLIED_PATCHES,
 };

--- a/src/__tests__/migration-release-gate-sol06.test.ts
+++ b/src/__tests__/migration-release-gate-sol06.test.ts
@@ -20,6 +20,15 @@ const gate = require("../../scripts/migrations/release-gate.js") as {
     bytes: number;
     sha256: string;
   };
+  KNOWN_EXTERNAL_APPLIED_PATCHES: Record<string, string>;
+  classifyPatchLedgerRows: (
+    applied: Array<{ filename: string; sha256: string }>,
+    local: Array<{ filename: string; sha256: string }>,
+  ) => {
+    checksum_mismatches: string[];
+    known_external_applied: string[];
+    unknown_applied: string[];
+  };
 };
 
 const ROOT = path.resolve(__dirname, "..", "..");
@@ -127,5 +136,21 @@ describe("SOL-06 migration release gate", () => {
 
     expect(gate.validateBackup(backup, validSha)).toMatchObject({ bytes: 21, sha256: validSha });
     expect(() => gate.validateBackup(backup, "0".repeat(64))).toThrow("backup SHA-256 mismatch");
+  });
+
+  it("reconnaît uniquement le patch GED historique avec son checksum terrain exact", () => {
+    const filename = "20260731_ged_fiches_360.sql";
+    const expected = gate.KNOWN_EXTERNAL_APPLIED_PATCHES[filename];
+    const exact = gate.classifyPatchLedgerRows([{ filename, sha256: expected }], []);
+    expect(exact.known_external_applied).toEqual([filename]);
+    expect(exact.checksum_mismatches).toEqual([]);
+    expect(exact.unknown_applied).toEqual([]);
+
+    const changed = gate.classifyPatchLedgerRows([{ filename, sha256: "0".repeat(64) }], []);
+    expect(changed.checksum_mismatches).toEqual([filename]);
+    expect(changed.known_external_applied).toEqual([]);
+
+    const unknown = gate.classifyPatchLedgerRows([{ filename: "untracked.sql", sha256: "1".repeat(64) }], []);
+    expect(unknown.unknown_applied).toEqual(["untracked.sql"]);
   });
 });


### PR DESCRIPTION
Promotes the exact-checksum historical GED ledger reconciliation required by the real test preflight. No SQL schema change.

## Summary by Sourcery

Tighten the migration release gate by reconciling the historical GED migration using exact checksums and enforcing database state evidence for known externally-applied patches.

Bug Fixes:
- Detect checksum mismatches and incomplete application of the historical GED migration patch in the migration ledger preflight.

Enhancements:
- Introduce reusable classification of migration ledger rows, including handling of known external patches.
- Expose migration ledger classification utilities and known external patch metadata for reuse.

Tests:
- Add tests covering recognition and validation of the historical GED patch with its exact checksum and classification of unknown or mismatched applied migrations.