### PR TITLE
fix(deploy): include OpenAPI tooling in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY tsconfig.json ./
 COPY src ./src
 # `npm run build` executes the production-data boundary before and after tsc.
 # Keep that guard inside the container build used by Coolify and HyperBox2.
+COPY scripts/openapi ./scripts/openapi
 COPY scripts/security ./scripts/security
 COPY scripts/build ./scripts/build
 RUN npm run build

--- a/src/__tests__/dockerfile.storage.test.ts
+++ b/src/__tests__/dockerfile.storage.test.ts
@@ -10,11 +10,17 @@ const gitAttributes = fs.readFileSync(repoPath(".gitattributes"), "utf8");
 
 describe("Dockerfile storage permissions", () => {
   it("copies every build-time security guard before npm run build", () => {
+    const openApiScriptsIndex = dockerfile.indexOf("COPY scripts/openapi ./scripts/openapi");
     const securityScriptsIndex = dockerfile.indexOf("COPY scripts/security ./scripts/security");
+    const buildScriptsIndex = dockerfile.indexOf("COPY scripts/build ./scripts/build");
     const buildIndex = dockerfile.indexOf("RUN npm run build");
 
+    expect(openApiScriptsIndex).toBeGreaterThanOrEqual(0);
     expect(securityScriptsIndex).toBeGreaterThanOrEqual(0);
+    expect(buildScriptsIndex).toBeGreaterThanOrEqual(0);
+    expect(buildIndex).toBeGreaterThan(openApiScriptsIndex);
     expect(buildIndex).toBeGreaterThan(securityScriptsIndex);
+    expect(buildIndex).toBeGreaterThan(buildScriptsIndex);
   });
 
   it("creates image defaults and revalidates runtime mounts before dropping privileges", () => {


### PR DESCRIPTION
Fixes the Coolify/Docker build boundary introduced by SOL-28: 
pm run build invokes scripts/openapi, so the builder now copies that directory before running the build. Adds a contract test that prevents any required build-time script directory from being omitted.\n\nValidated: 11 Docker contract tests, typecheck, full production build.

## Summary by Sourcery

Ensure Docker builds include all required build-time scripts for OpenAPI and security tooling before running the production build.

Bug Fixes:
- Include the scripts/openapi directory in the Docker build context so OpenAPI tooling is available during npm run build.

Build:
- Enforce that Dockerfile copies scripts/openapi and scripts/build before executing npm run build.

Tests:
- Extend Dockerfile storage permissions tests to require copying of OpenAPI and build script directories before the build step.