### PR TITLE
fix(migrations): verify webhook immutability for owner role

### DIFF
--- a/db/patches/support/20260814_api_contract_webhooks_sol28.verify.sql
+++ b/db/patches/support/20260814_api_contract_webhooks_sol28.verify.sql
@@ -43,12 +43,53 @@ BEGIN
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') AND (
     NOT has_table_privilege('cerp_app', 'public.api_webhook_subscriptions', 'SELECT,INSERT,UPDATE')
     OR NOT has_table_privilege('cerp_app', 'public.api_webhook_deliveries', 'SELECT,INSERT,UPDATE')
-    OR has_table_privilege('cerp_app', 'public.api_webhook_audit_events', 'UPDATE,DELETE')
+    OR NOT has_table_privilege('cerp_app', 'public.api_webhook_audit_events', 'SELECT,INSERT')
   ) THEN
     RAISE EXCEPTION 'SOL-28 verify: cerp_app grants are invalid';
   END IF;
 END
 $verify$;
+
+-- The migration role may own these relations, so ownership legitimately implies
+-- UPDATE/DELETE privileges even when those privileges were not explicitly granted.
+-- Prove append-only enforcement through the trigger itself, inside a rolled-back
+-- transaction, instead of inferring it from has_table_privilege().
+BEGIN;
+DO $verify_immutable_runtime$
+DECLARE
+  probe_id bigint;
+  immutable_enforced boolean := false;
+BEGIN
+  INSERT INTO public.api_webhook_audit_events (
+    actor_id,
+    action,
+    entity_type,
+    entity_id,
+    details
+  ) VALUES (
+    NULL,
+    'SOL28_VERIFY_PROBE',
+    'api_webhook_audit_event',
+    'rolled-back-probe',
+    '{"probe": true}'::jsonb
+  )
+  RETURNING id INTO probe_id;
+
+  BEGIN
+    UPDATE public.api_webhook_audit_events
+    SET details = '{"probe": false}'::jsonb
+    WHERE id = probe_id;
+  EXCEPTION
+    WHEN SQLSTATE '55000' THEN
+      immutable_enforced := true;
+  END;
+
+  IF NOT immutable_enforced THEN
+    RAISE EXCEPTION 'SOL-28 verify: immutable audit trigger did not reject an update';
+  END IF;
+END
+$verify_immutable_runtime$;
+ROLLBACK;
 
 SELECT current_database() AS database_name,
        (SELECT count(*) FROM public.api_webhook_subscriptions) AS subscriptions,

--- a/src/__tests__/webhook-migration-sol28.test.ts
+++ b/src/__tests__/webhook-migration-sol28.test.ts
@@ -25,7 +25,14 @@ describe("SOL-28 migration safety contract", () => {
     expect(preflight).toContain("gen_random_uuid");
     expect(preflight).toContain("pg_database_size");
     expect(verify).toContain("immutable evidence triggers are incomplete");
-    expect(verify).toContain("has_table_privilege");
+    expect(verify).toContain(
+      "NOT has_table_privilege('cerp_app', 'public.api_webhook_audit_events', 'SELECT,INSERT')",
+    );
+    expect(verify).not.toContain(
+      "has_table_privilege('cerp_app', 'public.api_webhook_audit_events', 'UPDATE,DELETE')",
+    );
+    expect(verify).toContain("WHEN SQLSTATE '55000'");
+    expect(verify).toMatch(/BEGIN;[\s\S]*SOL28_VERIFY_PROBE[\s\S]*ROLLBACK;/);
     expect(rollback).toContain("rollback refused: webhook business or audit evidence exists");
     expect(rollback).toContain("verify_rollback");
   });


### PR DESCRIPTION
## Correctif SOL-28\n\nLe rôle de migration peut être propriétaire des tables : has_table_privilege ne permet donc pas de déduire l'absence de droits UPDATE/DELETE.\n\n- vérifie les droits applicatifs requis SELECT/INSERT ;\n- prouve l'immutabilité via une tentative UPDATE réellement rejetée par le trigger SQLSTATE 55000 ;\n- exécute la preuve dans une transaction annulée ;\n- validé sur cerp_test.\n\nTests : typecheck, build, test de contrat migration et vérification SQL réelle.

## Summary by Sourcery

Strengthen the SOL-28 webhook migration safety verification by validating application grants and proving audit table immutability via a runtime trigger check executed in a rolled-back transaction.

Bug Fixes:
- Correct webhook audit events privilege checks to only require SELECT/INSERT for the cerp_app role instead of inferring absence of UPDATE/DELETE from has_table_privilege.

Tests:
- Extend the SOL-28 migration safety contract test to assert the updated privilege checks and the presence of the runtime immutability proof logic.