### PR TITLE
release: promote SOL-28 Docker coverage input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY src ./src
 # `npm run build` executes the production-data boundary before and after tsc.
 # Keep that guard inside the container build used by Coolify and HyperBox2.
 COPY scripts/openapi ./scripts/openapi
+COPY docs/http/openapi-route-coverage.json ./docs/http/openapi-route-coverage.json
 COPY scripts/security ./scripts/security
 COPY scripts/build ./scripts/build
 RUN npm run build

--- a/src/__tests__/dockerfile.storage.test.ts
+++ b/src/__tests__/dockerfile.storage.test.ts
@@ -21,14 +21,19 @@ const packageLock = JSON.parse(fs.readFileSync(repoPath("package-lock.json"), "u
 describe("Dockerfile storage permissions", () => {
   it("copies every build-time security guard before npm run build", () => {
     const openApiScriptsIndex = dockerfile.indexOf("COPY scripts/openapi ./scripts/openapi");
+    const openApiCoverageIndex = dockerfile.indexOf(
+      "COPY docs/http/openapi-route-coverage.json ./docs/http/openapi-route-coverage.json",
+    );
     const securityScriptsIndex = dockerfile.indexOf("COPY scripts/security ./scripts/security");
     const buildScriptsIndex = dockerfile.indexOf("COPY scripts/build ./scripts/build");
     const buildIndex = dockerfile.indexOf("RUN npm run build");
 
     expect(openApiScriptsIndex).toBeGreaterThanOrEqual(0);
+    expect(openApiCoverageIndex).toBeGreaterThan(openApiScriptsIndex);
     expect(securityScriptsIndex).toBeGreaterThanOrEqual(0);
     expect(buildScriptsIndex).toBeGreaterThanOrEqual(0);
     expect(buildIndex).toBeGreaterThan(openApiScriptsIndex);
+    expect(buildIndex).toBeGreaterThan(openApiCoverageIndex);
     expect(buildIndex).toBeGreaterThan(securityScriptsIndex);
     expect(buildIndex).toBeGreaterThan(buildScriptsIndex);
   });


### PR DESCRIPTION
Promotes the final OpenAPI builder input required by the Coolify Docker build.

## Summary by Sourcery

Tests:
- Extend Dockerfile storage permissions test to assert copying of the OpenAPI route coverage file before running the build.