### PR TITLE
release: promote SOL-28 webhook verification fix

### DIFF
--- a/db/patches/support/20260814_api_contract_webhooks_sol28.verify.sql
+++ b/db/patches/support/20260814_api_contract_webhooks_sol28.verify.sql
@@ -43,12 +43,53 @@ BEGIN
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') AND (
     NOT has_table_privilege('cerp_app', 'public.api_webhook_subscriptions', 'SELECT,INSERT,UPDATE')
     OR NOT has_table_privilege('cerp_app', 'public.api_webhook_deliveries', 'SELECT,INSERT,UPDATE')
-    OR has_table_privilege('cerp_app', 'public.api_webhook_audit_events', 'UPDATE,DELETE')
+    OR NOT has_table_privilege('cerp_app', 'public.api_webhook_audit_events', 'SELECT,INSERT')
   ) THEN
     RAISE EXCEPTION 'SOL-28 verify: cerp_app grants are invalid';
   END IF;
 END
 $verify$;
+
+-- The migration role may own these relations, so ownership legitimately implies
+-- UPDATE/DELETE privileges even when those privileges were not explicitly granted.
+-- Prove append-only enforcement through the trigger itself, inside a rolled-back
+-- transaction, instead of inferring it from has_table_privilege().
+BEGIN;
+DO $verify_immutable_runtime$
+DECLARE
+  probe_id bigint;
+  immutable_enforced boolean := false;
+BEGIN
+  INSERT INTO public.api_webhook_audit_events (
+    actor_id,
+    action,
+    entity_type,
+    entity_id,
+    details
+  ) VALUES (
+    NULL,
+    'SOL28_VERIFY_PROBE',
+    'api_webhook_audit_event',
+    'rolled-back-probe',
+    '{"probe": true}'::jsonb
+  )
+  RETURNING id INTO probe_id;
+
+  BEGIN
+    UPDATE public.api_webhook_audit_events
+    SET details = '{"probe": false}'::jsonb
+    WHERE id = probe_id;
+  EXCEPTION
+    WHEN SQLSTATE '55000' THEN
+      immutable_enforced := true;
+  END;
+
+  IF NOT immutable_enforced THEN
+    RAISE EXCEPTION 'SOL-28 verify: immutable audit trigger did not reject an update';
+  END IF;
+END
+$verify_immutable_runtime$;
+ROLLBACK;
 
 SELECT current_database() AS database_name,
        (SELECT count(*) FROM public.api_webhook_subscriptions) AS subscriptions,

--- a/src/__tests__/webhook-migration-sol28.test.ts
+++ b/src/__tests__/webhook-migration-sol28.test.ts
@@ -25,7 +25,14 @@ describe("SOL-28 migration safety contract", () => {
     expect(preflight).toContain("gen_random_uuid");
     expect(preflight).toContain("pg_database_size");
     expect(verify).toContain("immutable evidence triggers are incomplete");
-    expect(verify).toContain("has_table_privilege");
+    expect(verify).toContain(
+      "NOT has_table_privilege('cerp_app', 'public.api_webhook_audit_events', 'SELECT,INSERT')",
+    );
+    expect(verify).not.toContain(
+      "has_table_privilege('cerp_app', 'public.api_webhook_audit_events', 'UPDATE,DELETE')",
+    );
+    expect(verify).toContain("WHEN SQLSTATE '55000'");
+    expect(verify).toMatch(/BEGIN;[\s\S]*SOL28_VERIFY_PROBE[\s\S]*ROLLBACK;/);
     expect(rollback).toContain("rollback refused: webhook business or audit evidence exists");
     expect(rollback).toContain("verify_rollback");
   });


### PR DESCRIPTION
Promotes the SOL-28 database verification correction already validated on the isolated test database. No migration checksum changed; production remains untouched until main is built and revalidated.

## Summary by Sourcery

Strengthen SOL-28 webhook audit verification by enforcing append-only behavior via runtime trigger checks and update the migration safety contract test expectations accordingly.

Enhancements:
- Tighten cerp_app privilege verification on api_webhook_audit_events to require only SELECT and INSERT access.
- Add a transactional runtime probe to confirm the immutable audit trigger rejects updates to webhook audit events.

Tests:
- Adjust SOL-28 migration safety contract tests to assert the new privilege checks and runtime trigger validation are present in the verification script.