### PR TITLE
release: promote SOL-28 Docker build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY tsconfig.json ./
 COPY src ./src
 # `npm run build` executes the production-data boundary before and after tsc.
 # Keep that guard inside the container build used by Coolify and HyperBox2.
+COPY scripts/openapi ./scripts/openapi
 COPY scripts/security ./scripts/security
 COPY scripts/build ./scripts/build
 RUN npm run build

--- a/src/__tests__/dockerfile.storage.test.ts
+++ b/src/__tests__/dockerfile.storage.test.ts
@@ -10,11 +10,17 @@ const gitAttributes = fs.readFileSync(repoPath(".gitattributes"), "utf8");
 
 describe("Dockerfile storage permissions", () => {
   it("copies every build-time security guard before npm run build", () => {
+    const openApiScriptsIndex = dockerfile.indexOf("COPY scripts/openapi ./scripts/openapi");
     const securityScriptsIndex = dockerfile.indexOf("COPY scripts/security ./scripts/security");
+    const buildScriptsIndex = dockerfile.indexOf("COPY scripts/build ./scripts/build");
     const buildIndex = dockerfile.indexOf("RUN npm run build");
 
+    expect(openApiScriptsIndex).toBeGreaterThanOrEqual(0);
     expect(securityScriptsIndex).toBeGreaterThanOrEqual(0);
+    expect(buildScriptsIndex).toBeGreaterThanOrEqual(0);
+    expect(buildIndex).toBeGreaterThan(openApiScriptsIndex);
     expect(buildIndex).toBeGreaterThan(securityScriptsIndex);
+    expect(buildIndex).toBeGreaterThan(buildScriptsIndex);
   });
 
   it("creates image defaults and revalidates runtime mounts before dropping privileges", () => {


### PR DESCRIPTION
Promotes the tested Coolify/Docker build correction for SOL-28 from dev to main.

## Summary by Sourcery

Ensure Docker builds include all required security and build-time guard scripts before running the production build.

Bug Fixes:
- Include the openapi script directory in Docker builds to fix missing build-time guard behavior.

Tests:
- Extend Dockerfile storage permissions tests to assert presence and ordering of openapi and build scripts relative to the build step.