### PR TITLE
fix(deploy): include OpenAPI coverage in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY src ./src
 # `npm run build` executes the production-data boundary before and after tsc.
 # Keep that guard inside the container build used by Coolify and HyperBox2.
 COPY scripts/openapi ./scripts/openapi
+COPY docs/http/openapi-route-coverage.json ./docs/http/openapi-route-coverage.json
 COPY scripts/security ./scripts/security
 COPY scripts/build ./scripts/build
 RUN npm run build

--- a/src/__tests__/dockerfile.storage.test.ts
+++ b/src/__tests__/dockerfile.storage.test.ts
@@ -21,14 +21,19 @@ const packageLock = JSON.parse(fs.readFileSync(repoPath("package-lock.json"), "u
 describe("Dockerfile storage permissions", () => {
   it("copies every build-time security guard before npm run build", () => {
     const openApiScriptsIndex = dockerfile.indexOf("COPY scripts/openapi ./scripts/openapi");
+    const openApiCoverageIndex = dockerfile.indexOf(
+      "COPY docs/http/openapi-route-coverage.json ./docs/http/openapi-route-coverage.json",
+    );
     const securityScriptsIndex = dockerfile.indexOf("COPY scripts/security ./scripts/security");
     const buildScriptsIndex = dockerfile.indexOf("COPY scripts/build ./scripts/build");
     const buildIndex = dockerfile.indexOf("RUN npm run build");
 
     expect(openApiScriptsIndex).toBeGreaterThanOrEqual(0);
+    expect(openApiCoverageIndex).toBeGreaterThan(openApiScriptsIndex);
     expect(securityScriptsIndex).toBeGreaterThanOrEqual(0);
     expect(buildScriptsIndex).toBeGreaterThanOrEqual(0);
     expect(buildIndex).toBeGreaterThan(openApiScriptsIndex);
+    expect(buildIndex).toBeGreaterThan(openApiCoverageIndex);
     expect(buildIndex).toBeGreaterThan(securityScriptsIndex);
     expect(buildIndex).toBeGreaterThan(buildScriptsIndex);
   });


### PR DESCRIPTION
The SOL-28 Docker build now reaches the OpenAPI stale check, which also validates the generated route coverage manifest. Copies that single machine-readable manifest into the builder and extends the Docker contract test.\n\nValidated: Docker contract test and production build.

## Summary by Sourcery

Include the OpenAPI route coverage manifest in the Docker build and enforce its presence and ordering in the Dockerfile contract test.

Deployment:
- Copy the generated OpenAPI route coverage JSON manifest into the Docker image before running the build.

Tests:
- Extend the Dockerfile storage permissions test to assert copying of the OpenAPI route coverage manifest before the build step.