### PR TITLE
release: promote SOL-29 client portal

### DIFF
--- a/db/patches/20260814_client_portal_sol29.sql
+++ b/db/patches/20260814_client_portal_sol29.sql
@@ -1,0 +1,328 @@
+-- SOL-29 — minimal isolated client portal.
+-- Additive and safe to replay. Portal identities are deliberately separate
+-- from ERP users and every business projection keeps client_id for the
+-- mandatory repository-side tenant predicate.
+
+BEGIN;
+
+DO $preconditions$
+BEGIN
+  IF current_setting('server_version_num')::integer < 140000 THEN
+    RAISE EXCEPTION 'SOL-29 requires PostgreSQL 14 or newer';
+  END IF;
+  IF to_regclass('public.clients') IS NULL
+     OR to_regclass('public.users') IS NULL
+     OR to_regclass('public.commande_client') IS NULL
+     OR to_regclass('public.commande_historique') IS NULL
+     OR to_regclass('public.bon_livraison') IS NULL
+     OR to_regclass('public.facture') IS NULL
+     OR to_regclass('public.ged_documents') IS NULL
+     OR to_regclass('public.ged_document_versions') IS NULL
+     OR to_regclass('public.ged_upload_sessions') IS NULL THEN
+    RAISE EXCEPTION 'SOL-29 prerequisite relation is missing';
+  END IF;
+END
+$preconditions$;
+
+CREATE TABLE IF NOT EXISTS public.client_portal_accounts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id varchar(3) NOT NULL REFERENCES public.clients(client_id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  email text NOT NULL,
+  email_normalized text NOT NULL,
+  display_name text NOT NULL,
+  password_hash text NOT NULL,
+  status text NOT NULL DEFAULT 'INVITED',
+  session_epoch integer NOT NULL DEFAULT 0,
+  activated_at timestamptz NULL,
+  last_login_at timestamptz NULL,
+  suspended_at timestamptz NULL,
+  revoked_at timestamptz NULL,
+  created_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  updated_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT client_portal_account_email_ck CHECK (
+    email_normalized = lower(btrim(email_normalized))
+    AND char_length(email_normalized) BETWEEN 3 AND 254
+    AND char_length(email) BETWEEN 3 AND 254
+  ),
+  CONSTRAINT client_portal_account_name_ck CHECK (char_length(btrim(display_name)) BETWEEN 2 AND 120),
+  CONSTRAINT client_portal_account_password_ck CHECK (char_length(password_hash) BETWEEN 40 AND 255),
+  CONSTRAINT client_portal_account_status_ck CHECK (status IN ('INVITED','ACTIVE','SUSPENDED','REVOKED')),
+  CONSTRAINT client_portal_account_epoch_ck CHECK (session_epoch >= 0),
+  CONSTRAINT client_portal_account_lifecycle_ck CHECK (
+    (status = 'ACTIVE' AND activated_at IS NOT NULL AND suspended_at IS NULL AND revoked_at IS NULL)
+    OR (status = 'INVITED' AND activated_at IS NULL AND suspended_at IS NULL AND revoked_at IS NULL)
+    OR (status = 'SUSPENDED' AND activated_at IS NOT NULL AND suspended_at IS NOT NULL AND revoked_at IS NULL)
+    OR (status = 'REVOKED' AND revoked_at IS NOT NULL)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS client_portal_accounts_email_active_uq
+  ON public.client_portal_accounts(email_normalized)
+  WHERE status <> 'REVOKED';
+CREATE INDEX IF NOT EXISTS client_portal_accounts_client_idx
+  ON public.client_portal_accounts(client_id, status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.client_portal_tokens (
+  id uuid PRIMARY KEY,
+  account_id uuid NOT NULL REFERENCES public.client_portal_accounts(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  purpose text NOT NULL,
+  token_hash text NOT NULL UNIQUE,
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz NULL,
+  revoked_at timestamptz NULL,
+  created_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT client_portal_token_purpose_ck CHECK (purpose IN ('INVITATION','PASSWORD_RESET')),
+  CONSTRAINT client_portal_token_hash_ck CHECK (token_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT client_portal_token_expiry_ck CHECK (expires_at > created_at),
+  CONSTRAINT client_portal_token_lifecycle_ck CHECK (consumed_at IS NULL OR revoked_at IS NULL)
+);
+
+CREATE INDEX IF NOT EXISTS client_portal_tokens_active_idx
+  ON public.client_portal_tokens(account_id, purpose, expires_at DESC)
+  WHERE consumed_at IS NULL AND revoked_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS public.client_portal_command_receipts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  erp_actor_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  action text NOT NULL,
+  idempotency_key uuid NOT NULL,
+  request_sha256 text NOT NULL,
+  result jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT client_portal_receipt_action_ck CHECK (char_length(action) BETWEEN 2 AND 80),
+  CONSTRAINT client_portal_receipt_hash_ck CHECK (request_sha256 ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT client_portal_receipt_result_ck CHECK (jsonb_typeof(result) = 'object'),
+  CONSTRAINT client_portal_receipt_uq UNIQUE (erp_actor_id, action, idempotency_key)
+);
+
+CREATE TABLE IF NOT EXISTS public.client_portal_publications (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id varchar(3) NOT NULL REFERENCES public.clients(client_id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  version_id uuid NOT NULL REFERENCES public.ged_document_versions(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  title_override text NULL,
+  acknowledgement_required boolean NOT NULL DEFAULT false,
+  expires_at timestamptz NULL,
+  revoked_at timestamptz NULL,
+  revoked_reason text NULL,
+  published_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  revoked_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT client_portal_publication_title_ck CHECK (
+    title_override IS NULL OR char_length(btrim(title_override)) BETWEEN 2 AND 180
+  ),
+  CONSTRAINT client_portal_publication_expiry_ck CHECK (expires_at IS NULL OR expires_at > created_at),
+  CONSTRAINT client_portal_publication_revocation_ck CHECK (
+    (revoked_at IS NULL AND revoked_by IS NULL AND revoked_reason IS NULL)
+    OR (revoked_at IS NOT NULL AND revoked_by IS NOT NULL AND char_length(btrim(revoked_reason)) BETWEEN 3 AND 500)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS client_portal_publications_active_uq
+  ON public.client_portal_publications(client_id, version_id)
+  WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS client_portal_publications_client_idx
+  ON public.client_portal_publications(client_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.client_portal_acknowledgements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  publication_id uuid NOT NULL REFERENCES public.client_portal_publications(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  account_id uuid NOT NULL REFERENCES public.client_portal_accounts(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  acknowledged_at timestamptz NOT NULL DEFAULT now(),
+  request_id text NULL,
+  CONSTRAINT client_portal_ack_request_ck CHECK (request_id IS NULL OR char_length(request_id) <= 160),
+  CONSTRAINT client_portal_ack_uq UNIQUE (publication_id, account_id)
+);
+
+CREATE OR REPLACE FUNCTION public.fn_client_portal_ack_tenant_guard_sol29()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  account_client_id varchar(3);
+  publication_client_id varchar(3);
+BEGIN
+  SELECT client_id INTO account_client_id
+    FROM public.client_portal_accounts
+   WHERE id = NEW.account_id;
+  SELECT client_id INTO publication_client_id
+    FROM public.client_portal_publications
+   WHERE id = NEW.publication_id;
+  IF account_client_id IS NULL
+     OR publication_client_id IS NULL
+     OR account_client_id <> publication_client_id THEN
+    RAISE EXCEPTION 'SOL-29 cross-client acknowledgement refused' USING ERRCODE = '42501';
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_client_portal_ack_tenant_guard_sol29 ON public.client_portal_acknowledgements;
+CREATE TRIGGER trg_client_portal_ack_tenant_guard_sol29
+BEFORE INSERT ON public.client_portal_acknowledgements
+FOR EACH ROW EXECUTE FUNCTION public.fn_client_portal_ack_tenant_guard_sol29();
+
+CREATE TABLE IF NOT EXISTS public.client_portal_audit_events (
+  id bigserial PRIMARY KEY,
+  erp_actor_id integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  portal_account_id uuid NULL REFERENCES public.client_portal_accounts(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  action text NOT NULL,
+  entity_type text NOT NULL,
+  entity_id text NOT NULL,
+  client_id varchar(3) NULL REFERENCES public.clients(client_id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  request_id text NULL,
+  ip_hash text NULL,
+  user_agent_family text NULL,
+  details jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT client_portal_audit_actor_ck CHECK (num_nonnulls(erp_actor_id, portal_account_id) <= 1),
+  CONSTRAINT client_portal_audit_action_ck CHECK (char_length(action) BETWEEN 2 AND 120),
+  CONSTRAINT client_portal_audit_entity_ck CHECK (
+    char_length(entity_type) BETWEEN 2 AND 80 AND char_length(entity_id) BETWEEN 1 AND 160
+  ),
+  CONSTRAINT client_portal_audit_request_ck CHECK (request_id IS NULL OR char_length(request_id) <= 160),
+  CONSTRAINT client_portal_audit_ip_ck CHECK (ip_hash IS NULL OR ip_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT client_portal_audit_ua_ck CHECK (user_agent_family IS NULL OR char_length(user_agent_family) <= 80),
+  CONSTRAINT client_portal_audit_details_ck CHECK (
+    jsonb_typeof(details) = 'object' AND octet_length(details::text) <= 32768
+  )
+);
+
+CREATE INDEX IF NOT EXISTS client_portal_audit_client_idx
+  ON public.client_portal_audit_events(client_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS client_portal_audit_account_idx
+  ON public.client_portal_audit_events(portal_account_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.client_portal_auth_attempts (
+  id bigserial PRIMARY KEY,
+  action text NOT NULL,
+  identifier_hash text NOT NULL,
+  ip_hash text NULL,
+  success boolean NOT NULL,
+  occurred_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT client_portal_auth_attempt_action_ck CHECK (action IN ('LOGIN','ACTIVATE','FORGOT_PASSWORD','RESET_PASSWORD')),
+  CONSTRAINT client_portal_auth_attempt_identifier_ck CHECK (identifier_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT client_portal_auth_attempt_ip_ck CHECK (ip_hash IS NULL OR ip_hash ~ '^[0-9a-f]{64}$')
+);
+
+CREATE INDEX IF NOT EXISTS client_portal_auth_attempts_lookup_idx
+  ON public.client_portal_auth_attempts(action, identifier_hash, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS client_portal_auth_attempts_ip_idx
+  ON public.client_portal_auth_attempts(action, ip_hash, occurred_at DESC)
+  WHERE ip_hash IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.fn_client_portal_evidence_immutable_sol29()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  RAISE EXCEPTION 'SOL-29 client portal evidence is immutable' USING ERRCODE = '55000';
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_client_portal_receipts_immutable_sol29 ON public.client_portal_command_receipts;
+CREATE TRIGGER trg_client_portal_receipts_immutable_sol29
+BEFORE UPDATE OR DELETE ON public.client_portal_command_receipts
+FOR EACH ROW EXECUTE FUNCTION public.fn_client_portal_evidence_immutable_sol29();
+
+DROP TRIGGER IF EXISTS trg_client_portal_ack_immutable_sol29 ON public.client_portal_acknowledgements;
+CREATE TRIGGER trg_client_portal_ack_immutable_sol29
+BEFORE UPDATE OR DELETE ON public.client_portal_acknowledgements
+FOR EACH ROW EXECUTE FUNCTION public.fn_client_portal_evidence_immutable_sol29();
+
+DROP TRIGGER IF EXISTS trg_client_portal_audit_immutable_sol29 ON public.client_portal_audit_events;
+CREATE TRIGGER trg_client_portal_audit_immutable_sol29
+BEFORE UPDATE OR DELETE ON public.client_portal_audit_events
+FOR EACH ROW EXECUTE FUNCTION public.fn_client_portal_evidence_immutable_sol29();
+
+CREATE OR REPLACE VIEW public.client_portal_orders_v
+WITH (security_barrier = true)
+AS
+SELECT
+  cc.client_id,
+  cc.id::text AS id,
+  cc.numero,
+  cc.date_commande::text AS date_commande,
+  COALESCE(st.nouveau_statut, 'BROUILLON')::text AS statut,
+  cc.total_ht::float8 AS total_ht,
+  cc.total_ttc::float8 AS total_ttc,
+  NULLIF(btrim(to_jsonb(c)->>'devise'), '') AS currency,
+  cc.updated_at::text AS updated_at
+FROM public.commande_client cc
+JOIN public.clients c ON c.client_id = cc.client_id
+LEFT JOIN LATERAL (
+  SELECT COALESCE(
+           NULLIF(to_jsonb(ch)->>'nouveau_statut', ''),
+           NULLIF((to_jsonb(ch)->'details')->>'nouveau_statut', ''),
+           NULLIF((to_jsonb(ch)->'details')->>'to', '')
+         ) AS nouveau_statut
+  FROM public.commande_historique ch
+  WHERE ch.commande_id = cc.id
+  ORDER BY ch.date_action DESC, ch.id DESC
+  LIMIT 1
+) st ON true
+WHERE upper(COALESCE(st.nouveau_statut, 'BROUILLON')) <> 'BROUILLON';
+
+CREATE OR REPLACE VIEW public.client_portal_deliveries_v
+WITH (security_barrier = true)
+AS
+SELECT
+  bl.client_id,
+  bl.id::text AS id,
+  bl.numero,
+  bl.statut::text AS statut,
+  bl.commande_id::text AS commande_id,
+  cc.numero AS commande_numero,
+  bl.date_creation::text AS date_creation,
+  bl.date_expedition::text AS date_expedition,
+  bl.date_livraison::text AS date_livraison,
+  bl.transporteur,
+  bl.tracking_number,
+  bl.updated_at::text AS updated_at
+FROM public.bon_livraison bl
+LEFT JOIN public.commande_client cc ON cc.id = bl.commande_id
+WHERE upper(bl.statut::text) <> 'DRAFT';
+
+CREATE OR REPLACE VIEW public.client_portal_invoices_v
+WITH (security_barrier = true)
+AS
+SELECT
+  f.client_id,
+  f.id::text AS id,
+  f.numero,
+  f.commande_id::text AS commande_id,
+  f.date_emission::text AS date_emission,
+  f.date_echeance::text AS date_echeance,
+  f.statut::text AS statut,
+  f.document_status::text AS document_status,
+  f.settlement_status::text AS settlement_status,
+  f.total_ht::float8 AS total_ht,
+  f.total_ttc::float8 AS total_ttc,
+  NULLIF(btrim(to_jsonb(c)->>'devise'), '') AS currency,
+  f.updated_at::text AS updated_at
+FROM public.facture f
+JOIN public.clients c ON c.client_id = f.client_id
+WHERE upper(COALESCE(f.document_status::text, f.statut::text, 'DRAFT')) NOT IN ('DRAFT','BROUILLON');
+
+DO $grants$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT, INSERT, UPDATE ON public.client_portal_accounts TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE ON public.client_portal_tokens TO cerp_app;
+    GRANT SELECT, INSERT ON public.client_portal_command_receipts TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE ON public.client_portal_publications TO cerp_app;
+    GRANT SELECT, INSERT ON public.client_portal_acknowledgements TO cerp_app;
+    GRANT SELECT, INSERT ON public.client_portal_audit_events TO cerp_app;
+    GRANT SELECT, INSERT, DELETE ON public.client_portal_auth_attempts TO cerp_app;
+    GRANT SELECT ON public.client_portal_orders_v TO cerp_app;
+    GRANT SELECT ON public.client_portal_deliveries_v TO cerp_app;
+    GRANT SELECT ON public.client_portal_invoices_v TO cerp_app;
+    GRANT USAGE, SELECT ON SEQUENCE public.client_portal_audit_events_id_seq TO cerp_app;
+    GRANT USAGE, SELECT ON SEQUENCE public.client_portal_auth_attempts_id_seq TO cerp_app;
+  END IF;
+END
+$grants$;
+
+COMMIT;

--- a/db/patches/support/20260814_client_portal_sol29.preflight.sql
+++ b/db/patches/support/20260814_client_portal_sol29.preflight.sql
@@ -1,0 +1,33 @@
+-- Read-only SOL-29 preflight. Run after a verified backup.
+DO $preflight$
+DECLARE
+  missing text[] := ARRAY[]::text[];
+BEGIN
+  IF current_setting('server_version_num')::integer < 140000 THEN
+    RAISE EXCEPTION 'SOL-29 preflight: PostgreSQL 14 or newer is required';
+  END IF;
+  IF to_regclass('public.clients') IS NULL THEN missing := array_append(missing, 'clients'); END IF;
+  IF to_regclass('public.users') IS NULL THEN missing := array_append(missing, 'users'); END IF;
+  IF to_regclass('public.commande_client') IS NULL THEN missing := array_append(missing, 'commande_client'); END IF;
+  IF to_regclass('public.commande_historique') IS NULL THEN missing := array_append(missing, 'commande_historique'); END IF;
+  IF to_regclass('public.bon_livraison') IS NULL THEN missing := array_append(missing, 'bon_livraison'); END IF;
+  IF to_regclass('public.facture') IS NULL THEN missing := array_append(missing, 'facture'); END IF;
+  IF to_regclass('public.ged_documents') IS NULL THEN missing := array_append(missing, 'ged_documents'); END IF;
+  IF to_regclass('public.ged_document_versions') IS NULL THEN missing := array_append(missing, 'ged_document_versions'); END IF;
+  IF to_regclass('public.ged_upload_sessions') IS NULL THEN missing := array_append(missing, 'ged_upload_sessions'); END IF;
+  IF cardinality(missing) > 0 THEN
+    RAISE EXCEPTION 'SOL-29 preflight: missing relation(s): %', array_to_string(missing, ', ');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'gen_random_uuid' AND pg_function_is_visible(oid)) THEN
+    RAISE EXCEPTION 'SOL-29 preflight: gen_random_uuid() is unavailable';
+  END IF;
+END
+$preflight$;
+
+SELECT current_database() AS database_name,
+       current_setting('server_version') AS postgres_version,
+       pg_database_size(current_database()) AS database_size_bytes,
+       (SELECT count(*) FROM public.clients) AS client_count,
+       (SELECT count(*) FROM public.ged_document_versions) AS ged_version_count,
+       now() AS checked_at;
+

--- a/db/patches/support/20260814_client_portal_sol29.rollback.sql
+++ b/db/patches/support/20260814_client_portal_sol29.rollback.sql
@@ -1,0 +1,51 @@
+-- Rollback is permitted only before any portal identity, publication or audit
+-- evidence exists. Once used, disable the routes and preserve the evidence.
+BEGIN;
+
+DO $rollback_guard$
+DECLARE
+  evidence bigint := 0;
+BEGIN
+  IF to_regclass('public.client_portal_accounts') IS NOT NULL THEN
+    EXECUTE 'SELECT count(*) FROM public.client_portal_accounts' INTO evidence;
+  END IF;
+  IF evidence = 0 AND to_regclass('public.client_portal_publications') IS NOT NULL THEN
+    EXECUTE 'SELECT count(*) FROM public.client_portal_publications' INTO evidence;
+  END IF;
+  IF evidence = 0 AND to_regclass('public.client_portal_audit_events') IS NOT NULL THEN
+    EXECUTE 'SELECT count(*) FROM public.client_portal_audit_events' INTO evidence;
+  END IF;
+  IF evidence > 0 THEN
+    RAISE EXCEPTION 'SOL-29 rollback refused: portal identity, publication or audit evidence exists';
+  END IF;
+END
+$rollback_guard$;
+
+DROP VIEW IF EXISTS public.client_portal_invoices_v;
+DROP VIEW IF EXISTS public.client_portal_deliveries_v;
+DROP VIEW IF EXISTS public.client_portal_orders_v;
+DROP TRIGGER IF EXISTS trg_client_portal_ack_tenant_guard_sol29 ON public.client_portal_acknowledgements;
+DROP TRIGGER IF EXISTS trg_client_portal_receipts_immutable_sol29 ON public.client_portal_command_receipts;
+DROP TRIGGER IF EXISTS trg_client_portal_ack_immutable_sol29 ON public.client_portal_acknowledgements;
+DROP TRIGGER IF EXISTS trg_client_portal_audit_immutable_sol29 ON public.client_portal_audit_events;
+DROP TABLE IF EXISTS public.client_portal_auth_attempts;
+DROP TABLE IF EXISTS public.client_portal_audit_events;
+DROP TABLE IF EXISTS public.client_portal_acknowledgements;
+DROP TABLE IF EXISTS public.client_portal_publications;
+DROP TABLE IF EXISTS public.client_portal_command_receipts;
+DROP TABLE IF EXISTS public.client_portal_tokens;
+DROP TABLE IF EXISTS public.client_portal_accounts;
+DROP FUNCTION IF EXISTS public.fn_client_portal_ack_tenant_guard_sol29();
+DROP FUNCTION IF EXISTS public.fn_client_portal_evidence_immutable_sol29();
+
+COMMIT;
+
+DO $verify_rollback$
+BEGIN
+  IF to_regclass('public.client_portal_accounts') IS NOT NULL
+     OR to_regclass('public.client_portal_publications') IS NOT NULL
+     OR to_regclass('public.client_portal_audit_events') IS NOT NULL THEN
+    RAISE EXCEPTION 'SOL-29 rollback verification failed';
+  END IF;
+END
+$verify_rollback$;

--- a/db/patches/support/20260814_client_portal_sol29.verify.sql
+++ b/db/patches/support/20260814_client_portal_sol29.verify.sql
@@ -1,0 +1,141 @@
+DO $verify$
+DECLARE
+  missing text[] := ARRAY[]::text[];
+  invalid bigint;
+  immutable_triggers integer;
+  tenant_guard_triggers integer;
+BEGIN
+  IF to_regclass('public.client_portal_accounts') IS NULL THEN missing := array_append(missing, 'client_portal_accounts'); END IF;
+  IF to_regclass('public.client_portal_tokens') IS NULL THEN missing := array_append(missing, 'client_portal_tokens'); END IF;
+  IF to_regclass('public.client_portal_command_receipts') IS NULL THEN missing := array_append(missing, 'client_portal_command_receipts'); END IF;
+  IF to_regclass('public.client_portal_publications') IS NULL THEN missing := array_append(missing, 'client_portal_publications'); END IF;
+  IF to_regclass('public.client_portal_acknowledgements') IS NULL THEN missing := array_append(missing, 'client_portal_acknowledgements'); END IF;
+  IF to_regclass('public.client_portal_audit_events') IS NULL THEN missing := array_append(missing, 'client_portal_audit_events'); END IF;
+  IF to_regclass('public.client_portal_auth_attempts') IS NULL THEN missing := array_append(missing, 'client_portal_auth_attempts'); END IF;
+  IF to_regclass('public.client_portal_orders_v') IS NULL THEN missing := array_append(missing, 'client_portal_orders_v'); END IF;
+  IF to_regclass('public.client_portal_deliveries_v') IS NULL THEN missing := array_append(missing, 'client_portal_deliveries_v'); END IF;
+  IF to_regclass('public.client_portal_invoices_v') IS NULL THEN missing := array_append(missing, 'client_portal_invoices_v'); END IF;
+  IF cardinality(missing) > 0 THEN
+    RAISE EXCEPTION 'SOL-29 verify: missing relation(s): %', array_to_string(missing, ', ');
+  END IF;
+
+  SELECT count(*) INTO invalid FROM public.client_portal_accounts a
+  LEFT JOIN public.clients c ON c.client_id = a.client_id
+  WHERE c.client_id IS NULL OR a.email_normalized <> lower(btrim(a.email_normalized)) OR a.session_epoch < 0;
+  IF invalid > 0 THEN RAISE EXCEPTION 'SOL-29 verify: % invalid portal account row(s)', invalid; END IF;
+
+  SELECT count(*) INTO invalid
+  FROM public.client_portal_acknowledgements ack
+  JOIN public.client_portal_accounts account ON account.id = ack.account_id
+  JOIN public.client_portal_publications publication ON publication.id = ack.publication_id
+  WHERE account.client_id <> publication.client_id;
+  IF invalid > 0 THEN RAISE EXCEPTION 'SOL-29 verify: % cross-client acknowledgement row(s)', invalid; END IF;
+
+  SELECT count(*) INTO immutable_triggers
+  FROM pg_trigger
+  WHERE NOT tgisinternal AND tgname IN (
+    'trg_client_portal_receipts_immutable_sol29',
+    'trg_client_portal_ack_immutable_sol29',
+    'trg_client_portal_audit_immutable_sol29'
+  );
+  IF immutable_triggers <> 3 THEN
+    RAISE EXCEPTION 'SOL-29 verify: immutable evidence triggers are incomplete';
+  END IF;
+
+  SELECT count(*) INTO tenant_guard_triggers
+  FROM pg_trigger
+  WHERE NOT tgisinternal AND tgname = 'trg_client_portal_ack_tenant_guard_sol29';
+  IF tenant_guard_triggers <> 1 THEN
+    RAISE EXCEPTION 'SOL-29 verify: acknowledgement tenant guard is missing';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') AND (
+    NOT has_table_privilege('cerp_app', 'public.client_portal_accounts', 'SELECT,INSERT,UPDATE')
+    OR NOT has_table_privilege('cerp_app', 'public.client_portal_publications', 'SELECT,INSERT,UPDATE')
+    OR NOT has_table_privilege('cerp_app', 'public.client_portal_audit_events', 'SELECT,INSERT')
+    OR NOT has_table_privilege('cerp_app', 'public.client_portal_orders_v', 'SELECT')
+  ) THEN
+    RAISE EXCEPTION 'SOL-29 verify: cerp_app grants are invalid';
+  END IF;
+END
+$verify$;
+
+BEGIN;
+DO $verify_immutable_runtime$
+DECLARE
+  probe_id bigint;
+  rejected boolean := false;
+BEGIN
+  INSERT INTO public.client_portal_audit_events(action, entity_type, entity_id, details)
+  VALUES ('SOL29_VERIFY_PROBE', 'portal_probe', 'rolled-back', '{"probe":true}'::jsonb)
+  RETURNING id INTO probe_id;
+  BEGIN
+    UPDATE public.client_portal_audit_events SET details = '{"probe":false}'::jsonb WHERE id = probe_id;
+  EXCEPTION WHEN SQLSTATE '55000' THEN rejected := true;
+  END;
+  IF NOT rejected THEN RAISE EXCEPTION 'SOL-29 verify: immutable audit trigger did not reject an update'; END IF;
+END
+$verify_immutable_runtime$;
+ROLLBACK;
+
+BEGIN;
+DO $verify_ack_tenant_guard_runtime$
+DECLARE
+  first_client varchar(3);
+  second_client varchar(3);
+  actor integer;
+  first_account uuid;
+  second_account uuid;
+  publication uuid;
+  probe_version_id uuid;
+  first_email text;
+  second_email text;
+  rejected boolean := false;
+BEGIN
+  SELECT min(client_id), max(client_id) INTO first_client, second_client FROM public.clients;
+  SELECT id INTO actor FROM public.users ORDER BY id LIMIT 1;
+  SELECT id INTO probe_version_id FROM public.ged_document_versions ORDER BY created_at, id LIMIT 1;
+  IF first_client IS NULL OR second_client IS NULL OR first_client = second_client OR actor IS NULL OR probe_version_id IS NULL THEN
+    RETURN;
+  END IF;
+  first_email := format('sol29-guard-a-%s@invalid.example', txid_current());
+  second_email := format('sol29-guard-b-%s@invalid.example', txid_current());
+  INSERT INTO public.client_portal_accounts(
+    client_id,email,email_normalized,display_name,password_hash,status,created_by,updated_by
+  ) VALUES (
+    first_client,first_email,first_email,'SOL29 Guard A',repeat('x',60),'INVITED',actor,actor
+  ) RETURNING id INTO first_account;
+  INSERT INTO public.client_portal_accounts(
+    client_id,email,email_normalized,display_name,password_hash,status,created_by,updated_by
+  ) VALUES (
+    second_client,second_email,second_email,'SOL29 Guard B',repeat('x',60),'INVITED',actor,actor
+  ) RETURNING id INTO second_account;
+  INSERT INTO public.client_portal_publications(client_id,version_id,title_override,published_by)
+  VALUES (first_client,probe_version_id,'SOL29 tenant guard probe',actor)
+  ON CONFLICT DO NOTHING
+  RETURNING id INTO publication;
+  IF publication IS NULL THEN
+    SELECT id INTO publication
+     FROM public.client_portal_publications
+     WHERE client_id=first_client AND client_portal_publications.version_id=probe_version_id
+     LIMIT 1;
+  END IF;
+  IF publication IS NULL THEN RAISE EXCEPTION 'SOL-29 verify: tenant guard probe publication unavailable'; END IF;
+  BEGIN
+    INSERT INTO public.client_portal_acknowledgements(publication_id,account_id)
+    VALUES (publication,second_account);
+  EXCEPTION WHEN SQLSTATE '42501' THEN rejected := true;
+  END;
+  IF NOT rejected THEN
+    RAISE EXCEPTION 'SOL-29 verify: cross-client acknowledgement was accepted';
+  END IF;
+END
+$verify_ack_tenant_guard_runtime$;
+ROLLBACK;
+
+SELECT current_database() AS database_name,
+       (SELECT count(*) FROM public.client_portal_accounts) AS accounts,
+       (SELECT count(*) FROM public.client_portal_publications) AS publications,
+       (SELECT count(*) FROM public.client_portal_acknowledgements) AS acknowledgements,
+       (SELECT count(*) FROM public.client_portal_audit_events) AS audit_events,
+       now() AS verified_at;

--- a/docs/adr/ADR-0075-client-portal-isolation.md
+++ b/docs/adr/ADR-0075-client-portal-isolation.md
@@ -1,0 +1,36 @@
+# ADR-0075 — Frontière d’isolation du portail client
+
+- Statut : accepté
+- Date : 2026-08-14
+- Propriétaire : Keenan Martin
+- Périmètre : `/api/v1/portal`, `/api/v1/admin/client-portal`, GED et projections commerciales
+
+## Contexte
+
+Un compte ERP donne accès à des modules internes, des données transverses et un choix de base. Le réutiliser pour un client externe rendrait une erreur de permission trop dangereuse. Les commandes, livraisons, factures et documents contiennent en outre des états internes ou provisoires qui ne doivent pas être présentés au client.
+
+## Décision
+
+1. Une identité portail est distincte de `users`. Elle est rattachée à exactement un `client_id` et ne reçoit aucun rôle ERP, aucun sélecteur de base et aucun accès websocket interne.
+2. Le portail utilise un secret JWT dédié, l’audience `cerp-client-portal`, l’émetteur `cerp-api`, un objet `client-portal-session-v1` et une durée de 15 minutes. Le middleware vérifie à chaque requête le statut `ACTIVE`, le client et `session_epoch` en base. Suspension, révocation ou changement de mot de passe invalide donc immédiatement les sessions existantes.
+3. Le navigateur ne fournit jamais `client_id` pour filtrer les listes. Le dépôt le prend exclusivement dans l’identité vérifiée et applique `WHERE client_id=$1`. Un paramètre `client_id` inattendu est rejeté par la validation stricte.
+4. Les vues PostgreSQL `client_portal_orders_v`, `client_portal_deliveries_v` et `client_portal_invoices_v` sont des projections en liste blanche avec `security_barrier`. Les brouillons ne sont pas exposés. Le code ne permet pas de choisir arbitrairement une table ou une vue.
+5. Les documents ne sont visibles qu’après une publication explicite vers le même client. Une publication exige une version GED courante, applicable, non archivée et reliée au client, à sa commande, sa facture ou son bon de livraison. Le téléchargement exige en plus un verdict antivirus sain et une quarantaine libérée.
+6. Les états documentaires publics sont `AVAILABLE`, `PENDING_SCAN`, `QUARANTINED`, `EXPIRED`, `REPLACED`, `UNAVAILABLE` et `REVOKED`. Un état non disponible n’est jamais remplacé par une version précédente ni converti en succès vide.
+7. Création, invitation et publication administratives exigent un superadministrateur ERP et une `Idempotency-Key` UUID. Le reçu persistant associe acteur, action, empreinte de requête et résultat ; un retry identique rejoue le résultat et une charge différente retourne un conflit.
+8. Invitation et récupération sont des jetons à usage unique. Seul leur SHA-256 est stocké. L’invitation expire après 24 heures, la récupération après une heure. Les mots de passe ont au moins 12 caractères avec les quatre classes et sont hachés en bcrypt coût 12.
+9. Les réponses de connexion et de récupération ne révèlent pas l’existence d’un compte. Les limites sont persistées en PostgreSQL et sérialisées par verrous consultatifs : connexion 5 tentatives/identifiant et 30/IP sur 15 minutes ; récupération 4/identifiant et 20/IP par heure ; activation ou reset 8/jeton et 30/IP par heure.
+10. Connexion, invitation, activation, récupération, changement d’état, publication, révocation, téléchargement, échec d’intégrité et accusé de lecture sont audités. L’audit conserve un hash d’IP et une famille d’agent, jamais l’adresse email, le mot de passe, le jeton, le contenu ou la clé de stockage.
+11. Les reçus de commande, accusés et événements d’audit sont append-only. Un trigger PostgreSQL refuse en plus tout accusé entre un compte et une publication de clients différents.
+12. Le pilote est strictement consultatif : aucune mutation de commande, validation contractuelle, signature ni paiement. La MFA n’est donc pas imposée au pilote. Elle devient un prérequis avant toute extension à une action engageante ; le choix cible est WebAuthn/passkey avec TOTP de secours, et non SMS.
+
+## Session navigateur et risque résiduel
+
+Le jeton portail est conservé dans un espace navigateur dédié, séparé du jeton ERP, et supprimé à son expiration. Sa durée courte et la validation en base limitent le rejeu, mais un script injecté dans la même origine pourrait le lire. La politique CSP, l’absence de HTML non fiable et la protection XSS restent donc obligatoires. Une session serveur en cookie `HttpOnly` ou un schéma BFF doit être retenu avant ouverture multi-domaines ou ajout d’actions engageantes.
+
+## Conséquences
+
+- Une fuite par simple filtre de requête est bloquée à la fois dans le contrôleur, le dépôt et, pour les accusés, par la base.
+- Les champs publics sont intentionnellement moins nombreux que les modèles internes ; toute extension nécessite une revue de cette ADR et des tests inter-clients négatifs.
+- `CLIENT_PORTAL_JWT_SECRET` doit être une valeur aléatoire d’au moins 32 caractères, distincte de `JWT_SECRET`, et être provisionnée séparément sur chaque environnement.
+- Le retrait SQL n’est possible qu’avant toute preuve portail. Après usage, on désactive les routes et on conserve les comptes, publications et audits.

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -697,3 +697,7 @@ after a verified encrypted backup, apply only the immutable registered patch,
 then run the verify script and an idempotent replay. Rollback is allowed only
 before any subscription, delivery, command receipt or audit evidence exists;
 after use, disable the worker and preserve evidence.
+
+# 2026-08-14 — Portail client isolé (SOL-29)
+
+`20260814_client_portal_sol29.sql` ajoute les identités portail séparées des utilisateurs ERP, les jetons à usage unique, reçus idempotents, publications GED explicites, accusés et audits append-only, limites d’authentification persistées et trois projections commerciales en liste blanche. Le trigger `trg_client_portal_ack_tenant_guard_sol29` refuse aussi un accusé entre deux clients différents. Exécuter le preflight après une sauvegarde vérifiée, appliquer seulement le patch immuable, lancer le verify puis un replay. Le rollback est autorisé uniquement avant toute preuve portail ; après usage, désactiver les routes et conserver les données d’audit.

--- a/docs/execution-reports/SOL-29.md
+++ b/docs/execution-reports/SOL-29.md
@@ -1,0 +1,84 @@
+# SOL-29 — Portail client minimal et isolé
+
+- Date : 2026-08-14
+- Propriétaire : Keenan Martin
+- Issue : `BigFootLime/crp-systems-web#704`
+- Branche : `feature/704-client-portal`
+- Statut fonctionnel : implémenté et validé avant promotion ; les preuves de migration et de déploiement réels seront ajoutées après promotion.
+
+## Diagnostic et cause racine
+
+L'ERP ne possédait pas de frontière client dédiée. Réutiliser les comptes internes, leurs JWT ou les routes ERP aurait permis une confusion de rôles et aurait fait dépendre l'isolation du navigateur. La GED ne disposait pas non plus d'une publication explicite, révocable et limitée à un client.
+
+Pendant l'E2E réel de téléchargement, Node 24 a révélé un second défaut : la lecture d'intégrité via `for await` fermait implicitement le descripteur partagé avant la diffusion HTTP (`EBADF`). Le téléchargement est maintenant vérifié par lectures positionnelles bornées sur le même `FileHandle`, puis diffusé avec ce descripteur encore ouvert.
+
+## Choix d'architecture et frontière de données
+
+- Les comptes portail sont séparés des utilisateurs ERP. Ils ont leur propre secret JWT, audience `cerp-client-portal`, expiration de 15 minutes, statut et `session_epoch` relus en base à chaque requête.
+- Le navigateur ne transmet jamais de `client_id`. Toutes les requêtes partent de l'identité portail et utilisent des vues SQL à projection explicitement autorisée.
+- Les invitations et récupérations sont à usage unique ; seul le SHA-256 du jeton est conservé. Les mots de passe sont hachés avec bcrypt coût 12.
+- Les créations et invitations administratives sont idempotentes. Les limites de débit sont persistées en PostgreSQL et verrouillées de façon déterministe sur IP et identifiant.
+- Les commandes, livraisons et factures exposées excluent les brouillons et publient source, fraîcheur et fiabilité. Une valeur absente reste `null` et n'est jamais transformée en zéro.
+- Un document GED n'est visible qu'après publication explicite à un client. Le téléchargement exige une version courante, propre et disponible. Les états `pending`, `quarantined`, `expired`, `replaced`, `unavailable` et `revoked` sont explicites.
+- Les connexions, téléchargements, accusés, invitations, activations, suspensions, révocations et publications alimentent un audit append-only sans email brut, mot de passe, jeton, contenu documentaire ni IP brute.
+- MFA est différée pour ce pilote strictement consultatif. Avant toute mutation métier, paiement ou ouverture multi-domaine, l'ADR impose WebAuthn/passkey avec TOTP de secours et une session HttpOnly/BFF.
+
+## Fichiers modifiés
+
+- Domaine backend : `src/module/client-portal/`.
+- Montage et configuration : `src/routes/v1.routes.ts`, `src/config/app.ts`, `src/index.ts`.
+- Téléchargement sûr : `src/shared/uploads/secure-download.ts` et son test de régression.
+- Contrat : `src/swagger/openapi-contract.ts`, inventaire généré et rapport de couverture.
+- Base : `db/patches/20260814_client_portal_sol29.sql` et scripts `preflight`, `verify`, `rollback` associés.
+- E2E : `scripts/e2e/client-portal-sol29-seed.js` et adaptation du runner isolé côté frontend.
+- Documentation : ADR-0075, contrat HTTP, runbook et présent rapport.
+
+## Migration et changements de données
+
+Le patch additif crée les comptes portail, jetons à usage unique, limites de débit, publications documentaires, accusés et audit, ainsi que les vues à projection autorisée. Un trigger refuse un accusé croisant deux clients avec `SQLSTATE 42501`. Aucune donnée client fictive n'est insérée par la migration.
+
+Répétition PostgreSQL 16.14 jetable sur stockage `tmpfs` :
+
+- sauvegarde : 1 968 419 octets, SHA-256 `5c6e0651dc6394966dd19f9f6a1242123f7323120fb4076d4ea8b36da37b3bf3` ;
+- registre : 140 → 160 patches, aucun écart de checksum ;
+- migration SOL-29 : 708 ms ; vérification : 239 ms ; rejeu : 0 patch ;
+- sonde multi-client : refus vérifié dans une transaction annulée ;
+- rollback : réussi en 458 ms ;
+- restauration : réussie en 3 933 ms, comptages identiques et empreinte source/restaurée `225a42078d5f067edf34f7e50bc1ac7a0cfd23abf8666cbfece0d1adcb601168`.
+
+Preuve machine : `docs/release/sol29-rehearsal/MIGRATION_REHEARSAL_SOL_06.json`.
+
+## Tests et résultats
+
+- backend `pnpm typecheck` : réussi ;
+- backend `pnpm build` : réussi, 1 042/1 042 opérations OpenAPI inventoriées, contrat valide, 714 fichiers runtime contrôlés avant et après émission ;
+- suite backend complète : exit 0 en 28,4 s ;
+- suite ciblée de téléchargement sûr : 46/46 tests réussis ;
+- frontend lint, typecheck et build : réussis ; build de 11 860 modules en 39,17 s ;
+- suite frontend complète : 293 fichiers et 2 487 tests réussis ;
+- Playwright isolé : 1 scénario métier complet réussi, 0 échec, 0 flaky ; rapport `test-results/sol-05/report.md` côté frontend ;
+- répétition de migration, sauvegarde, vérification, rejeu, rollback et restauration : réussie.
+
+## Vérification E2E
+
+Le scénario crée deux clients indépendants et couvre : anonyme 401, admin anonyme 401, utilisateur ERP standard 403, invitation expirée, reprise après client invalide, retry idempotent, activation et connexion des deux clients, injection de `client_id` rejetée, publication GED limitée au client A, publication croisée rejetée, invisibilité côté client B, téléchargement et accusé côté client A, puis invalidation immédiate de la session après révocation.
+
+Les traces, captures et vidéos sont configurées uniquement en cas d'échec. Le dernier passage ne produit donc aucun artefact d'échec.
+
+## Risques et compatibilité
+
+- La session portail reste dans un stockage navigateur distinct pour ce pilote ; l'ADR exige le passage HttpOnly/BFF avant extension de la surface sensible.
+- L'envoi d'email dépend de Resend. Sans configuration valide, l'administration retourne un lien ponctuel sûr afin de permettre l'exploitation initiale sans exposer le jeton dans les logs.
+- Le portail reste volontairement en lecture seule, hormis l'accusé documentaire. Aucune mutation commerciale ou financière n'est ouverte.
+- Les routes ERP existantes et leurs JWT ne changent pas. Le schéma est additif.
+
+## Rollback
+
+Avant toute preuve portail, sauvegarder la base, arrêter les nouvelles invitations, exécuter le rollback fourni et redéployer la release précédente. Dès qu'un compte, audit, accusé ou publication existe, le rollback refuse la suppression ; le rollback opérationnel consiste alors à révoquer les comptes, retirer les publications, redéployer la release précédente et conserver les tables pour audit. Une restauration complète n'est autorisée qu'après décision d'incident et contrôle de la sauvegarde chiffrée.
+
+## Restant réellement à faire
+
+- promouvoir les commits jusqu'à `dev` puis `main` dans les deux dépôts ;
+- sauvegarder et appliquer le patch à `cerp_test`, puis `cerp_prod`, avec preflight, vérification et rejeu ;
+- provisionner les secrets portail séparés, déployer Coolify/HYPERBOX2 et vérifier les SHA de santé ;
+- exécuter la vérification navigateur post-déploiement et reporter ces preuves ici.

--- a/docs/http/client-portal-sol29.md
+++ b/docs/http/client-portal-sol29.md
@@ -1,0 +1,28 @@
+# Portail client SOL-29 — contrat d’exposition
+
+Toutes les routes sont sous `/api/v1`. Les routes `/portal/auth/*` sont publiques et limitées en débit. Les autres routes `/portal/*` exigent le JWT portail ; elles n’acceptent ni jeton ERP ni `client_id` fourni par le navigateur. Les routes `/admin/client-portal/*` exigent un JWT ERP actif et `is_superadmin` dans la base courante.
+
+## Champs exposés
+
+| Entité | Champs publics | Exclus explicitement |
+|---|---|---|
+| Profil | `account_id`, `client_id`, `display_name`, `company_name`, `last_login_at` | email interne, rôles, notes, conditions commerciales |
+| Commande | `id`, `numero`, `date_commande`, `statut`, `total_ht`, `total_ttc`, `currency`, `updated_at` | brouillons, marges, coûts, notes, historique interne |
+| Livraison | `id`, `numero`, `statut`, `commande_id`, `commande_numero`, `date_creation`, `date_expedition`, `date_livraison`, `transporteur`, `tracking_number`, `updated_at` | brouillons, coûts transport, commentaires internes |
+| Facture | `id`, `numero`, `commande_id`, `date_emission`, `date_echeance`, `statut`, `document_status`, `settlement_status`, `total_ht`, `total_ttc`, `currency`, `updated_at` | brouillons, écritures comptables, comptes, lettrage interne |
+| Document publié | publication/version/document IDs, code, titre public, version, nom original, MIME, taille, SHA-256, état public, expiration, accusé, date de publication et métadonnées antivirus | chemin de stockage, contenu avant verdict, versions non publiées, journal GED interne |
+
+Chaque liste retourne `source`, `freshness_at` et `reliability=SYSTEM_OF_RECORD`. Les montants ou devises absents restent `null`; ils ne sont jamais remplacés par zéro.
+
+## Parcours
+
+- `POST /admin/client-portal/accounts` puis `POST /admin/client-portal/accounts/{id}/invitations` : création inactive et invitation idempotentes.
+- `POST /portal/auth/activate` : activation du jeton à usage unique et définition du mot de passe.
+- `POST /portal/auth/login`, `POST /portal/auth/forgot-password`, `POST /portal/auth/reset-password` : session, récupération générique et révocation des anciennes sessions.
+- `GET /portal/me|orders|deliveries|invoices|documents` : lecture isolée par le client du jeton.
+- `GET /portal/documents/{publicationId}/download` : flux binaire uniquement si l’état calculé est `AVAILABLE`; en-têtes `Content-Disposition` et `X-CERP-Document-SHA256`.
+- `POST /portal/documents/{publicationId}/acknowledgements` : accusé append-only et idempotent.
+- `PATCH /admin/client-portal/accounts/{id}/status` : suspension, réactivation ou révocation motivée.
+- `POST /admin/client-portal/publications` puis `POST /admin/client-portal/publications/{id}/revoke` : publication et retrait motivé.
+
+Les commandes administratives de création, invitation et publication exigent `Idempotency-Key`. Les erreurs d’isolation retournent 400/401/403/404 sans donnée du client visé.

--- a/docs/http/openapi-route-coverage.json
+++ b/docs/http/openapi-route-coverage.json
@@ -1,9 +1,9 @@
 {
   "scope": "/api/v1",
-  "source_sha256": "d82d666b7244413a8c33839fd7bd8817f881d4c56ffcdb3c6529b76ca4dd21fb",
-  "discovered_operations": 1024,
-  "documented_operations": 1024,
+  "source_sha256": "13ed1f48241a77e539c2f6161df31213617115e8493e1401edd68683a12357b9",
+  "discovered_operations": 1042,
+  "documented_operations": 1042,
   "coverage_percent": 100,
-  "authenticated_operations": 1016,
-  "public_operations": 8
+  "authenticated_operations": 1023,
+  "public_operations": 19
 }

--- a/docs/release/sol29-rehearsal/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/sol29-rehearsal/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-14T20:19:35.513Z",
+  "started_at": "2026-08-14T20:27:30.656Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 18261,
-    "source_seed": 200,
-    "backup": 744,
-    "preflight": 148,
-    "integrity_before": 582,
-    "migration": 710,
-    "verify": 240,
-    "replay": 124,
-    "integrity_after": 1488,
-    "negative_gate": 40,
-    "rollback": 423,
-    "restore": 3904
+    "source_migration": 18856,
+    "source_seed": 194,
+    "backup": 755,
+    "preflight": 145,
+    "integrity_before": 581,
+    "migration": 708,
+    "verify": 239,
+    "replay": 126,
+    "integrity_after": 1563,
+    "negative_gate": 42,
+    "rollback": 458,
+    "restore": 3933
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-14T20:19:57.265Z",
-    "duration_ms": 89,
+    "checked_at": "2026-08-14T20:27:53.180Z",
+    "duration_ms": 90,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36355095"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-lFZtoa\\cerp-test-before-sol06.dump",
-      "bytes": 1968396,
-      "sha256": "bf8d8054534afa102281bfccbf27e7089042f5bab8266e661e7acacd874bfd37",
-      "free_bytes": 413007364096
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-mTEGe3\\cerp-test-before-sol06.dump",
+      "bytes": 1968419,
+      "sha256": "5c6e0651dc6394966dd19f9f6a1242123f7323120fb4076d4ea8b36da37b3bf3",
+      "free_bytes": 413065613312
     },
     "ledger": {
       "applied": 140,
@@ -476,8 +476,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-14T20:20:00.414Z",
-    "duration_ms": 1475,
+    "checked_at": "2026-08-14T20:27:56.401Z",
+    "duration_ms": 1549,
     "table_counts": {
       "accounting_export_batch_sources": "0",
       "accounting_export_batches": "0",
@@ -996,7 +996,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1013,7 +1013,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1031,7 +1031,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1057,7 +1057,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1074,7 +1074,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1092,7 +1092,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1112,7 +1112,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1130,7 +1130,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1156,7 +1156,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1174,7 +1174,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1193,7 +1193,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1231,7 +1231,7 @@
         "period_start": "2026-08-13T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-14T20:19:58.946Z",
+        "freshness_at": "2026-08-14T20:27:54.853Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1330,5 +1330,5 @@
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-14T20:20:04.948Z"
+  "completed_at": "2026-08-14T20:28:01.009Z"
 }

--- a/docs/release/sol29-rehearsal/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/sol29-rehearsal/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,10 +1,10 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-14T20:20:04.948Z
+- Exécutée : 2026-08-14T20:28:01.009Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36355095 octets
-- Sauvegarde : 1968396 octets, SHA-256 `bf8d8054534afa102281bfccbf27e7089042f5bab8266e661e7acacd874bfd37`
+- Sauvegarde : 1968419 octets, SHA-256 `5c6e0651dc6394966dd19f9f6a1242123f7323120fb4076d4ea8b36da37b3bf3`
 - Patches avant/après : 140 / 160
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
@@ -17,17 +17,17 @@
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 18261 |
-| source_seed | 200 |
-| backup | 744 |
-| preflight | 148 |
-| integrity_before | 582 |
-| migration | 710 |
-| verify | 240 |
-| replay | 124 |
-| integrity_after | 1488 |
-| negative_gate | 40 |
-| rollback | 423 |
-| restore | 3904 |
+| source_migration | 18856 |
+| source_seed | 194 |
+| backup | 755 |
+| preflight | 145 |
+| integrity_before | 581 |
+| migration | 708 |
+| verify | 239 |
+| replay | 126 |
+| integrity_after | 1563 |
+| negative_gate | 42 |
+| rollback | 458 |
+| restore | 3933 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/docs/runbooks/client-portal-sol29.md
+++ b/docs/runbooks/client-portal-sol29.md
@@ -1,0 +1,65 @@
+# Runbook — Portail client SOL-29
+
+- Propriétaire : Keenan Martin / administration CERP+
+- Version : 2026-08-14
+- Gravité : P0 si une donnée d’un autre client est visible ; P1 si connexion, invitation ou document indisponible pour un seul client
+
+## Préparation et configuration
+
+1. Générer un secret aléatoire distinct de `JWT_SECRET`, d’au moins 32 caractères, dans le gestionnaire de secrets de l’environnement. Ne jamais le placer dans Git, un ticket ou un log.
+2. Définir `CLIENT_PORTAL_JWT_SECRET` et l’URL HTTPS externe exacte dans `CLIENT_PORTAL_PUBLIC_URL`. Pour l’email, définir `RESEND_API_KEY`, `RESEND_FROM` et, seulement pour une recette locale, `RESEND_API_BASE_URL`.
+3. Faire un dump custom chiffré, vérifier son SHA-256 et une restauration isolée. Exécuter le preflight SOL-29 puis appliquer uniquement `20260814_client_portal_sol29.sql` sur `cerp_test` avant `cerp_prod`.
+4. Exécuter le verify et le replay de patch. Ne pas ouvrir le portail si une vue, un trigger append-only ou le trigger inter-client manque.
+
+## Exploitation normale
+
+1. Dans **Administration → Portail clients**, créer le compte avec le code client, l’email et le nom du contact. Le compte reste inactif.
+2. Envoyer l’invitation. Si l’email indique `NOT_CONFIGURED` ou `FAILED`, copier le lien une seule fois et le transmettre par un canal authentifié ; ne jamais le coller dans un ticket partagé.
+3. Le client active sous 24 heures, puis se connecte. Une récupération expire après une heure.
+4. Publier seulement une version GED courante, applicable, liée au bon client et antivirus saine. Vérifier le titre public, l’expiration et si un accusé est requis.
+5. En cas de départ du contact, suspendre immédiatement. Révoquer si l’accès ne doit jamais être réactivé. Toute action exige un motif exploitable.
+
+## Incident et arbre de décision
+
+- **Suspicion de fuite inter-client** : couper immédiatement les routes `/api/v1/portal` au reverse proxy, conserver logs et audit, ne modifier aucune preuve, classer P0 et lancer une investigation par `request_id`, `portal_account_id` et `client_id`.
+- **Jeton volé ou poste perdu** : suspendre le compte. Le changement de `session_epoch` invalide les sessions en cours ; réactiver seulement après vérification du contact et reset du mot de passe.
+- **Invitation expirée** : relancer l’invitation avec une nouvelle clé d’idempotence. Ne pas modifier l’expiration SQL.
+- **Email absent** : vérifier la configuration Resend et son statut ; ne pas révéler par l’API publique si l’adresse existe.
+- **Document en attente/quarantaine** : suivre le runbook antivirus. Ne jamais forcer le statut ni servir directement la clé de stockage.
+- **Document remplacé/expiré** : publier explicitement la nouvelle version ou une nouvelle échéance ; ne pas réactiver en base à la main.
+- **Erreur d’intégrité SHA-256** : couper le téléchargement du document, préserver le blob, classer P0/P1 selon diffusion et suivre le runbook de corruption.
+
+## Vérifications reproductibles
+
+```powershell
+rtk proxy "C:\Program Files\nodejs\corepack.cmd" pnpm vitest run src/module/client-portal src/__tests__/client-portal-isolation.repository.test.ts src/__tests__/client-portal-sol29.migration-guards.test.ts
+rtk proxy "C:\Program Files\nodejs\corepack.cmd" pnpm db:migrations:preflight
+rtk proxy "C:\Program Files\nodejs\corepack.cmd" pnpm db:migrations:rehearse
+```
+
+Depuis le frontend propre :
+
+```powershell
+rtk proxy "C:\Program Files\nodejs\corepack.cmd" pnpm test -- src/modules/client-portal
+rtk proxy "C:\Program Files\nodejs\corepack.cmd" pnpm e2e:isolated -- e2e/client-portal-isolation.spec.ts
+```
+
+Le test E2E doit prouver : anonyme 401, utilisateur standard 403 sur l’administration, invitation expirée, retry/idempotence, deux clients mutuellement invisibles et révocation immédiate.
+
+## Retour au service
+
+- Health/readiness verts sur le SHA déployé.
+- E2E d’isolation vert sans retry flaky.
+- Un compte de recette peut voir uniquement sa commande et aucun brouillon.
+- Un document non sain reste visible comme indisponible mais impossible à télécharger ou accuser.
+- Audit de connexion, téléchargement et action administrative présent, sans email, secret ni contenu.
+
+## Rollback
+
+- Avant tout compte/publication/audit : désactiver les routes, redéployer le SHA précédent puis exécuter le rollback support uniquement sur la cible vérifiée.
+- Après toute preuve : le rollback SQL refuse volontairement. Désactiver les routes et les comptes, conserver les tables append-only, corriger en migration additive puis redéployer.
+- Une restauration de dump se fait dans une nouvelle base isolée ; elle ne remplace jamais directement la production sans décision et fenêtre explicites.
+
+## Actions interdites
+
+Ne jamais changer un `client_id`, supprimer un audit/accusé, marquer un scan sain manuellement, publier une ancienne version par SQL, partager un jeton dans les logs, utiliser le secret ERP pour le portail ni augmenter les limites pour masquer une attaque.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "e2e:migrate:isolated": "node scripts/e2e/migrate-isolated.js",
     "e2e:seed:isolated": "node scripts/e2e/seed-isolated.js",
     "e2e:accounting-export:isolated": "node scripts/e2e/accounting-export-sol27-run.js",
+    "e2e:client-portal:seed": "node scripts/e2e/client-portal-sol29-seed.js",
     "maintenance:dashboard-usage": "node scripts/prune-dashboard-usage.js",
     "maintenance:planning-usage": "node scripts/prune-planning-usage.js",
     "test": "vitest --config vitest.config.ts",

--- a/scripts/e2e/client-portal-sol29-seed.js
+++ b/scripts/e2e/client-portal-sol29-seed.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+const { Client } = require("pg");
+
+function assertIsolated() {
+  if (process.env.CERP_E2E_ISOLATED !== "1") {
+    throw new Error("CERP_E2E_ISOLATED=1 is required for the SOL-29 fixture");
+  }
+  const url = new URL(process.env.DATABASE_URL ?? "");
+  if (!["127.0.0.1", "localhost", "::1"].includes(url.hostname) || url.pathname !== "/cerp_test") {
+    throw new Error("SOL-29 fixture refuses non-loopback or non-cerp_test databases");
+  }
+}
+
+async function main() {
+  assertIsolated();
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `INSERT INTO public.clients (client_id,client_code,company_name,status,document_policy)
+       VALUES ('902','E2E-CLIENT-902','Client isolation SOL-29','client','NONE')
+       ON CONFLICT (client_id) DO UPDATE SET
+         client_code=EXCLUDED.client_code,
+         company_name=EXCLUDED.company_name,
+         status='client'`
+    );
+    await client.query(
+      `INSERT INTO public.commande_client (
+         id,numero,client_id,date_commande,order_type,total_ht,total_ttc
+       ) VALUES
+         (9290001,'SOL29-ORDER-A','901',DATE '2026-08-14','FERME',100,120),
+         (9290002,'SOL29-ORDER-B','902',DATE '2026-08-14','FERME',200,240)
+       ON CONFLICT (id) DO UPDATE SET
+         numero=EXCLUDED.numero,
+         client_id=EXCLUDED.client_id,
+         date_commande=EXCLUDED.date_commande,
+         order_type=EXCLUDED.order_type,
+         total_ht=EXCLUDED.total_ht,
+         total_ttc=EXCLUDED.total_ttc`
+    );
+    await client.query(
+      `INSERT INTO public.commande_historique (
+         commande_id,user_id,ancien_statut,nouveau_statut,commentaire
+       )
+       SELECT fixture.commande_id, actor.id, 'BROUILLON', 'ENREGISTREE', 'Fixture isolée SOL-29'
+         FROM (VALUES (9290001::bigint),(9290002::bigint)) AS fixture(commande_id)
+         CROSS JOIN LATERAL (
+           SELECT id FROM public.users WHERE username='KEENAN' LIMIT 1
+         ) actor
+        WHERE NOT EXISTS (
+          SELECT 1 FROM public.commande_historique existing
+           WHERE existing.commande_id=fixture.commande_id
+             AND existing.commentaire='Fixture isolée SOL-29'
+        )`
+    );
+    await client.query(
+      `INSERT INTO public.ged_document_links (
+         id,document_id,entity_type,entity_id,link_role,created_by
+       ) VALUES (
+         '92900000-0000-4000-8000-000000000001',
+         '92000000-0000-4000-8000-000000000005',
+         'CLIENT','901','PORTAL_SOL29',
+         (SELECT id FROM public.users WHERE username='KEENAN')
+       ) ON CONFLICT (document_id,entity_type,entity_id,link_role) DO NOTHING`
+    );
+    await client.query("COMMIT");
+    process.stdout.write("SOL-29 isolated fixture ready: clients=901/902 orders=SOL29-ORDER-A/B document=GED-E2E-SOL20-PLAN\n");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error.message}\n`);
+  process.exitCode = 1;
+});

--- a/src/__tests__/client-portal-isolation.repository.test.ts
+++ b/src/__tests__/client-portal-isolation.repository.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  query: vi.fn(),
+  connect: vi.fn(),
+}));
+
+vi.mock("../config/database", () => ({
+  default: { query: mocked.query, connect: mocked.connect },
+}));
+
+import {
+  repoGetPortalDocumentDownload,
+  repoListPortalInvoices,
+  repoListPortalOrders,
+} from "../module/client-portal/repository/client-portal.repository";
+
+const identity = {
+  accountId: "3f31d6d6-c0d4-4c90-8fc3-5057a4e10370",
+  clientId: "042",
+  sessionEpoch: 2,
+};
+
+describe("client portal repository tenant isolation", () => {
+  beforeEach(() => mocked.query.mockReset());
+
+  it.each([
+    ["orders", repoListPortalOrders],
+    ["invoices", repoListPortalInvoices],
+  ] as const)("always binds the authenticated client for %s", async (_label, loader) => {
+    mocked.query
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] })
+      .mockResolvedValueOnce({ rows: [] });
+    await loader(identity, 1, 20);
+    expect(mocked.query).toHaveBeenCalledTimes(2);
+    for (const [sql, values] of mocked.query.mock.calls) {
+      expect(String(sql)).toContain("WHERE client_id=$1");
+      expect(values[0]).toBe("042");
+    }
+  });
+
+  it("binds both the portal account and client when resolving a download", async () => {
+    mocked.query.mockResolvedValueOnce({ rows: [] });
+    await expect(repoGetPortalDocumentDownload(
+      identity,
+      "d5ec6d7e-f2f9-42aa-b766-bf98147f42b3",
+    )).resolves.toBeNull();
+    const [sql, values] = mocked.query.mock.calls[0];
+    expect(String(sql)).toContain("publication.client_id=$3");
+    expect(values).toEqual([
+      identity.accountId,
+      "d5ec6d7e-f2f9-42aa-b766-bf98147f42b3",
+      identity.clientId,
+    ]);
+  });
+});
+

--- a/src/__tests__/client-portal-sol29.migration-guards.test.ts
+++ b/src/__tests__/client-portal-sol29.migration-guards.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "../..");
+const read = (relative: string) => fs.readFileSync(path.join(root, relative), "utf8");
+
+describe("SOL-29 migration guards", () => {
+  const patch = read("db/patches/20260814_client_portal_sol29.sql");
+  const preflight = read("db/patches/support/20260814_client_portal_sol29.preflight.sql");
+  const verify = read("db/patches/support/20260814_client_portal_sol29.verify.sql");
+  const rollback = read("db/patches/support/20260814_client_portal_sol29.rollback.sql");
+
+  it("keeps portal identities separate and tenant projections filtered", () => {
+    expect(patch).toContain("client_portal_accounts");
+    expect(patch).toContain("client_id varchar(3) NOT NULL REFERENCES public.clients");
+    expect(patch).toContain("WITH (security_barrier = true)");
+    expect(patch).toContain("client_portal_orders_v");
+    expect(patch).toContain("client_portal_deliveries_v");
+    expect(patch).toContain("client_portal_invoices_v");
+    expect(patch).not.toContain("REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,\n  email_normalized");
+  });
+
+  it("protects audit, acknowledgement and idempotency evidence", () => {
+    expect(patch.match(/fn_client_portal_evidence_immutable_sol29/g)?.length).toBeGreaterThanOrEqual(4);
+    expect(patch).toContain("CLIENT_PORTAL_RECEIPT_UQ".toLowerCase());
+    expect(verify).toContain("cross-client acknowledgement row(s)");
+    expect(verify).toContain("immutable audit trigger did not reject an update");
+  });
+
+  it("enforces acknowledgement isolation inside PostgreSQL", () => {
+    expect(patch).toContain("fn_client_portal_ack_tenant_guard_sol29");
+    expect(patch).toContain("cross-client acknowledgement refused");
+    expect(verify).toContain("cross-client acknowledgement was accepted");
+  });
+
+  it("ships preflight, verification and guarded rollback", () => {
+    expect(preflight).toContain("gen_random_uuid() is unavailable");
+    expect(verify).toContain("cerp_app grants are invalid");
+    expect(rollback).toContain("rollback refused");
+    expect(rollback).toContain("portal identity, publication or audit evidence exists");
+  });
+});

--- a/src/__tests__/openapi-contract-sol28.test.ts
+++ b/src/__tests__/openapi-contract-sol28.test.ts
@@ -59,6 +59,9 @@ describe("SOL-28 generated OpenAPI contract", () => {
       if (route.authenticated) {
         expect(security, `${route.method} ${route.path}`).toEqual([{ bearerAuth: [] }]);
         expect(operation["x-cerp-rbac"]).toBeTruthy();
+      } else if (route.middleware.includes("authenticateClientPortal")) {
+        expect(security, `${route.method} ${route.path}`).toEqual([{ clientPortalBearerAuth: [] }]);
+        expect(operation["x-cerp-rbac"]).toEqual(["clientPortalTenantBoundary"]);
       } else {
         expect(operation["x-cerp-public-reason"], `${route.method} ${route.path}`).toBeTypeOf("string");
       }

--- a/src/__tests__/secure-upload.test.ts
+++ b/src/__tests__/secure-upload.test.ts
@@ -745,6 +745,18 @@ describe("téléchargement sécurisé et compatibilité historique", () => {
     expect(response.text).toBe("contenu-original");
   });
 
+  it("vérifie l'empreinte puis diffuse le même descripteur sans le fermer", async () => {
+    const candidate = path.join(root, "document-verifie.txt");
+    const content = Buffer.from("contenu portail vérifié", "utf8");
+    const expectedSha256 = (await import("node:crypto")).createHash("sha256").update(content).digest("hex");
+    await fs.writeFile(candidate, content);
+
+    const response = await request(downloadApp(candidate, expectedSha256)).get("/download");
+
+    expect(response.status).toBe(200);
+    expect(Buffer.from(response.text, "utf8")).toEqual(content);
+  });
+
   it("interrompt l'intégrité si le client ferme et ne ferme le handle qu'une fois", async () => {
     const candidate = path.join(root, "large-document.bin");
     const content = Buffer.alloc(2 * 1024 * 1024, 0x5a);

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -94,7 +94,12 @@ const corsOptionsDelegate: cors.CorsOptionsDelegate = (req, cb) => {
       "X-Session-Id",
       "Idempotency-Key",
     ],
-    exposedHeaders: ["X-Request-Id", "X-Correlation-Id"],
+    exposedHeaders: [
+      "X-Request-Id",
+      "X-Correlation-Id",
+      "Content-Disposition",
+      "X-CERP-Document-SHA256",
+    ],
     optionsSuccessStatus: 204,
   });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,5 +107,9 @@ void start().catch((error) => {
       error_fingerprint: errorFingerprint(error),
     });
   });
+  if (process.env.CERP_E2E_ISOLATED === "1" && process.env.CERP_E2E_DIAGNOSTICS === "1") {
+    const diagnostic = error instanceof Error ? error.stack ?? error.message : String(error);
+    process.stderr.write(`[isolated-startup-diagnostic] ${diagnostic}\n`);
+  }
   process.exitCode = 1;
 });

--- a/src/module/client-portal/controllers/client-portal.controller.ts
+++ b/src/module/client-portal/controllers/client-portal.controller.ts
@@ -1,0 +1,253 @@
+import type { NextFunction, Request, Response } from "express";
+
+import { requireSuperadmin } from "../../access-control/middlewares/require-superadmin";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import { HttpError } from "../../../utils/httpError";
+import * as repository from "../repository/client-portal.repository";
+import * as service from "../services/client-portal.service";
+import {
+  adminCreatePortalAccountSchema,
+  adminCreatePortalPublicationSchema,
+  adminPortalAccountStatusSchema,
+  adminRevokePortalPublicationSchema,
+  idempotencyKeySchema,
+  portalActivateSchema,
+  portalForgotPasswordSchema,
+  portalLoginSchema,
+  portalPaginationSchema,
+  portalResetPasswordSchema,
+  portalUuidParamSchema,
+} from "../validators/client-portal.validators";
+
+export { requireSuperadmin };
+
+function metaFrom(req: Request) {
+  const userAgent = req.headers["user-agent"]?.toString() ?? null;
+  const device = parseDevice(userAgent);
+  return service.buildPortalRequestMeta({
+    requestId: req.requestId ?? null,
+    ip: getClientIp(req),
+    browser: device.browser,
+  });
+}
+
+function parseBody<T>(schema: { safeParse(value: unknown): { success: true; data: T } | { success: false; error: unknown } }, body: unknown): T {
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    throw new HttpError(400, "CLIENT_PORTAL_VALIDATION", "Données portail invalides.", parsed.error);
+  }
+  return parsed.data;
+}
+
+function portalIdentity(req: Request) {
+  if (!req.portalIdentity) throw new HttpError(401, "CLIENT_PORTAL_SESSION_REQUIRED", "Session portail requise.");
+  return req.portalIdentity;
+}
+
+function erpActorId(req: Request): number {
+  if (!req.user || typeof req.user.id !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  return req.user.id;
+}
+
+function idempotencyKey(req: Request): string {
+  const parsed = idempotencyKeySchema.safeParse(req.header("Idempotency-Key"));
+  if (!parsed.success) {
+    throw new HttpError(400, "CLIENT_PORTAL_IDEMPOTENCY_REQUIRED", "Un en-tête Idempotency-Key UUID est requis.");
+  }
+  return parsed.data;
+}
+
+function uuidParam(value: unknown): string {
+  const parsed = portalUuidParamSchema.safeParse(value);
+  if (!parsed.success) throw new HttpError(400, "CLIENT_PORTAL_VALIDATION", "Identifiant invalide.");
+  return parsed.data;
+}
+
+export async function login(req: Request, res: Response, next: NextFunction) {
+  try {
+    const body = parseBody(portalLoginSchema, req.body);
+    res.json(await service.loginPortal(body, metaFrom(req)));
+  } catch (error) { next(error); }
+}
+
+export async function activate(req: Request, res: Response, next: NextFunction) {
+  try {
+    const body = parseBody(portalActivateSchema, req.body);
+    res.json(await service.activatePortalAccount(body, metaFrom(req)));
+  } catch (error) { next(error); }
+}
+
+export async function forgotPassword(req: Request, res: Response, next: NextFunction) {
+  try {
+    const body = parseBody(portalForgotPasswordSchema, req.body);
+    await service.requestPortalPasswordReset(body.email, metaFrom(req));
+    res.status(202).json({ accepted: true });
+  } catch (error) { next(error); }
+}
+
+export async function resetPassword(req: Request, res: Response, next: NextFunction) {
+  try {
+    const body = parseBody(portalResetPasswordSchema, req.body);
+    res.json(await service.resetPortalPassword(body, metaFrom(req)));
+  } catch (error) { next(error); }
+}
+
+export async function me(req: Request, res: Response, next: NextFunction) {
+  try { res.json(await service.getPortalProfile(portalIdentity(req))); }
+  catch (error) { next(error); }
+}
+
+function pagination(req: Request) {
+  return parseBody(portalPaginationSchema, req.query);
+}
+
+export async function listOrders(req: Request, res: Response, next: NextFunction) {
+  try { res.json(await service.listPortalOrders(portalIdentity(req), pagination(req))); }
+  catch (error) { next(error); }
+}
+
+export async function listDeliveries(req: Request, res: Response, next: NextFunction) {
+  try { res.json(await service.listPortalDeliveries(portalIdentity(req), pagination(req))); }
+  catch (error) { next(error); }
+}
+
+export async function listInvoices(req: Request, res: Response, next: NextFunction) {
+  try { res.json(await service.listPortalInvoices(portalIdentity(req), pagination(req))); }
+  catch (error) { next(error); }
+}
+
+export async function listDocuments(req: Request, res: Response, next: NextFunction) {
+  try { res.json(await service.listPortalDocuments(portalIdentity(req))); }
+  catch (error) { next(error); }
+}
+
+export async function acknowledgeDocument(req: Request, res: Response, next: NextFunction) {
+  try {
+    const publicationId = uuidParam(req.params.publicationId);
+    res.json(await service.acknowledgePortalDocument(portalIdentity(req), publicationId, metaFrom(req)));
+  } catch (error) { next(error); }
+}
+
+export async function downloadDocument(req: Request, res: Response, next: NextFunction) {
+  const identity = req.portalIdentity;
+  const publicationId = portalUuidParamSchema.safeParse(req.params.publicationId);
+  if (!identity || !publicationId.success) {
+    next(new HttpError(identity ? 400 : 401, "CLIENT_PORTAL_DOCUMENT_REQUEST", "Demande de document invalide."));
+    return;
+  }
+  try {
+    const document = await service.getPortalDocumentDownload(identity, publicationId.data);
+    res.setHeader("X-CERP-Document-SHA256", document.sha256);
+    res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'");
+    const result = await sendSecureStoredFile(res, {
+      filePath: document.file_path,
+      allowedRoots: [document.allowed_root],
+      filename: document.filename,
+      mimeType: document.mime_type,
+      download: true,
+      expectedSha256: document.sha256,
+      integrityError: {
+        status: 409,
+        code: "CLIENT_PORTAL_DOCUMENT_INTEGRITY",
+        message: "L'intégrité du document ne peut pas être vérifiée.",
+      },
+    });
+    if (result === "completed") {
+      await repository.repoRecordPortalDocumentDownload({
+        identity,
+        publicationId: publicationId.data,
+        outcome: "SUCCEEDED",
+        meta: metaFrom(req),
+      });
+    }
+  } catch (error) {
+    if (error instanceof HttpError && error.code === "CLIENT_PORTAL_DOCUMENT_INTEGRITY") {
+      await repository.repoRecordPortalDocumentDownload({
+        identity,
+        publicationId: publicationId.data,
+        outcome: "INTEGRITY_FAILURE",
+        meta: metaFrom(req),
+      }).catch(() => undefined);
+    }
+    next(error);
+  }
+}
+
+export async function listAdminAccounts(req: Request, res: Response, next: NextFunction) {
+  try {
+    const clientId = typeof req.query.client_id === "string" ? req.query.client_id.trim() : undefined;
+    if (clientId && clientId.length > 3) throw new HttpError(400, "CLIENT_PORTAL_VALIDATION", "Client invalide.");
+    res.json({ data: await repository.repoListPortalAccounts(clientId) });
+  } catch (error) { next(error); }
+}
+
+export async function createAdminAccount(req: Request, res: Response, next: NextFunction) {
+  try {
+    const result = await service.createPortalAccountByAdmin({
+      actorId: erpActorId(req),
+      idempotencyKey: idempotencyKey(req),
+      body: parseBody(adminCreatePortalAccountSchema, req.body),
+      meta: metaFrom(req),
+    });
+    res.status(result.replayed ? 200 : 201).json(result);
+  } catch (error) { next(error); }
+}
+
+export async function createAdminInvitation(req: Request, res: Response, next: NextFunction) {
+  try {
+    const result = await service.createPortalInvitationByAdmin({
+      actorId: erpActorId(req),
+      accountId: uuidParam(req.params.accountId),
+      idempotencyKey: idempotencyKey(req),
+      meta: metaFrom(req),
+    });
+    res.status(result.replayed ? 200 : 201).json(result);
+  } catch (error) { next(error); }
+}
+
+export async function patchAdminAccountStatus(req: Request, res: Response, next: NextFunction) {
+  try {
+    const body = parseBody(adminPortalAccountStatusSchema, req.body);
+    res.json({ data: await service.setPortalAccountStatusByAdmin({
+      actorId: erpActorId(req),
+      accountId: uuidParam(req.params.accountId),
+      status: body.status,
+      reason: body.reason,
+      meta: metaFrom(req),
+    }) });
+  } catch (error) { next(error); }
+}
+
+export async function listAdminPublications(req: Request, res: Response, next: NextFunction) {
+  try {
+    const clientId = typeof req.query.client_id === "string" ? req.query.client_id.trim() : undefined;
+    if (clientId && clientId.length > 3) throw new HttpError(400, "CLIENT_PORTAL_VALIDATION", "Client invalide.");
+    res.json({ data: await repository.repoListPortalPublications(clientId) });
+  } catch (error) { next(error); }
+}
+
+export async function createAdminPublication(req: Request, res: Response, next: NextFunction) {
+  try {
+    const result = await service.createPortalPublicationByAdmin({
+      actorId: erpActorId(req),
+      idempotencyKey: idempotencyKey(req),
+      body: parseBody(adminCreatePortalPublicationSchema, req.body),
+      meta: metaFrom(req),
+    });
+    res.status(result.replayed ? 200 : 201).json(result);
+  } catch (error) { next(error); }
+}
+
+export async function revokeAdminPublication(req: Request, res: Response, next: NextFunction) {
+  try {
+    const body = parseBody(adminRevokePortalPublicationSchema, req.body);
+    res.json({ data: await repository.repoRevokePortalPublication({
+      actorId: erpActorId(req),
+      publicationId: uuidParam(req.params.publicationId),
+      reason: body.reason,
+      meta: metaFrom(req),
+    }) });
+  } catch (error) { next(error); }
+}
+

--- a/src/module/client-portal/domain/client-portal-security.test.ts
+++ b/src/module/client-portal/domain/client-portal-security.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  hashPortalOpaqueValue,
+  normalizePortalEmail,
+  signPortalInvitationToken,
+  signPortalSession,
+  verifyPortalInvitationToken,
+  verifyPortalSession,
+} from "./client-portal-security";
+
+const previousSecret = process.env.CLIENT_PORTAL_JWT_SECRET;
+
+describe("client portal security boundary", () => {
+  beforeEach(() => {
+    process.env.CLIENT_PORTAL_JWT_SECRET = "sol29-test-secret-with-at-least-32-characters";
+  });
+
+  afterEach(() => {
+    if (previousSecret === undefined) delete process.env.CLIENT_PORTAL_JWT_SECRET;
+    else process.env.CLIENT_PORTAL_JWT_SECRET = previousSecret;
+  });
+
+  it("normalizes an email without changing the stored display value", () => {
+    expect(normalizePortalEmail("  CONTACT.Client@Example.COM ")).toBe("contact.client@example.com");
+  });
+
+  it("signs a portal session with a dedicated audience and tenant claims", () => {
+    const token = signPortalSession({
+      accountId: "3f31d6d6-c0d4-4c90-8fc3-5057a4e10370",
+      clientId: "042",
+      sessionEpoch: 7,
+    });
+    expect(verifyPortalSession(token)).toEqual({
+      accountId: "3f31d6d6-c0d4-4c90-8fc3-5057a4e10370",
+      clientId: "042",
+      sessionEpoch: 7,
+    });
+  });
+
+  it("rejects an ERP token signed with another secret", () => {
+    process.env.CLIENT_PORTAL_JWT_SECRET = "sol29-other-secret-with-at-least-32-characters";
+    const token = signPortalSession({
+      accountId: "3f31d6d6-c0d4-4c90-8fc3-5057a4e10370",
+      clientId: "042",
+      sessionEpoch: 1,
+    });
+    process.env.CLIENT_PORTAL_JWT_SECRET = "sol29-test-secret-with-at-least-32-characters";
+    expect(() => verifyPortalSession(token)).toThrowError(/Session portail invalide/);
+  });
+
+  it("keeps invitation tokens deterministic and only stores a SHA-256 fingerprint", () => {
+    const data = {
+      tokenId: "1e13fe9c-58ca-4e04-8388-d617f59095d6",
+      accountId: "3f31d6d6-c0d4-4c90-8fc3-5057a4e10370",
+      createdAt: "2026-08-14T12:00:00.000Z",
+      expiresAt: "2026-08-15T12:00:00.000Z",
+    };
+    const first = signPortalInvitationToken(data);
+    const second = signPortalInvitationToken(data);
+    expect(first).toBe(second);
+    expect(hashPortalOpaqueValue(first)).toMatch(/^[0-9a-f]{64}$/);
+    expect(verifyPortalInvitationToken(first)).toEqual({ tokenId: data.tokenId, accountId: data.accountId });
+  });
+
+  it("rejects an expired invitation without revealing the account", () => {
+    const token = signPortalInvitationToken({
+      tokenId: "1e13fe9c-58ca-4e04-8388-d617f59095d6",
+      accountId: "3f31d6d6-c0d4-4c90-8fc3-5057a4e10370",
+      createdAt: "2025-08-14T12:00:00.000Z",
+      expiresAt: "2025-08-15T12:00:00.000Z",
+    });
+    expect(() => verifyPortalInvitationToken(token)).toThrowError(/Lien portail expiré/);
+  });
+});

--- a/src/module/client-portal/domain/client-portal-security.ts
+++ b/src/module/client-portal/domain/client-portal-security.ts
@@ -1,0 +1,184 @@
+import crypto from "node:crypto";
+import jwt from "jsonwebtoken";
+
+import { HttpError } from "../../../utils/httpError";
+import type { ClientPortalIdentity } from "../types/client-portal.types";
+
+const PORTAL_AUDIENCE = "cerp-client-portal";
+const PORTAL_ISSUER = "cerp-api";
+const PORTAL_SESSION_PURPOSE = "client-portal-session-v1";
+const PORTAL_INVITATION_PURPOSE = "client-portal-invitation-v1";
+const PORTAL_RESET_PURPOSE = "client-portal-password-reset-v1";
+
+type PortalActionTokenPurpose =
+  | typeof PORTAL_INVITATION_PURPOSE
+  | typeof PORTAL_RESET_PURPOSE;
+
+export type PortalActionTokenData = Readonly<{
+  tokenId: string;
+  accountId: string;
+  createdAt: string;
+  expiresAt: string;
+}>;
+
+function portalSecret(): string {
+  const secret = (process.env.CLIENT_PORTAL_JWT_SECRET ?? "").trim();
+  if (secret.length < 32) {
+    throw new HttpError(
+      503,
+      "CLIENT_PORTAL_NOT_CONFIGURED",
+      "Le portail client n'est pas configuré sur cet environnement."
+    );
+  }
+  return secret;
+}
+
+function isUuid(value: unknown): value is string {
+  return typeof value === "string"
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+export function normalizePortalEmail(value: string): string {
+  return value.trim().toLocaleLowerCase("fr-FR");
+}
+
+export function hashPortalOpaqueValue(value: string): string {
+  return crypto.createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+export function hashPortalRateLimitValue(value: string): string {
+  return crypto.createHmac("sha256", portalSecret()).update(value, "utf8").digest("hex");
+}
+
+export function stablePortalRequestHash(value: unknown): string {
+  return hashPortalOpaqueValue(JSON.stringify(value));
+}
+
+export function signPortalSession(identity: ClientPortalIdentity): string {
+  return jwt.sign(
+    {
+      purpose: PORTAL_SESSION_PURPOSE,
+      account_id: identity.accountId,
+      client_id: identity.clientId,
+      session_epoch: identity.sessionEpoch,
+    },
+    portalSecret(),
+    {
+      algorithm: "HS256",
+      audience: PORTAL_AUDIENCE,
+      issuer: PORTAL_ISSUER,
+      expiresIn: "15m",
+      subject: identity.accountId,
+    }
+  );
+}
+
+export function verifyPortalSession(token: string): ClientPortalIdentity {
+  try {
+    const decoded = jwt.verify(token, portalSecret(), {
+      algorithms: ["HS256"],
+      audience: PORTAL_AUDIENCE,
+      issuer: PORTAL_ISSUER,
+    });
+    if (
+      typeof decoded !== "object"
+      || decoded === null
+      || decoded.purpose !== PORTAL_SESSION_PURPOSE
+      || !isUuid(decoded.account_id)
+      || typeof decoded.client_id !== "string"
+      || !/^.{1,3}$/.test(decoded.client_id)
+      || typeof decoded.session_epoch !== "number"
+      || !Number.isSafeInteger(decoded.session_epoch)
+      || decoded.session_epoch < 0
+    ) {
+      throw new Error("invalid portal claims");
+    }
+    return {
+      accountId: decoded.account_id,
+      clientId: decoded.client_id,
+      sessionEpoch: decoded.session_epoch,
+    };
+  } catch {
+    throw new HttpError(401, "CLIENT_PORTAL_SESSION_INVALID", "Session portail invalide ou expirée.");
+  }
+}
+
+function signPortalActionToken(purpose: PortalActionTokenPurpose, data: PortalActionTokenData): string {
+  const expiresAtSeconds = Math.floor(new Date(data.expiresAt).getTime() / 1000);
+  if (!Number.isSafeInteger(expiresAtSeconds)) throw new Error("Invalid portal token expiry");
+  return jwt.sign(
+    {
+      purpose,
+      token_id: data.tokenId,
+      account_id: data.accountId,
+      created_at: new Date(data.createdAt).toISOString(),
+      exp: expiresAtSeconds,
+    },
+    portalSecret(),
+    {
+      algorithm: "HS256",
+      audience: PORTAL_AUDIENCE,
+      issuer: PORTAL_ISSUER,
+      noTimestamp: true,
+      subject: data.accountId,
+    }
+  );
+}
+
+function verifyPortalActionToken(
+  purpose: PortalActionTokenPurpose,
+  rawToken: string,
+  expiredCode: string,
+  invalidCode: string
+): Pick<PortalActionTokenData, "tokenId" | "accountId"> {
+  try {
+    const decoded = jwt.verify(rawToken, portalSecret(), {
+      algorithms: ["HS256"],
+      audience: PORTAL_AUDIENCE,
+      issuer: PORTAL_ISSUER,
+    });
+    if (
+      typeof decoded !== "object"
+      || decoded === null
+      || decoded.purpose !== purpose
+      || !isUuid(decoded.token_id)
+      || !isUuid(decoded.account_id)
+    ) {
+      throw new HttpError(400, invalidCode, "Lien portail invalide ou expiré.");
+    }
+    return { tokenId: decoded.token_id, accountId: decoded.account_id };
+  } catch (error) {
+    if (error instanceof HttpError) throw error;
+    if (error instanceof jwt.TokenExpiredError) {
+      throw new HttpError(400, expiredCode, "Lien portail expiré. Demandez un nouveau lien.");
+    }
+    throw new HttpError(400, invalidCode, "Lien portail invalide ou expiré.");
+  }
+}
+
+export function signPortalInvitationToken(data: PortalActionTokenData): string {
+  return signPortalActionToken(PORTAL_INVITATION_PURPOSE, data);
+}
+
+export function verifyPortalInvitationToken(rawToken: string) {
+  return verifyPortalActionToken(
+    PORTAL_INVITATION_PURPOSE,
+    rawToken,
+    "CLIENT_PORTAL_INVITATION_EXPIRED",
+    "CLIENT_PORTAL_INVITATION_INVALID"
+  );
+}
+
+export function signPortalResetToken(data: PortalActionTokenData): string {
+  return signPortalActionToken(PORTAL_RESET_PURPOSE, data);
+}
+
+export function verifyPortalResetToken(rawToken: string) {
+  return verifyPortalActionToken(
+    PORTAL_RESET_PURPOSE,
+    rawToken,
+    "CLIENT_PORTAL_RESET_EXPIRED",
+    "CLIENT_PORTAL_RESET_INVALID"
+  );
+}
+

--- a/src/module/client-portal/middlewares/client-portal-auth.middleware.test.ts
+++ b/src/module/client-portal/middlewares/client-portal-auth.middleware.test.ts
@@ -1,0 +1,71 @@
+import type { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({ getLive: vi.fn() }));
+vi.mock("../repository/client-portal.repository", () => ({
+  repoGetLivePortalAccount: mocked.getLive,
+}));
+
+import { signPortalSession } from "../domain/client-portal-security";
+import { authenticateClientPortal } from "./client-portal-auth.middleware";
+
+const previousPortalSecret = process.env.CLIENT_PORTAL_JWT_SECRET;
+
+function responseDouble() {
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json }));
+  return { response: { status } as unknown as Response, status, json };
+}
+
+describe("authenticateClientPortal", () => {
+  beforeEach(() => {
+    process.env.CLIENT_PORTAL_JWT_SECRET = "sol29-test-secret-with-at-least-32-characters";
+    mocked.getLive.mockReset();
+  });
+
+  afterEach(() => {
+    if (previousPortalSecret === undefined) delete process.env.CLIENT_PORTAL_JWT_SECRET;
+    else process.env.CLIENT_PORTAL_JWT_SECRET = previousPortalSecret;
+  });
+
+  it("rejects an ERP JWT even when it is structurally valid", () => {
+    const erpToken = jwt.sign({ id: 1, role: "Directeur" }, "erp-secret");
+    const req = { headers: { authorization: `Bearer ${erpToken}` }, originalUrl: "/api/v1/portal/orders" } as Request;
+    const { response, status } = responseDouble();
+    authenticateClientPortal(req, response, vi.fn() as NextFunction);
+    expect(status).toHaveBeenCalledWith(401);
+    expect(mocked.getLive).not.toHaveBeenCalled();
+  });
+
+  it("revalidates the live account status and epoch before every request", async () => {
+    const identity = {
+      accountId: "3f31d6d6-c0d4-4c90-8fc3-5057a4e10370",
+      clientId: "042",
+      sessionEpoch: 3,
+    };
+    const token = signPortalSession(identity);
+    mocked.getLive.mockResolvedValue({ ...identity, id: identity.accountId, client_id: identity.clientId, status: "ACTIVE", session_epoch: 3 });
+    const req = { headers: { authorization: `Bearer ${token}` }, originalUrl: "/api/v1/portal/orders" } as Request;
+    const { response } = responseDouble();
+    const next = vi.fn();
+    authenticateClientPortal(req, response, next as NextFunction);
+    await vi.waitFor(() => expect(next).toHaveBeenCalledOnce());
+    expect(req.portalIdentity).toEqual(identity);
+  });
+
+  it("revokes a token immediately after a session epoch change", async () => {
+    const identity = {
+      accountId: "3f31d6d6-c0d4-4c90-8fc3-5057a4e10370",
+      clientId: "042",
+      sessionEpoch: 3,
+    };
+    const token = signPortalSession(identity);
+    mocked.getLive.mockResolvedValue({ id: identity.accountId, client_id: identity.clientId, status: "ACTIVE", session_epoch: 4 });
+    const req = { headers: { authorization: `Bearer ${token}` }, originalUrl: "/api/v1/portal/orders" } as Request;
+    const { response, status } = responseDouble();
+    authenticateClientPortal(req, response, vi.fn() as NextFunction);
+    await vi.waitFor(() => expect(status).toHaveBeenCalledWith(401));
+  });
+});
+

--- a/src/module/client-portal/middlewares/client-portal-auth.middleware.ts
+++ b/src/module/client-portal/middlewares/client-portal-auth.middleware.ts
@@ -1,0 +1,39 @@
+import type { RequestHandler } from "express";
+
+import { stripQueryFromUrl } from "../../../utils/logPath";
+import { verifyPortalSession } from "../domain/client-portal-security";
+import { repoGetLivePortalAccount } from "../repository/client-portal.repository";
+
+export const authenticateClientPortal: RequestHandler = (req, res, next) => {
+  const authorization = req.headers.authorization;
+  if (!authorization?.startsWith("Bearer ")) {
+    res.status(401).json({ code: "CLIENT_PORTAL_SESSION_REQUIRED", message: "Session portail requise." });
+    return;
+  }
+  try {
+    const identity = verifyPortalSession(authorization.slice("Bearer ".length));
+    repoGetLivePortalAccount(identity)
+      .then((account) => {
+        if (
+          !account
+          || account.status !== "ACTIVE"
+          || account.session_epoch !== identity.sessionEpoch
+        ) {
+          res.status(401).json({ code: "CLIENT_PORTAL_SESSION_INVALID", message: "Session portail invalide ou expirée." });
+          return;
+        }
+        req.portalIdentity = identity;
+        next();
+      })
+      .catch(next);
+  } catch {
+    console.warn(JSON.stringify({
+      type: "client_portal_auth_failed",
+      requestId: req.requestId ?? null,
+      path: stripQueryFromUrl(req.originalUrl),
+      reason: "session_invalid",
+    }));
+    res.status(401).json({ code: "CLIENT_PORTAL_SESSION_INVALID", message: "Session portail invalide ou expirée." });
+  }
+};
+

--- a/src/module/client-portal/repository/client-portal.repository.ts
+++ b/src/module/client-portal/repository/client-portal.repository.ts
@@ -1,0 +1,973 @@
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import type {
+  ClientPortalAuditActor,
+  ClientPortalDocumentState,
+  ClientPortalIdentity,
+  ClientPortalRequestMeta,
+} from "../types/client-portal.types";
+
+type Db = Pick<PoolClient, "query">;
+type JsonObject = Record<string, unknown>;
+
+export type PortalAccountRow = Readonly<{
+  id: string;
+  client_id: string;
+  company_name: string;
+  email: string;
+  email_normalized: string;
+  display_name: string;
+  password_hash: string;
+  status: "INVITED" | "ACTIVE" | "SUSPENDED" | "REVOKED";
+  session_epoch: number;
+  activated_at: string | null;
+  last_login_at: string | null;
+  created_at: string;
+}>;
+
+export type PortalDocumentRow = Readonly<{
+  id: string;
+  client_id: string;
+  version_id: string;
+  document_id: string;
+  code: string;
+  title: string;
+  version_number: number;
+  version_status: string;
+  current_version_id: string | null;
+  document_archived_at: string | null;
+  original_name: string;
+  mime_type: string;
+  size_bytes: number;
+  sha256: string;
+  storage_key?: string;
+  scan_status: string | null;
+  quarantine_status: string | null;
+  scanned_at: string | null;
+  expires_at: string | null;
+  revoked_at: string | null;
+  acknowledgement_required: boolean;
+  acknowledged_at: string | null;
+  published_at: string;
+}>;
+
+async function withTransaction<T>(work: (tx: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await work(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+function pgCode(error: unknown): string | null {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code ?? "")
+    : null;
+}
+
+export async function repoInsertPortalAudit(
+  db: Db,
+  input: {
+    actor: ClientPortalAuditActor;
+    action: string;
+    entityType: string;
+    entityId: string;
+    clientId: string | null;
+    meta: ClientPortalRequestMeta;
+    details?: JsonObject;
+  }
+): Promise<void> {
+  const erpActorId = input.actor.kind === "ERP_USER" ? input.actor.id : null;
+  const portalAccountId = input.actor.kind === "PORTAL_ACCOUNT" ? input.actor.id : null;
+  await db.query(
+    `INSERT INTO public.client_portal_audit_events (
+       erp_actor_id, portal_account_id, action, entity_type, entity_id,
+       client_id, request_id, ip_hash, user_agent_family, details
+     ) VALUES ($1,$2::uuid,$3,$4,$5,$6,$7,$8,$9,$10::jsonb)`,
+    [
+      erpActorId,
+      portalAccountId,
+      input.action,
+      input.entityType,
+      input.entityId,
+      input.clientId,
+      input.meta.requestId,
+      input.meta.ipHash,
+      input.meta.userAgentFamily,
+      JSON.stringify(input.details ?? {}),
+    ]
+  );
+}
+
+async function readReceipt(
+  tx: Db,
+  actorId: number,
+  action: string,
+  idempotencyKey: string,
+  requestHash: string
+): Promise<JsonObject | null> {
+  const result = await tx.query<{ request_sha256: string; result: JsonObject }>(
+    `SELECT request_sha256, result
+       FROM public.client_portal_command_receipts
+      WHERE erp_actor_id=$1 AND action=$2 AND idempotency_key=$3::uuid
+      FOR SHARE`,
+    [actorId, action, idempotencyKey]
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  if (row.request_sha256 !== requestHash) {
+    throw new HttpError(
+      409,
+      "CLIENT_PORTAL_IDEMPOTENCY_CONFLICT",
+      "Cette clé d'idempotence a déjà été utilisée avec une autre demande."
+    );
+  }
+  return row.result;
+}
+
+async function insertReceipt(
+  tx: Db,
+  actorId: number,
+  action: string,
+  idempotencyKey: string,
+  requestHash: string,
+  result: JsonObject
+): Promise<void> {
+  await tx.query(
+    `INSERT INTO public.client_portal_command_receipts (
+       erp_actor_id, action, idempotency_key, request_sha256, result
+     ) VALUES ($1,$2,$3::uuid,$4,$5::jsonb)`,
+    [actorId, action, idempotencyKey, requestHash, JSON.stringify(result)]
+  );
+}
+
+export async function repoListPortalAccounts(clientId?: string) {
+  const values: unknown[] = [];
+  const where = clientId ? `WHERE account.client_id=$${values.push(clientId)}` : "";
+  const result = await pool.query(
+    `SELECT account.id::text AS id, account.client_id, client.company_name,
+            account.email, account.display_name, account.status,
+            account.activated_at::text AS activated_at,
+            account.last_login_at::text AS last_login_at,
+            account.created_at::text AS created_at,
+            account.updated_at::text AS updated_at
+       FROM public.client_portal_accounts account
+       JOIN public.clients client ON client.client_id=account.client_id
+       ${where}
+      ORDER BY account.created_at DESC
+      LIMIT 250`,
+    values
+  );
+  return result.rows;
+}
+
+export async function repoCreatePortalAccount(input: {
+  actorId: number;
+  idempotencyKey: string;
+  requestHash: string;
+  clientId: string;
+  email: string;
+  emailNormalized: string;
+  displayName: string;
+  passwordHash: string;
+  meta: ClientPortalRequestMeta;
+}): Promise<{ account: JsonObject; replayed: boolean }> {
+  try {
+    return await withTransaction(async (tx) => {
+      const replay = await readReceipt(tx, input.actorId, "CREATE_ACCOUNT", input.idempotencyKey, input.requestHash);
+      if (replay) {
+        const replayedAccount = await tx.query<JsonObject>(
+          `SELECT account.id::text AS id, account.client_id, client.company_name,
+                  account.email, account.display_name, account.status,
+                  account.created_at::text AS created_at
+             FROM public.client_portal_accounts account
+             JOIN public.clients client ON client.client_id=account.client_id
+            WHERE account.id=$1::uuid`,
+          [String(replay.id)]
+        );
+        if (!replayedAccount.rows[0]) {
+          throw new HttpError(409, "CLIENT_PORTAL_IDEMPOTENCY_ORPHAN", "Le reçu existe mais le compte est introuvable.");
+        }
+        return { account: replayedAccount.rows[0], replayed: true };
+      }
+
+      const client = await tx.query<{ client_id: string; company_name: string }>(
+        `SELECT client_id, company_name FROM public.clients WHERE client_id=$1 FOR SHARE`,
+        [input.clientId]
+      );
+      if (!client.rows[0]) {
+        throw new HttpError(404, "CLIENT_PORTAL_CLIENT_NOT_FOUND", "Client introuvable.");
+      }
+
+      const created = await tx.query<{
+        id: string;
+        client_id: string;
+        email: string;
+        display_name: string;
+        status: string;
+        created_at: string;
+      }>(
+        `INSERT INTO public.client_portal_accounts (
+           client_id, email, email_normalized, display_name, password_hash,
+           status, created_by, updated_by
+         ) VALUES ($1,$2,$3,$4,$5,'INVITED',$6,$6)
+         RETURNING id::text AS id, client_id, email, display_name, status, created_at::text AS created_at`,
+        [input.clientId, input.email, input.emailNormalized, input.displayName, input.passwordHash, input.actorId]
+      );
+      const createdAccount = created.rows[0];
+      if (!createdAccount) throw new Error("Portal account insert returned no row");
+      const account: JsonObject = { ...createdAccount, company_name: client.rows[0].company_name };
+      await repoInsertPortalAudit(tx, {
+        actor: { kind: "ERP_USER", id: input.actorId },
+        action: "CLIENT_PORTAL_ACCOUNT_CREATED",
+        entityType: "client_portal_account",
+        entityId: String(account.id),
+        clientId: input.clientId,
+        meta: input.meta,
+        details: { status: "INVITED" },
+      });
+      await insertReceipt(tx, input.actorId, "CREATE_ACCOUNT", input.idempotencyKey, input.requestHash, {
+        id: account.id,
+        client_id: account.client_id,
+        status: account.status,
+        created_at: account.created_at,
+      });
+      return { account, replayed: false };
+    });
+  } catch (error) {
+    if (pgCode(error) === "23505") {
+      throw new HttpError(409, "CLIENT_PORTAL_ACCOUNT_EXISTS", "Un compte portail actif existe déjà pour cet email.");
+    }
+    throw error;
+  }
+}
+
+export async function repoCreatePortalInvitation(input: {
+  actorId: number;
+  accountId: string;
+  tokenId: string;
+  tokenHash: string;
+  createdAt: string;
+  expiresAt: string;
+  idempotencyKey: string;
+  requestHash: string;
+  meta: ClientPortalRequestMeta;
+}): Promise<{ token: JsonObject; replayed: boolean }> {
+  return withTransaction(async (tx) => {
+    const replay = await readReceipt(tx, input.actorId, "CREATE_INVITATION", input.idempotencyKey, input.requestHash);
+    if (replay) {
+      const replayAccount = await tx.query<{ email: string; display_name: string }>(
+        `SELECT email, display_name FROM public.client_portal_accounts WHERE id=$1::uuid`,
+        [String(replay.account_id)]
+      );
+      if (!replayAccount.rows[0]) {
+        throw new HttpError(409, "CLIENT_PORTAL_IDEMPOTENCY_ORPHAN", "Le reçu existe mais le compte est introuvable.");
+      }
+      return { token: { ...replay, ...replayAccount.rows[0] }, replayed: true };
+    }
+
+    const accountResult = await tx.query<PortalAccountRow>(
+      `SELECT account.id::text AS id, account.client_id, client.company_name,
+              account.email, account.email_normalized, account.display_name,
+              account.password_hash, account.status, account.session_epoch,
+              account.activated_at::text AS activated_at,
+              account.last_login_at::text AS last_login_at,
+              account.created_at::text AS created_at
+         FROM public.client_portal_accounts account
+         JOIN public.clients client ON client.client_id=account.client_id
+        WHERE account.id=$1::uuid
+        FOR UPDATE OF account`,
+      [input.accountId]
+    );
+    const account = accountResult.rows[0];
+    if (!account) throw new HttpError(404, "CLIENT_PORTAL_ACCOUNT_NOT_FOUND", "Compte portail introuvable.");
+    if (account.status !== "INVITED") {
+      throw new HttpError(409, "CLIENT_PORTAL_INVITATION_STATE", "Ce compte n'est pas en attente d'activation.");
+    }
+
+    await tx.query(
+      `UPDATE public.client_portal_tokens
+          SET revoked_at=now()
+        WHERE account_id=$1::uuid AND purpose='INVITATION'
+          AND consumed_at IS NULL AND revoked_at IS NULL`,
+      [account.id]
+    );
+    const inserted = await tx.query<JsonObject>(
+      `INSERT INTO public.client_portal_tokens (
+         id, account_id, purpose, token_hash, expires_at, created_by, created_at
+       ) VALUES ($1::uuid,$2::uuid,'INVITATION',$3,$4::timestamptz,$5,$6::timestamptz)
+       RETURNING id::text AS token_id, account_id::text AS account_id,
+                 created_at::text AS created_at, expires_at::text AS expires_at`,
+      [input.tokenId, account.id, input.tokenHash, input.expiresAt, input.actorId, input.createdAt]
+    );
+    const receiptToken = {
+      ...inserted.rows[0],
+      client_id: account.client_id,
+    };
+    const token = { ...receiptToken, email: account.email, display_name: account.display_name };
+    await repoInsertPortalAudit(tx, {
+      actor: { kind: "ERP_USER", id: input.actorId },
+      action: "CLIENT_PORTAL_ACCOUNT_INVITED",
+      entityType: "client_portal_account",
+      entityId: account.id,
+      clientId: account.client_id,
+      meta: input.meta,
+      details: { expires_at: input.expiresAt },
+    });
+    await insertReceipt(tx, input.actorId, "CREATE_INVITATION", input.idempotencyKey, input.requestHash, receiptToken);
+    return { token, replayed: false };
+  });
+}
+
+export async function repoActivatePortalAccount(input: {
+  tokenId: string;
+  accountId: string;
+  tokenHash: string;
+  passwordHash: string;
+  meta: ClientPortalRequestMeta;
+}): Promise<{ account_id: string; client_id: string; replayed: boolean }> {
+  return withTransaction(async (tx) => {
+    const result = await tx.query<{
+      token_id: string;
+      account_id: string;
+      client_id: string;
+      status: string;
+      consumed_at: string | null;
+      revoked_at: string | null;
+      expires_at: string;
+    }>(
+      `SELECT token.id::text AS token_id, account.id::text AS account_id,
+              account.client_id, account.status, token.consumed_at::text AS consumed_at,
+              token.revoked_at::text AS revoked_at, token.expires_at::text AS expires_at
+         FROM public.client_portal_tokens token
+         JOIN public.client_portal_accounts account ON account.id=token.account_id
+        WHERE token.id=$1::uuid AND account.id=$2::uuid
+          AND token.purpose='INVITATION' AND token.token_hash=$3
+        FOR UPDATE OF token, account`,
+      [input.tokenId, input.accountId, input.tokenHash]
+    );
+    const row = result.rows[0];
+    if (!row || row.revoked_at || new Date(row.expires_at).getTime() <= Date.now()) {
+      throw new HttpError(400, "CLIENT_PORTAL_INVITATION_INVALID", "Invitation invalide ou expirée.");
+    }
+    if (row.consumed_at) {
+      if (row.status === "ACTIVE") return { account_id: row.account_id, client_id: row.client_id, replayed: true };
+      throw new HttpError(409, "CLIENT_PORTAL_INVITATION_STATE", "Cette invitation a déjà été utilisée.");
+    }
+    if (row.status !== "INVITED") {
+      throw new HttpError(409, "CLIENT_PORTAL_INVITATION_STATE", "Ce compte n'est plus activable.");
+    }
+
+    await tx.query(
+      `UPDATE public.client_portal_accounts
+          SET password_hash=$2, status='ACTIVE', activated_at=now(),
+              suspended_at=NULL, revoked_at=NULL, session_epoch=session_epoch+1, updated_at=now()
+        WHERE id=$1::uuid`,
+      [row.account_id, input.passwordHash]
+    );
+    await tx.query(`UPDATE public.client_portal_tokens SET consumed_at=now() WHERE id=$1::uuid`, [row.token_id]);
+    await repoInsertPortalAudit(tx, {
+      actor: { kind: "PORTAL_ACCOUNT", id: row.account_id },
+      action: "CLIENT_PORTAL_ACCOUNT_ACTIVATED",
+      entityType: "client_portal_account",
+      entityId: row.account_id,
+      clientId: row.client_id,
+      meta: input.meta,
+    });
+    return { account_id: row.account_id, client_id: row.client_id, replayed: false };
+  });
+}
+
+export async function repoFindPortalAccountByEmail(emailNormalized: string): Promise<PortalAccountRow | null> {
+  const result = await pool.query<PortalAccountRow>(
+    `SELECT account.id::text AS id, account.client_id, client.company_name,
+            account.email, account.email_normalized, account.display_name,
+            account.password_hash, account.status, account.session_epoch,
+            account.activated_at::text AS activated_at,
+            account.last_login_at::text AS last_login_at,
+            account.created_at::text AS created_at
+       FROM public.client_portal_accounts account
+       JOIN public.clients client ON client.client_id=account.client_id
+      WHERE account.email_normalized=$1 AND account.status <> 'REVOKED'
+      LIMIT 1`,
+    [emailNormalized]
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function repoGetLivePortalAccount(identity: ClientPortalIdentity) {
+  const result = await pool.query<{
+    id: string;
+    client_id: string;
+    status: string;
+    session_epoch: number;
+  }>(
+    `SELECT id::text AS id, client_id, status, session_epoch::int AS session_epoch
+       FROM public.client_portal_accounts
+      WHERE id=$1::uuid AND client_id=$2`,
+    [identity.accountId, identity.clientId]
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function repoRecordPortalLogin(account: PortalAccountRow, meta: ClientPortalRequestMeta): Promise<void> {
+  await withTransaction(async (tx) => {
+    await tx.query(
+      `UPDATE public.client_portal_accounts SET last_login_at=now(), updated_at=now() WHERE id=$1::uuid`,
+      [account.id]
+    );
+    await repoInsertPortalAudit(tx, {
+      actor: { kind: "PORTAL_ACCOUNT", id: account.id },
+      action: "CLIENT_PORTAL_LOGIN_SUCCEEDED",
+      entityType: "client_portal_account",
+      entityId: account.id,
+      clientId: account.client_id,
+      meta,
+    });
+  });
+}
+
+export async function repoCreatePortalResetToken(input: {
+  accountId: string;
+  tokenId: string;
+  tokenHash: string;
+  createdAt: string;
+  expiresAt: string;
+  meta: ClientPortalRequestMeta;
+}): Promise<void> {
+  await withTransaction(async (tx) => {
+    const account = await tx.query<{ id: string; client_id: string; status: string }>(
+      `SELECT id::text AS id, client_id, status
+         FROM public.client_portal_accounts
+        WHERE id=$1::uuid FOR UPDATE`,
+      [input.accountId]
+    );
+    const row = account.rows[0];
+    if (!row || row.status === "REVOKED") return;
+    await tx.query(
+      `UPDATE public.client_portal_tokens SET revoked_at=now()
+        WHERE account_id=$1::uuid AND purpose='PASSWORD_RESET'
+          AND consumed_at IS NULL AND revoked_at IS NULL`,
+      [row.id]
+    );
+    await tx.query(
+      `INSERT INTO public.client_portal_tokens (
+         id, account_id, purpose, token_hash, expires_at, created_at
+       ) VALUES ($1::uuid,$2::uuid,'PASSWORD_RESET',$3,$4::timestamptz,$5::timestamptz)`,
+      [input.tokenId, row.id, input.tokenHash, input.expiresAt, input.createdAt]
+    );
+    await repoInsertPortalAudit(tx, {
+      actor: { kind: "PORTAL_ACCOUNT", id: row.id },
+      action: "CLIENT_PORTAL_PASSWORD_RESET_REQUESTED",
+      entityType: "client_portal_account",
+      entityId: row.id,
+      clientId: row.client_id,
+      meta: input.meta,
+      details: { expires_at: input.expiresAt },
+    });
+  });
+}
+
+export async function repoResetPortalPassword(input: {
+  tokenId: string;
+  accountId: string;
+  tokenHash: string;
+  passwordHash: string;
+  meta: ClientPortalRequestMeta;
+}): Promise<{ account_id: string; client_id: string }> {
+  return withTransaction(async (tx) => {
+    const result = await tx.query<{
+      token_id: string;
+      account_id: string;
+      client_id: string;
+      status: string;
+      consumed_at: string | null;
+      revoked_at: string | null;
+      expires_at: string;
+    }>(
+      `SELECT token.id::text AS token_id, account.id::text AS account_id,
+              account.client_id, account.status, token.consumed_at::text AS consumed_at,
+              token.revoked_at::text AS revoked_at, token.expires_at::text AS expires_at
+         FROM public.client_portal_tokens token
+         JOIN public.client_portal_accounts account ON account.id=token.account_id
+        WHERE token.id=$1::uuid AND account.id=$2::uuid
+          AND token.purpose='PASSWORD_RESET' AND token.token_hash=$3
+        FOR UPDATE OF token, account`,
+      [input.tokenId, input.accountId, input.tokenHash]
+    );
+    const row = result.rows[0];
+    if (
+      !row || row.revoked_at || row.consumed_at || row.status === "REVOKED"
+      || new Date(row.expires_at).getTime() <= Date.now()
+    ) {
+      throw new HttpError(400, "CLIENT_PORTAL_RESET_INVALID", "Lien de réinitialisation invalide ou expiré.");
+    }
+    await tx.query(
+      `UPDATE public.client_portal_accounts
+          SET password_hash=$2, session_epoch=session_epoch+1, updated_at=now()
+        WHERE id=$1::uuid`,
+      [row.account_id, input.passwordHash]
+    );
+    await tx.query(`UPDATE public.client_portal_tokens SET consumed_at=now() WHERE id=$1::uuid`, [row.token_id]);
+    await repoInsertPortalAudit(tx, {
+      actor: { kind: "PORTAL_ACCOUNT", id: row.account_id },
+      action: "CLIENT_PORTAL_PASSWORD_RESET_COMPLETED",
+      entityType: "client_portal_account",
+      entityId: row.account_id,
+      clientId: row.client_id,
+      meta: input.meta,
+    });
+    return { account_id: row.account_id, client_id: row.client_id };
+  });
+}
+
+export async function repoSetPortalAccountStatus(input: {
+  actorId: number;
+  accountId: string;
+  status: "ACTIVE" | "SUSPENDED" | "REVOKED";
+  reason: string;
+  meta: ClientPortalRequestMeta;
+}) {
+  return withTransaction(async (tx) => {
+    const current = await tx.query<{ id: string; client_id: string; status: string; activated_at: string | null }>(
+      `SELECT id::text AS id, client_id, status, activated_at::text AS activated_at
+         FROM public.client_portal_accounts WHERE id=$1::uuid FOR UPDATE`,
+      [input.accountId]
+    );
+    const row = current.rows[0];
+    if (!row) throw new HttpError(404, "CLIENT_PORTAL_ACCOUNT_NOT_FOUND", "Compte portail introuvable.");
+    if (row.status === "REVOKED") {
+      throw new HttpError(409, "CLIENT_PORTAL_ACCOUNT_REVOKED", "Un compte révoqué ne peut pas être réactivé.");
+    }
+    if (input.status === "ACTIVE" && !row.activated_at) {
+      throw new HttpError(409, "CLIENT_PORTAL_ACCOUNT_NOT_ACTIVATED", "Le compte doit d'abord être activé par invitation.");
+    }
+    const updated = await tx.query(
+      `UPDATE public.client_portal_accounts
+          SET status=$2,
+              suspended_at=CASE WHEN $2='SUSPENDED' THEN now() ELSE NULL END,
+              revoked_at=CASE WHEN $2='REVOKED' THEN now() ELSE NULL END,
+              session_epoch=session_epoch+1, updated_by=$3, updated_at=now()
+        WHERE id=$1::uuid
+        RETURNING id::text AS id, client_id, status, session_epoch::int AS session_epoch`,
+      [row.id, input.status, input.actorId]
+    );
+    await tx.query(
+      `UPDATE public.client_portal_tokens SET revoked_at=now()
+        WHERE account_id=$1::uuid AND consumed_at IS NULL AND revoked_at IS NULL`,
+      [row.id]
+    );
+    await repoInsertPortalAudit(tx, {
+      actor: { kind: "ERP_USER", id: input.actorId },
+      action: `CLIENT_PORTAL_ACCOUNT_${input.status}`,
+      entityType: "client_portal_account",
+      entityId: row.id,
+      clientId: row.client_id,
+      meta: input.meta,
+      details: { previous_status: row.status, reason_recorded: true },
+    });
+    return updated.rows[0];
+  });
+}
+
+export async function repoConsumePortalAuthAttempt(input: {
+  action: "LOGIN" | "ACTIVATE" | "FORGOT_PASSWORD" | "RESET_PASSWORD";
+  identifierHash: string;
+  ipHash: string | null;
+  identifierLimit: number;
+  ipLimit: number;
+  windowSeconds: number;
+}): Promise<string> {
+  return withTransaction(async (tx) => {
+    const lockKeys = [
+      `client-portal-rate:${input.action}:identifier:${input.identifierHash}`,
+      ...(input.ipHash ? [`client-portal-rate:${input.action}:ip:${input.ipHash}`] : []),
+    ].sort();
+    await tx.query(
+      `SELECT pg_advisory_xact_lock(hashtextextended(lock_key, 0))
+         FROM unnest($1::text[]) AS lock_key
+        ORDER BY lock_key`,
+      [lockKeys]
+    );
+    const counts = await tx.query<{ identifier_count: string; ip_count: string }>(
+      `SELECT
+         count(*) FILTER (WHERE identifier_hash=$2)::bigint::text AS identifier_count,
+         count(*) FILTER (WHERE $3::text IS NOT NULL AND ip_hash=$3)::bigint::text AS ip_count
+       FROM public.client_portal_auth_attempts
+       WHERE action=$1 AND occurred_at > now() - make_interval(secs => $4::int)`,
+      [input.action, input.identifierHash, input.ipHash, input.windowSeconds]
+    );
+    const identifierCount = Number(counts.rows[0]?.identifier_count ?? 0);
+    const ipCount = Number(counts.rows[0]?.ip_count ?? 0);
+    if (identifierCount >= input.identifierLimit || ipCount >= input.ipLimit) {
+      throw new HttpError(429, "CLIENT_PORTAL_RATE_LIMITED", "Trop de tentatives. Réessayez plus tard.");
+    }
+    const inserted = await tx.query<{ id: string }>(
+      `INSERT INTO public.client_portal_auth_attempts(action, identifier_hash, ip_hash, success)
+       VALUES ($1,$2,$3,false) RETURNING id::bigint::text AS id`,
+      [input.action, input.identifierHash, input.ipHash]
+    );
+    await tx.query(`DELETE FROM public.client_portal_auth_attempts WHERE occurred_at < now() - interval '2 days'`);
+    return String(inserted.rows[0].id);
+  });
+}
+
+export async function repoMarkPortalAuthAttemptSuccess(attemptId: string): Promise<void> {
+  await pool.query(
+    `UPDATE public.client_portal_auth_attempts SET success=true WHERE id=$1::bigint`,
+    [attemptId]
+  );
+}
+
+export async function repoGetPortalProfile(identity: ClientPortalIdentity) {
+  const result = await pool.query(
+    `SELECT account.id::text AS account_id, account.client_id, account.display_name,
+            client.company_name, account.last_login_at::text AS last_login_at
+       FROM public.client_portal_accounts account
+       JOIN public.clients client ON client.client_id=account.client_id
+      WHERE account.id=$1::uuid AND account.client_id=$2 AND account.status='ACTIVE'`,
+    [identity.accountId, identity.clientId]
+  );
+  return result.rows[0] ?? null;
+}
+
+async function listProjection(viewName: string, identity: ClientPortalIdentity, page: number, pageSize: number) {
+  const allowedViews = new Set([
+    "client_portal_orders_v",
+    "client_portal_deliveries_v",
+    "client_portal_invoices_v",
+  ]);
+  if (!allowedViews.has(viewName)) throw new Error("Unknown portal projection");
+  const offset = (page - 1) * pageSize;
+  const count = await pool.query<{ total: number }>(
+    `SELECT count(*)::int AS total FROM public.${viewName} WHERE client_id=$1`,
+    [identity.clientId]
+  );
+  const data = await pool.query(
+    `SELECT * FROM public.${viewName}
+      WHERE client_id=$1
+      ORDER BY updated_at DESC, id DESC
+      LIMIT $2 OFFSET $3`,
+    [identity.clientId, pageSize, offset]
+  );
+  return { items: data.rows.map(({ client_id: _clientId, ...row }) => row), total: count.rows[0]?.total ?? 0 };
+}
+
+export const repoListPortalOrders = (identity: ClientPortalIdentity, page: number, pageSize: number) =>
+  listProjection("client_portal_orders_v", identity, page, pageSize);
+
+export const repoListPortalDeliveries = (identity: ClientPortalIdentity, page: number, pageSize: number) =>
+  listProjection("client_portal_deliveries_v", identity, page, pageSize);
+
+export const repoListPortalInvoices = (identity: ClientPortalIdentity, page: number, pageSize: number) =>
+  listProjection("client_portal_invoices_v", identity, page, pageSize);
+
+const PORTAL_DOCUMENT_SELECT = `
+  publication.id::text AS id,
+  publication.client_id,
+  publication.version_id::text AS version_id,
+  version.document_id::text AS document_id,
+  document.code,
+  COALESCE(publication.title_override, document.title) AS title,
+  version.version_number::int AS version_number,
+  version.status::text AS version_status,
+  document.current_version_id::text AS current_version_id,
+  document.archived_at::text AS document_archived_at,
+  version.original_name,
+  blob.mime_type,
+  blob.size_bytes::bigint::text AS size_bytes,
+  blob.sha256,
+  session.scan_status,
+  session.quarantine_status,
+  session.scanned_at::text AS scanned_at,
+  publication.expires_at::text AS expires_at,
+  publication.revoked_at::text AS revoked_at,
+  publication.acknowledgement_required,
+  acknowledgement.acknowledged_at::text AS acknowledged_at,
+  publication.created_at::text AS published_at
+`;
+
+function mapPortalDocument(row: Record<string, unknown>): PortalDocumentRow {
+  return {
+    id: String(row.id),
+    client_id: String(row.client_id),
+    version_id: String(row.version_id),
+    document_id: String(row.document_id),
+    code: String(row.code),
+    title: String(row.title),
+    version_number: Number(row.version_number),
+    version_status: String(row.version_status),
+    current_version_id: row.current_version_id == null ? null : String(row.current_version_id),
+    document_archived_at: row.document_archived_at == null ? null : String(row.document_archived_at),
+    original_name: String(row.original_name),
+    mime_type: String(row.mime_type),
+    size_bytes: Number(row.size_bytes),
+    sha256: String(row.sha256),
+    ...(row.storage_key == null ? {} : { storage_key: String(row.storage_key) }),
+    scan_status: row.scan_status == null ? null : String(row.scan_status),
+    quarantine_status: row.quarantine_status == null ? null : String(row.quarantine_status),
+    scanned_at: row.scanned_at == null ? null : String(row.scanned_at),
+    expires_at: row.expires_at == null ? null : String(row.expires_at),
+    revoked_at: row.revoked_at == null ? null : String(row.revoked_at),
+    acknowledgement_required: Boolean(row.acknowledgement_required),
+    acknowledged_at: row.acknowledged_at == null ? null : String(row.acknowledged_at),
+    published_at: String(row.published_at),
+  };
+}
+
+export async function repoListPortalDocuments(identity: ClientPortalIdentity): Promise<PortalDocumentRow[]> {
+  const result = await pool.query(
+    `SELECT ${PORTAL_DOCUMENT_SELECT}
+       FROM public.client_portal_publications publication
+       JOIN public.ged_document_versions version ON version.id=publication.version_id
+       JOIN public.ged_documents document ON document.id=version.document_id
+       JOIN public.ged_blobs blob ON blob.id=version.blob_id
+       LEFT JOIN public.ged_upload_sessions session ON session.id=version.upload_session_id
+       LEFT JOIN public.client_portal_acknowledgements acknowledgement
+         ON acknowledgement.publication_id=publication.id AND acknowledgement.account_id=$1::uuid
+      WHERE publication.client_id=$2
+      ORDER BY publication.created_at DESC`,
+    [identity.accountId, identity.clientId]
+  );
+  return result.rows.map(mapPortalDocument);
+}
+
+export async function repoGetPortalDocumentDownload(
+  identity: ClientPortalIdentity,
+  publicationId: string
+): Promise<PortalDocumentRow | null> {
+  const result = await pool.query(
+    `SELECT ${PORTAL_DOCUMENT_SELECT}, blob.storage_key
+       FROM public.client_portal_publications publication
+       JOIN public.ged_document_versions version ON version.id=publication.version_id
+       JOIN public.ged_documents document ON document.id=version.document_id
+       JOIN public.ged_blobs blob ON blob.id=version.blob_id
+       LEFT JOIN public.ged_upload_sessions session ON session.id=version.upload_session_id
+       LEFT JOIN public.client_portal_acknowledgements acknowledgement
+         ON acknowledgement.publication_id=publication.id AND acknowledgement.account_id=$1::uuid
+      WHERE publication.id=$2::uuid AND publication.client_id=$3`,
+    [identity.accountId, publicationId, identity.clientId]
+  );
+  return result.rows[0] ? mapPortalDocument(result.rows[0]) : null;
+}
+
+export async function repoAcknowledgePortalDocument(input: {
+  identity: ClientPortalIdentity;
+  publicationId: string;
+  state: ClientPortalDocumentState;
+  meta: ClientPortalRequestMeta;
+}) {
+  return withTransaction(async (tx) => {
+    const publication = await tx.query<{ id: string; client_id: string; acknowledgement_required: boolean }>(
+      `SELECT id::text AS id, client_id, acknowledgement_required
+         FROM public.client_portal_publications
+        WHERE id=$1::uuid AND client_id=$2
+        FOR SHARE`,
+      [input.publicationId, input.identity.clientId]
+    );
+    const row = publication.rows[0];
+    if (!row) throw new HttpError(404, "CLIENT_PORTAL_DOCUMENT_NOT_FOUND", "Document introuvable.");
+    if (!row.acknowledgement_required) {
+      throw new HttpError(409, "CLIENT_PORTAL_ACK_NOT_REQUIRED", "Aucun accusé de lecture n'est requis.");
+    }
+    if (input.state !== "AVAILABLE") {
+      throw new HttpError(409, "CLIENT_PORTAL_DOCUMENT_UNAVAILABLE", "Ce document ne peut pas être accusé dans son état actuel.");
+    }
+    const inserted = await tx.query<{ acknowledged_at: string }>(
+      `INSERT INTO public.client_portal_acknowledgements(publication_id, account_id, request_id)
+       VALUES ($1::uuid,$2::uuid,$3)
+       ON CONFLICT (publication_id, account_id) DO NOTHING
+       RETURNING acknowledged_at::text AS acknowledged_at`,
+      [row.id, input.identity.accountId, input.meta.requestId]
+    );
+    const existing = inserted.rows[0] ?? (await tx.query<{ acknowledged_at: string }>(
+      `SELECT acknowledged_at::text AS acknowledged_at
+         FROM public.client_portal_acknowledgements
+        WHERE publication_id=$1::uuid AND account_id=$2::uuid`,
+      [row.id, input.identity.accountId]
+    )).rows[0];
+    if (inserted.rows[0]) {
+      await repoInsertPortalAudit(tx, {
+        actor: { kind: "PORTAL_ACCOUNT", id: input.identity.accountId },
+        action: "CLIENT_PORTAL_DOCUMENT_ACKNOWLEDGED",
+        entityType: "client_portal_publication",
+        entityId: row.id,
+        clientId: input.identity.clientId,
+        meta: input.meta,
+      });
+    }
+    return { acknowledged_at: existing.acknowledged_at, replayed: !inserted.rows[0] };
+  });
+}
+
+export async function repoCreatePortalPublication(input: {
+  actorId: number;
+  idempotencyKey: string;
+  requestHash: string;
+  clientId: string;
+  versionId: string;
+  title: string | null;
+  expiresAt: string | null;
+  acknowledgementRequired: boolean;
+  meta: ClientPortalRequestMeta;
+}) {
+  try {
+    return await withTransaction(async (tx) => {
+      const replay = await readReceipt(tx, input.actorId, "PUBLISH_DOCUMENT", input.idempotencyKey, input.requestHash);
+      if (replay) return { publication: replay, replayed: true };
+
+      const eligible = await tx.query<{ version_id: string; document_id: string }>(
+        `SELECT version.id::text AS version_id, version.document_id::text AS document_id
+           FROM public.ged_document_versions version
+           JOIN public.ged_documents document ON document.id=version.document_id
+           JOIN public.ged_upload_sessions session ON session.id=version.upload_session_id
+          WHERE version.id=$1::uuid
+            AND version.status='APPLICABLE'
+            AND document.current_version_id=version.id
+            AND document.archived_at IS NULL
+            AND session.scan_status='clean'
+            AND session.quarantine_status='released'
+            AND EXISTS (
+              SELECT 1
+                FROM public.ged_document_links link
+               WHERE link.document_id=document.id
+                 AND (
+                   (link.entity_type='CLIENT' AND link.entity_id=$2)
+                   OR (link.entity_type='COMMANDE_CLIENT' AND EXISTS (
+                     SELECT 1 FROM public.commande_client cc
+                      WHERE cc.id::text=link.entity_id AND cc.client_id=$2
+                   ))
+                   OR (link.entity_type='FACTURE' AND EXISTS (
+                     SELECT 1 FROM public.facture facture
+                      WHERE facture.id::text=link.entity_id AND facture.client_id=$2
+                   ))
+                   OR (link.entity_type IN ('BON_LIVRAISON','LIVRAISON') AND EXISTS (
+                     SELECT 1 FROM public.bon_livraison bl
+                      WHERE bl.id::text=link.entity_id AND bl.client_id=$2
+                   ))
+                 )
+            )
+          FOR SHARE OF version, document, session`,
+        [input.versionId, input.clientId]
+      );
+      if (!eligible.rows[0]) {
+        throw new HttpError(
+          409,
+          "CLIENT_PORTAL_DOCUMENT_NOT_ELIGIBLE",
+          "La version doit être courante, applicable, saine et liée à ce client."
+        );
+      }
+      const inserted = await tx.query<JsonObject>(
+        `INSERT INTO public.client_portal_publications (
+           client_id, version_id, title_override, acknowledgement_required,
+           expires_at, published_by
+         ) VALUES ($1,$2::uuid,$3,$4,$5::timestamptz,$6)
+         RETURNING id::text AS id, client_id, version_id::text AS version_id,
+                   acknowledgement_required, expires_at::text AS expires_at,
+                   created_at::text AS published_at`,
+        [input.clientId, input.versionId, input.title, input.acknowledgementRequired, input.expiresAt, input.actorId]
+      );
+      const publication = inserted.rows[0];
+      await repoInsertPortalAudit(tx, {
+        actor: { kind: "ERP_USER", id: input.actorId },
+        action: "CLIENT_PORTAL_DOCUMENT_PUBLISHED",
+        entityType: "client_portal_publication",
+        entityId: String(publication.id),
+        clientId: input.clientId,
+        meta: input.meta,
+        details: {
+          version_id: input.versionId,
+          acknowledgement_required: input.acknowledgementRequired,
+          expires_at: input.expiresAt,
+        },
+      });
+      await insertReceipt(tx, input.actorId, "PUBLISH_DOCUMENT", input.idempotencyKey, input.requestHash, publication);
+      return { publication, replayed: false };
+    });
+  } catch (error) {
+    if (pgCode(error) === "23505") {
+      throw new HttpError(409, "CLIENT_PORTAL_PUBLICATION_EXISTS", "Cette version est déjà publiée pour ce client.");
+    }
+    throw error;
+  }
+}
+
+export async function repoRevokePortalPublication(input: {
+  actorId: number;
+  publicationId: string;
+  reason: string;
+  meta: ClientPortalRequestMeta;
+}) {
+  return withTransaction(async (tx) => {
+    const result = await tx.query<{ id: string; client_id: string; revoked_at: string }>(
+      `UPDATE public.client_portal_publications
+          SET revoked_at=COALESCE(revoked_at, now()),
+              revoked_by=COALESCE(revoked_by, $2),
+              revoked_reason=COALESCE(revoked_reason, $3)
+        WHERE id=$1::uuid
+        RETURNING id::text AS id, client_id, revoked_at::text AS revoked_at`,
+      [input.publicationId, input.actorId, input.reason]
+    );
+    const row = result.rows[0];
+    if (!row) throw new HttpError(404, "CLIENT_PORTAL_PUBLICATION_NOT_FOUND", "Publication introuvable.");
+    await repoInsertPortalAudit(tx, {
+      actor: { kind: "ERP_USER", id: input.actorId },
+      action: "CLIENT_PORTAL_DOCUMENT_REVOKED",
+      entityType: "client_portal_publication",
+      entityId: row.id,
+      clientId: row.client_id,
+      meta: input.meta,
+      details: { reason_recorded: true },
+    });
+    return row;
+  });
+}
+
+export async function repoListPortalPublications(clientId?: string) {
+  const values: unknown[] = [];
+  const where = clientId ? `WHERE publication.client_id=$${values.push(clientId)}` : "";
+  const result = await pool.query(
+    `SELECT publication.id::text AS id, publication.client_id,
+            publication.version_id::text AS version_id, document.code,
+            COALESCE(publication.title_override, document.title) AS title,
+            publication.acknowledgement_required,
+            publication.expires_at::text AS expires_at,
+            publication.revoked_at::text AS revoked_at,
+            publication.created_at::text AS published_at
+       FROM public.client_portal_publications publication
+       JOIN public.ged_document_versions version ON version.id=publication.version_id
+       JOIN public.ged_documents document ON document.id=version.document_id
+       ${where}
+      ORDER BY publication.created_at DESC
+      LIMIT 250`,
+    values
+  );
+  return result.rows;
+}
+
+export async function repoRecordPortalDocumentDownload(input: {
+  identity: ClientPortalIdentity;
+  publicationId: string;
+  outcome: "SUCCEEDED" | "INTEGRITY_FAILURE";
+  meta: ClientPortalRequestMeta;
+}): Promise<void> {
+  await repoInsertPortalAudit(pool, {
+    actor: { kind: "PORTAL_ACCOUNT", id: input.identity.accountId },
+    action: input.outcome === "SUCCEEDED"
+      ? "CLIENT_PORTAL_DOCUMENT_DOWNLOADED"
+      : "CLIENT_PORTAL_DOCUMENT_INTEGRITY_FAILURE",
+    entityType: "client_portal_publication",
+    entityId: input.publicationId,
+    clientId: input.identity.clientId,
+    meta: input.meta,
+  });
+}

--- a/src/module/client-portal/routes/client-portal-admin.routes.ts
+++ b/src/module/client-portal/routes/client-portal-admin.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from "express";
+
+import { requireSuperadmin } from "../../access-control/middlewares/require-superadmin";
+import * as controller from "../controllers/client-portal.controller";
+
+const router = Router();
+
+router.use(requireSuperadmin);
+router.get("/accounts", controller.listAdminAccounts);
+router.post("/accounts", controller.createAdminAccount);
+router.post("/accounts/:accountId/invitations", controller.createAdminInvitation);
+router.patch("/accounts/:accountId/status", controller.patchAdminAccountStatus);
+router.get("/publications", controller.listAdminPublications);
+router.post("/publications", controller.createAdminPublication);
+router.post("/publications/:publicationId/revoke", controller.revokeAdminPublication);
+
+export default router;
+

--- a/src/module/client-portal/routes/client-portal.routes.ts
+++ b/src/module/client-portal/routes/client-portal.routes.ts
@@ -1,0 +1,24 @@
+import { Router } from "express";
+
+import * as controller from "../controllers/client-portal.controller";
+import { authenticateClientPortal } from "../middlewares/client-portal-auth.middleware";
+
+const router = Router();
+
+router.post("/auth/login", controller.login);
+router.post("/auth/activate", controller.activate);
+router.post("/auth/forgot-password", controller.forgotPassword);
+router.post("/auth/reset-password", controller.resetPassword);
+
+router.use(authenticateClientPortal);
+
+router.get("/me", controller.me);
+router.get("/orders", controller.listOrders);
+router.get("/deliveries", controller.listDeliveries);
+router.get("/invoices", controller.listInvoices);
+router.get("/documents", controller.listDocuments);
+router.get("/documents/:publicationId/download", controller.downloadDocument);
+router.post("/documents/:publicationId/acknowledgements", controller.acknowledgeDocument);
+
+export default router;
+

--- a/src/module/client-portal/services/client-portal-email.service.ts
+++ b/src/module/client-portal/services/client-portal-email.service.ts
@@ -1,0 +1,80 @@
+type EmailDelivery =
+  | { status: "SENT"; provider_id: string | null }
+  | { status: "NOT_CONFIGURED"; provider_id: null }
+  | { status: "FAILED"; provider_id: null };
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function portalBaseUrl(): string {
+  return (process.env.CLIENT_PORTAL_PUBLIC_URL ?? "https://cerp.croix-rousse-precision.fr")
+    .trim()
+    .replace(/\/+$/, "");
+}
+
+export function buildPortalUrl(path: string): string {
+  return `${portalBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+export async function sendPortalAccessEmail(input: {
+  to: string;
+  displayName: string;
+  path: string;
+  kind: "INVITATION" | "PASSWORD_RESET";
+  expiresMinutes: number;
+  idempotencyKey: string;
+}): Promise<EmailDelivery> {
+  const apiKey = (process.env.RESEND_API_KEY ?? "").trim();
+  const from = (process.env.RESEND_FROM ?? "").trim();
+  if (!apiKey || !from) return { status: "NOT_CONFIGURED", provider_id: null };
+
+  const url = buildPortalUrl(input.path);
+  const action = input.kind === "INVITATION" ? "Activer mon accès client" : "Réinitialiser mon mot de passe";
+  const subject = input.kind === "INVITATION"
+    ? "Votre accès au portail client CERP"
+    : "Réinitialisation de votre accès au portail client CERP";
+  const safeName = escapeHtml(input.displayName);
+  const safeUrl = escapeHtml(url);
+  const text =
+    `Bonjour ${input.displayName},\n\n${action} : ${url}\n\n` +
+    `Ce lien est à usage unique et expire dans ${input.expiresMinutes} minutes.\n` +
+    "Si vous n'êtes pas à l'origine de cette demande, ignorez ce message.";
+  const html = `<div style="font-family:Arial,sans-serif;color:#111827;max-width:560px;margin:auto">` +
+    `<h1 style="font-size:20px">Portail client CERP</h1>` +
+    `<p>Bonjour ${safeName},</p>` +
+    `<p>${escapeHtml(action)}. Ce lien à usage unique expire dans ${input.expiresMinutes} minutes.</p>` +
+    `<p><a href="${safeUrl}" style="display:inline-block;background:#111827;color:#fff;padding:10px 14px;text-decoration:none;border-radius:6px">${escapeHtml(action)}</a></p>` +
+    `<p style="font-size:12px;color:#6b7280;word-break:break-all">${safeUrl}</p>` +
+    `<p style="font-size:12px;color:#6b7280">Ignorez ce message si vous n'êtes pas à l'origine de la demande.</p>` +
+    `</div>`;
+
+  try {
+    const response = await fetch(
+      `${(process.env.RESEND_API_BASE_URL ?? "https://api.resend.com").replace(/\/+$/, "")}/emails`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          "Idempotency-Key": input.idempotencyKey.slice(0, 256),
+        },
+        body: JSON.stringify({ from, to: [input.to], subject, text, html }),
+      }
+    );
+    if (!response.ok) return { status: "FAILED", provider_id: null };
+    const payload = await response.json().catch(() => null) as { id?: unknown } | null;
+    return {
+      status: "SENT",
+      provider_id: typeof payload?.id === "string" ? payload.id : null,
+    };
+  } catch {
+    return { status: "FAILED", provider_id: null };
+  }
+}
+

--- a/src/module/client-portal/services/client-portal.service.test.ts
+++ b/src/module/client-portal/services/client-portal.service.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import type { PortalDocumentRow } from "../repository/client-portal.repository";
+import { portalDocumentState } from "./client-portal.service";
+
+function documentRow(overrides: Partial<PortalDocumentRow> = {}): PortalDocumentRow {
+  return {
+    id: "d5ec6d7e-f2f9-42aa-b766-bf98147f42b3",
+    client_id: "042",
+    version_id: "2f587271-10c4-40d6-a693-7b3650636661",
+    document_id: "81792fe1-4dc4-4cc3-bb3d-6ec44530e374",
+    code: "GED-0001",
+    title: "Certificat matière",
+    version_number: 2,
+    version_status: "APPLICABLE",
+    current_version_id: "2f587271-10c4-40d6-a693-7b3650636661",
+    document_archived_at: null,
+    original_name: "certificat.pdf",
+    mime_type: "application/pdf",
+    size_bytes: 1024,
+    sha256: "a".repeat(64),
+    scan_status: "clean",
+    quarantine_status: "released",
+    scanned_at: "2026-08-14T10:00:00.000Z",
+    expires_at: null,
+    revoked_at: null,
+    acknowledgement_required: true,
+    acknowledged_at: null,
+    published_at: "2026-08-14T11:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("client portal document truthfulness", () => {
+  const now = new Date("2026-08-14T12:00:00.000Z").getTime();
+
+  it.each([
+    [{}, "AVAILABLE"],
+    [{ scan_status: "pending", quarantine_status: "pending" }, "PENDING_SCAN"],
+    [{ scan_status: "infected", quarantine_status: "quarantined" }, "QUARANTINED"],
+    [{ expires_at: "2026-08-14T11:59:59.000Z" }, "EXPIRED"],
+    [{ current_version_id: "26e324db-08df-41d2-b0f5-b8a47dfa4b43" }, "REPLACED"],
+    [{ version_status: "OBSOLETE" }, "REPLACED"],
+    [{ scan_status: "scan_failed" }, "UNAVAILABLE"],
+    [{ scan_status: null, quarantine_status: null }, "UNAVAILABLE"],
+    [{ revoked_at: "2026-08-14T11:00:00.000Z" }, "REVOKED"],
+  ] as const)("maps %j to %s without fabricating availability", (overrides, expected) => {
+    expect(portalDocumentState(documentRow(overrides), now)).toBe(expected);
+  });
+});
+

--- a/src/module/client-portal/services/client-portal.service.ts
+++ b/src/module/client-portal/services/client-portal.service.ts
@@ -1,0 +1,404 @@
+import bcrypt from "bcryptjs";
+import crypto from "node:crypto";
+
+import { resolveBlobForDownload } from "../../ged/services/ged-vault.service";
+import { HttpError } from "../../../utils/httpError";
+import {
+  hashPortalOpaqueValue,
+  hashPortalRateLimitValue,
+  normalizePortalEmail,
+  signPortalInvitationToken,
+  signPortalResetToken,
+  signPortalSession,
+  stablePortalRequestHash,
+  verifyPortalInvitationToken,
+  verifyPortalResetToken,
+} from "../domain/client-portal-security";
+import * as repo from "../repository/client-portal.repository";
+import type {
+  ClientPortalDocumentState,
+  ClientPortalIdentity,
+  ClientPortalRequestMeta,
+} from "../types/client-portal.types";
+import type {
+  AdminCreatePortalAccountInput,
+  AdminCreatePortalPublicationInput,
+  PortalActivateInput,
+  PortalLoginInput,
+  PortalPagination,
+} from "../validators/client-portal.validators";
+import { sendPortalAccessEmail } from "./client-portal-email.service";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+function hashIp(ip: string | null): string | null {
+  return ip ? hashPortalRateLimitValue(`ip:${ip}`) : null;
+}
+
+export function buildPortalRequestMeta(input: {
+  requestId: string | null;
+  ip: string | null;
+  browser: string | null;
+}): ClientPortalRequestMeta {
+  return {
+    requestId: input.requestId,
+    ipHash: hashIp(input.ip),
+    userAgentFamily: input.browser?.trim().slice(0, 80) || null,
+  };
+}
+
+async function consumeAttempt(
+  action: "LOGIN" | "ACTIVATE" | "FORGOT_PASSWORD" | "RESET_PASSWORD",
+  identifier: string,
+  meta: ClientPortalRequestMeta,
+  limits: { identifier: number; ip: number; windowSeconds: number }
+): Promise<string> {
+  return repo.repoConsumePortalAuthAttempt({
+    action,
+    identifierHash: hashPortalRateLimitValue(`${action}:${identifier}`),
+    ipHash: meta.ipHash,
+    identifierLimit: limits.identifier,
+    ipLimit: limits.ip,
+    windowSeconds: limits.windowSeconds,
+  });
+}
+
+export async function createPortalAccountByAdmin(input: {
+  actorId: number;
+  idempotencyKey: string;
+  body: AdminCreatePortalAccountInput;
+  meta: ClientPortalRequestMeta;
+}) {
+  const emailNormalized = normalizePortalEmail(input.body.email);
+  const passwordHash = await bcrypt.hash(crypto.randomBytes(48).toString("base64url"), 12);
+  const requestHash = stablePortalRequestHash({
+    actor_id: input.actorId,
+    client_id: input.body.client_id,
+    email_normalized: emailNormalized,
+    display_name: input.body.display_name,
+  });
+  return repo.repoCreatePortalAccount({
+    actorId: input.actorId,
+    idempotencyKey: input.idempotencyKey,
+    requestHash,
+    clientId: input.body.client_id,
+    email: input.body.email.trim(),
+    emailNormalized,
+    displayName: input.body.display_name.trim(),
+    passwordHash,
+    meta: input.meta,
+  });
+}
+
+export async function createPortalInvitationByAdmin(input: {
+  actorId: number;
+  accountId: string;
+  idempotencyKey: string;
+  meta: ClientPortalRequestMeta;
+}) {
+  const tokenId = crypto.randomUUID();
+  const createdAt = new Date();
+  const expiresAt = new Date(createdAt.getTime() + 24 * ONE_HOUR_MS);
+  const tokenCandidate = signPortalInvitationToken({
+    tokenId,
+    accountId: input.accountId,
+    createdAt: createdAt.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+  });
+  const result = await repo.repoCreatePortalInvitation({
+    actorId: input.actorId,
+    accountId: input.accountId,
+    tokenId,
+    tokenHash: hashPortalOpaqueValue(tokenCandidate),
+    createdAt: createdAt.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+    idempotencyKey: input.idempotencyKey,
+    requestHash: stablePortalRequestHash({ actor_id: input.actorId, account_id: input.accountId }),
+    meta: input.meta,
+  });
+  const tokenRow = result.token;
+  const replayToken = signPortalInvitationToken({
+    tokenId: String(tokenRow.token_id),
+    accountId: String(tokenRow.account_id),
+    createdAt: String(tokenRow.created_at),
+    expiresAt: String(tokenRow.expires_at),
+  });
+  if (hashPortalOpaqueValue(replayToken) !== hashPortalOpaqueValue(tokenCandidate) && !result.replayed) {
+    throw new HttpError(409, "CLIENT_PORTAL_INVITATION_REPLAY", "Le lien d'invitation ne peut pas être reproduit.");
+  }
+  const path = `/portal/activate?token=${encodeURIComponent(replayToken)}`;
+  const delivery = await sendPortalAccessEmail({
+    to: String(tokenRow.email),
+    displayName: String(tokenRow.display_name),
+    path,
+    kind: "INVITATION",
+    expiresMinutes: 24 * 60,
+    idempotencyKey: input.idempotencyKey,
+  });
+  return {
+    invitation: {
+      account_id: String(tokenRow.account_id),
+      expires_at: String(tokenRow.expires_at),
+      activation_path: path,
+      token: replayToken,
+      delivery,
+    },
+    replayed: result.replayed,
+  };
+}
+
+export async function activatePortalAccount(body: PortalActivateInput, meta: ClientPortalRequestMeta) {
+  const claims = verifyPortalInvitationToken(body.token);
+  const attemptId = await consumeAttempt("ACTIVATE", claims.tokenId, meta, {
+    identifier: 8,
+    ip: 30,
+    windowSeconds: 60 * 60,
+  });
+  const passwordHash = await bcrypt.hash(body.password, 12);
+  const result = await repo.repoActivatePortalAccount({
+    tokenId: claims.tokenId,
+    accountId: claims.accountId,
+    tokenHash: hashPortalOpaqueValue(body.token),
+    passwordHash,
+    meta,
+  });
+  await repo.repoMarkPortalAuthAttemptSuccess(attemptId);
+  return result;
+}
+
+export async function loginPortal(body: PortalLoginInput, meta: ClientPortalRequestMeta) {
+  const emailNormalized = normalizePortalEmail(body.email);
+  const attemptId = await consumeAttempt("LOGIN", emailNormalized, meta, {
+    identifier: 5,
+    ip: 30,
+    windowSeconds: 15 * 60,
+  });
+  const account = await repo.repoFindPortalAccountByEmail(emailNormalized);
+  const hash = account?.password_hash ?? await bcrypt.hash("client-portal-nonexistent-account", 12);
+  const validPassword = await bcrypt.compare(body.password, hash);
+  if (!account || !validPassword || account.status !== "ACTIVE") {
+    throw new HttpError(401, "CLIENT_PORTAL_LOGIN_INVALID", "Email ou mot de passe incorrect.");
+  }
+  await repo.repoMarkPortalAuthAttemptSuccess(attemptId);
+  await repo.repoRecordPortalLogin(account, meta);
+  const identity: ClientPortalIdentity = {
+    accountId: account.id,
+    clientId: account.client_id,
+    sessionEpoch: account.session_epoch,
+  };
+  return {
+    token: signPortalSession(identity),
+    expires_in_seconds: 15 * 60,
+    account: {
+      id: account.id,
+      display_name: account.display_name,
+      client_id: account.client_id,
+      company_name: account.company_name,
+    },
+  };
+}
+
+export async function requestPortalPasswordReset(email: string, meta: ClientPortalRequestMeta) {
+  const emailNormalized = normalizePortalEmail(email);
+  const attemptId = await consumeAttempt("FORGOT_PASSWORD", emailNormalized, meta, {
+    identifier: 4,
+    ip: 20,
+    windowSeconds: 60 * 60,
+  });
+  const account = await repo.repoFindPortalAccountByEmail(emailNormalized);
+  if (account && account.status === "ACTIVE") {
+    const tokenId = crypto.randomUUID();
+    const createdAt = new Date();
+    const expiresAt = new Date(createdAt.getTime() + ONE_HOUR_MS);
+    const token = signPortalResetToken({
+      tokenId,
+      accountId: account.id,
+      createdAt: createdAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+    });
+    await repo.repoCreatePortalResetToken({
+      accountId: account.id,
+      tokenId,
+      tokenHash: hashPortalOpaqueValue(token),
+      createdAt: createdAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+      meta,
+    });
+    await sendPortalAccessEmail({
+      to: account.email,
+      displayName: account.display_name,
+      path: `/portal/reset-password?token=${encodeURIComponent(token)}`,
+      kind: "PASSWORD_RESET",
+      expiresMinutes: 60,
+      idempotencyKey: tokenId,
+    });
+  }
+  await repo.repoMarkPortalAuthAttemptSuccess(attemptId);
+  return { accepted: true };
+}
+
+export async function resetPortalPassword(body: PortalActivateInput, meta: ClientPortalRequestMeta) {
+  const claims = verifyPortalResetToken(body.token);
+  const attemptId = await consumeAttempt("RESET_PASSWORD", claims.tokenId, meta, {
+    identifier: 8,
+    ip: 30,
+    windowSeconds: 60 * 60,
+  });
+  const passwordHash = await bcrypt.hash(body.password, 12);
+  const result = await repo.repoResetPortalPassword({
+    tokenId: claims.tokenId,
+    accountId: claims.accountId,
+    tokenHash: hashPortalOpaqueValue(body.token),
+    passwordHash,
+    meta,
+  });
+  await repo.repoMarkPortalAuthAttemptSuccess(attemptId);
+  return result;
+}
+
+export async function setPortalAccountStatusByAdmin(input: {
+  actorId: number;
+  accountId: string;
+  status: "ACTIVE" | "SUSPENDED" | "REVOKED";
+  reason: string;
+  meta: ClientPortalRequestMeta;
+}) {
+  return repo.repoSetPortalAccountStatus(input);
+}
+
+export function portalDocumentState(row: repo.PortalDocumentRow, now = Date.now()): ClientPortalDocumentState {
+  if (row.revoked_at) return "REVOKED";
+  if (row.expires_at && new Date(row.expires_at).getTime() <= now) return "EXPIRED";
+  if (row.document_archived_at) return "UNAVAILABLE";
+  if (row.current_version_id !== row.version_id || row.version_status !== "APPLICABLE") return "REPLACED";
+  if (row.scan_status === "infected" || row.quarantine_status === "quarantined") return "QUARANTINED";
+  if (row.scan_status === "pending" || row.quarantine_status === "pending") return "PENDING_SCAN";
+  if (row.scan_status === "clean" && row.quarantine_status === "released") return "AVAILABLE";
+  return "UNAVAILABLE";
+}
+
+function sourceMeta(freshnessAt: string | null) {
+  return {
+    source: "CERP PostgreSQL — projection portail dédiée",
+    freshness_at: freshnessAt,
+    reliability: "SYSTEM_OF_RECORD" as const,
+  };
+}
+
+export async function getPortalProfile(identity: ClientPortalIdentity) {
+  const profile = await repo.repoGetPortalProfile(identity);
+  if (!profile) throw new HttpError(404, "CLIENT_PORTAL_ACCOUNT_NOT_FOUND", "Compte portail introuvable.");
+  return { data: profile, meta: sourceMeta(new Date().toISOString()) };
+}
+
+async function listPortalProjection(
+  identity: ClientPortalIdentity,
+  pagination: PortalPagination,
+  loader: (identity: ClientPortalIdentity, page: number, pageSize: number) => Promise<{ items: unknown[]; total: number }>
+) {
+  const result = await loader(identity, pagination.page, pagination.pageSize);
+  const freshness = result.items.reduce<string | null>((latest, item) => {
+    if (typeof item !== "object" || item === null || !("updated_at" in item)) return latest;
+    const value = (item as { updated_at?: unknown }).updated_at;
+    if (typeof value !== "string") return latest;
+    return latest === null || value > latest ? value : latest;
+  }, null);
+  return {
+    data: result.items,
+    pagination: { ...pagination, total: result.total },
+    meta: sourceMeta(freshness),
+  };
+}
+
+export const listPortalOrders = (identity: ClientPortalIdentity, pagination: PortalPagination) =>
+  listPortalProjection(identity, pagination, repo.repoListPortalOrders);
+
+export const listPortalDeliveries = (identity: ClientPortalIdentity, pagination: PortalPagination) =>
+  listPortalProjection(identity, pagination, repo.repoListPortalDeliveries);
+
+export const listPortalInvoices = (identity: ClientPortalIdentity, pagination: PortalPagination) =>
+  listPortalProjection(identity, pagination, repo.repoListPortalInvoices);
+
+export async function listPortalDocuments(identity: ClientPortalIdentity) {
+  const rows = await repo.repoListPortalDocuments(identity);
+  return {
+    data: rows.map((row) => ({
+      id: row.id,
+      code: row.code,
+      title: row.title,
+      version_number: row.version_number,
+      original_name: row.original_name,
+      mime_type: row.mime_type,
+      size_bytes: row.size_bytes,
+      sha256: row.sha256,
+      state: portalDocumentState(row),
+      acknowledgement_required: row.acknowledgement_required,
+      acknowledged_at: row.acknowledged_at,
+      expires_at: row.expires_at,
+      published_at: row.published_at,
+      antivirus: {
+        status: row.scan_status ?? "untracked",
+        quarantine_status: row.quarantine_status ?? "untracked",
+        freshness_at: row.scanned_at,
+        reliability: row.scan_status ? "MEASURED" : "UNAVAILABLE",
+      },
+    })),
+    meta: sourceMeta(rows.reduce<string | null>((latest, row) => latest === null || row.published_at > latest ? row.published_at : latest, null)),
+  };
+}
+
+export async function getPortalDocumentDownload(identity: ClientPortalIdentity, publicationId: string) {
+  const row = await repo.repoGetPortalDocumentDownload(identity, publicationId);
+  if (!row) throw new HttpError(404, "CLIENT_PORTAL_DOCUMENT_NOT_FOUND", "Document introuvable.");
+  const state = portalDocumentState(row);
+  if (state !== "AVAILABLE") {
+    throw new HttpError(409, `CLIENT_PORTAL_DOCUMENT_${state}`, "Ce document n'est pas disponible au téléchargement.");
+  }
+  if (!row.storage_key) throw new HttpError(503, "CLIENT_PORTAL_DOCUMENT_STORAGE", "Stockage documentaire indisponible.");
+  const resolved = await resolveBlobForDownload(row.storage_key);
+  return {
+    file_path: resolved.file_path,
+    allowed_root: resolved.allowed_root,
+    filename: row.original_name,
+    mime_type: row.mime_type,
+    sha256: row.sha256,
+    size_bytes: row.size_bytes,
+  };
+}
+
+export async function acknowledgePortalDocument(
+  identity: ClientPortalIdentity,
+  publicationId: string,
+  meta: ClientPortalRequestMeta
+) {
+  const row = await repo.repoGetPortalDocumentDownload(identity, publicationId);
+  if (!row) throw new HttpError(404, "CLIENT_PORTAL_DOCUMENT_NOT_FOUND", "Document introuvable.");
+  return repo.repoAcknowledgePortalDocument({
+    identity,
+    publicationId,
+    state: portalDocumentState(row),
+    meta,
+  });
+}
+
+export async function createPortalPublicationByAdmin(input: {
+  actorId: number;
+  idempotencyKey: string;
+  body: AdminCreatePortalPublicationInput;
+  meta: ClientPortalRequestMeta;
+}) {
+  return repo.repoCreatePortalPublication({
+    actorId: input.actorId,
+    idempotencyKey: input.idempotencyKey,
+    requestHash: stablePortalRequestHash({ actor_id: input.actorId, ...input.body }),
+    clientId: input.body.client_id,
+    versionId: input.body.version_id,
+    title: input.body.title ?? null,
+    expiresAt: input.body.expires_at ?? null,
+    acknowledgementRequired: input.body.acknowledgement_required,
+    meta: input.meta,
+  });
+}
+
+export { repo };
+

--- a/src/module/client-portal/types/client-portal.types.ts
+++ b/src/module/client-portal/types/client-portal.types.ts
@@ -1,0 +1,43 @@
+export const CLIENT_PORTAL_ACCOUNT_STATUSES = [
+  "INVITED",
+  "ACTIVE",
+  "SUSPENDED",
+  "REVOKED",
+] as const;
+
+export type ClientPortalAccountStatus = (typeof CLIENT_PORTAL_ACCOUNT_STATUSES)[number];
+
+export type ClientPortalIdentity = Readonly<{
+  accountId: string;
+  clientId: string;
+  sessionEpoch: number;
+}>;
+
+export type ClientPortalDocumentState =
+  | "AVAILABLE"
+  | "PENDING_SCAN"
+  | "QUARANTINED"
+  | "EXPIRED"
+  | "REPLACED"
+  | "UNAVAILABLE"
+  | "REVOKED";
+
+export type ClientPortalAuditActor =
+  | Readonly<{ kind: "ERP_USER"; id: number }>
+  | Readonly<{ kind: "PORTAL_ACCOUNT"; id: string }>
+  | Readonly<{ kind: "SYSTEM" }>;
+
+export type ClientPortalRequestMeta = Readonly<{
+  requestId: string | null;
+  ipHash: string | null;
+  userAgentFamily: string | null;
+}>;
+
+declare global {
+  namespace Express {
+    interface Request {
+      portalIdentity?: ClientPortalIdentity;
+    }
+  }
+}
+

--- a/src/module/client-portal/validators/client-portal.validators.ts
+++ b/src/module/client-portal/validators/client-portal.validators.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+const uuid = z.string().uuid();
+const email = z.string().trim().email().max(254);
+const password = z.string().min(12).max(128)
+  .regex(/[A-Z]/, "Une majuscule est requise.")
+  .regex(/[a-z]/, "Une minuscule est requise.")
+  .regex(/[0-9]/, "Un chiffre est requis.")
+  .regex(/[^A-Za-z0-9]/, "Un symbole est requis.");
+
+export const portalLoginSchema = z.object({
+  email,
+  password: z.string().min(1).max(128),
+}).strict();
+
+export const portalForgotPasswordSchema = z.object({ email }).strict();
+
+export const portalActivateSchema = z.object({
+  token: z.string().trim().min(32).max(4096),
+  password,
+}).strict();
+
+export const portalResetPasswordSchema = portalActivateSchema;
+
+export const portalPaginationSchema = z.object({
+  page: z.coerce.number().int().min(1).max(10_000).default(1),
+  pageSize: z.coerce.number().int().min(1).max(50).default(20),
+}).strict();
+
+export const portalUuidParamSchema = uuid;
+
+export const adminCreatePortalAccountSchema = z.object({
+  client_id: z.string().trim().min(1).max(3),
+  email,
+  display_name: z.string().trim().min(2).max(120),
+}).strict();
+
+export const adminPortalAccountStatusSchema = z.object({
+  status: z.enum(["ACTIVE", "SUSPENDED", "REVOKED"]),
+  reason: z.string().trim().min(3).max(500),
+}).strict();
+
+export const adminCreatePortalPublicationSchema = z.object({
+  client_id: z.string().trim().min(1).max(3),
+  version_id: uuid,
+  title: z.string().trim().min(2).max(180).optional().nullable(),
+  expires_at: z.string().datetime({ offset: true }).optional().nullable(),
+  acknowledgement_required: z.boolean().default(false),
+}).strict();
+
+export const adminRevokePortalPublicationSchema = z.object({
+  reason: z.string().trim().min(3).max(500),
+}).strict();
+
+export const idempotencyKeySchema = z.string().uuid();
+
+export type PortalLoginInput = z.infer<typeof portalLoginSchema>;
+export type PortalActivateInput = z.infer<typeof portalActivateSchema>;
+export type PortalPagination = z.infer<typeof portalPaginationSchema>;
+export type AdminCreatePortalAccountInput = z.infer<typeof adminCreatePortalAccountSchema>;
+export type AdminPortalAccountStatusInput = z.infer<typeof adminPortalAccountStatusSchema>;
+export type AdminCreatePortalPublicationInput = z.infer<typeof adminCreatePortalPublicationSchema>;
+

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -49,6 +49,8 @@ import electronicInvoiceWebhookRoutes from "../module/facturation/electronic-inv
 import accountingExportRoutes from "../module/accounting-export/accounting-export.routes";
 import openApiRoutes from "../swagger/openapi.routes";
 import webhookAdminRoutes from "../module/integrations/webhooks/webhook.routes";
+import clientPortalRoutes from "../module/client-portal/routes/client-portal.routes";
+import clientPortalAdminRoutes from "../module/client-portal/routes/client-portal-admin.routes";
 
 import traceabilityRoutes from "../module/traceability/routes/traceability.routes"
 import traceability360Routes from "../module/traceability/routes/traceability-360.routes"
@@ -73,6 +75,7 @@ router.use((_req, _res, next) => runWithAccountModuleAccessScope(next))
 
 // --- Routes publiques (avant authentification) ---
 router.use("/auth", authRoutes)
+router.use("/portal", clientPortalRoutes)
 router.use("/electronic-invoicing/webhooks", electronicInvoiceWebhookRoutes)
 router.use(openApiRoutes)
 
@@ -115,6 +118,7 @@ router.use("/audit-logs", auditLogsRoutes)
 // est gardée par le statut superadmin et ne doit pas hériter de son authorizeRole.
 router.use("/admin/access", accessControlRoutes);
 router.use("/admin/webhooks", webhookAdminRoutes);
+router.use("/admin/client-portal", clientPortalAdminRoutes);
 router.use("/admin", adminRoutes);
 router.use("/affaires", affaireRoutes);
 router.use("/devis", devisRoutes);

--- a/src/shared/uploads/secure-download.ts
+++ b/src/shared/uploads/secure-download.ts
@@ -182,7 +182,6 @@ export async function sendSecureStoredFile(
   }
 ): Promise<SecureStoredFileSendOutcome> {
   let opened: SecureOpenedFile | null = null;
-  let verifier: ReturnType<typeof createReadStream> | null = null;
   let stream: ReturnType<typeof createReadStream> | null = null;
   let responseClosed = res.destroyed;
   let settleStreaming: ((outcome: SecureStoredFileSendOutcome) => void) | null = null;
@@ -198,7 +197,6 @@ export async function sendSecureStoredFile(
 
   const onResponseClose = () => {
     responseClosed = true;
-    verifier?.destroy();
     stream?.destroy();
     settleStreaming?.("aborted");
     void closeHandleOnce();
@@ -215,33 +213,25 @@ export async function sendSecureStoredFile(
     if (options.expectedSha256) {
       const hash = createHash("sha256");
       if (opened.size > 0) {
-        verifier = createReadStream(opened.realPath, {
-          fd: opened.handle.fd,
-          autoClose: false,
-          start: 0,
-          end: opened.size - 1,
-        });
+        const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, opened.size));
+        let offset = 0;
         let integrityHookCalled = false;
-        try {
-          for await (const chunk of verifier) {
-            if (responseClosed || res.destroyed) return "aborted";
-            hash.update(chunk as Buffer);
-            if (!integrityHookCalled && secureDownloadHook) {
-              integrityHookCalled = true;
-              await secureDownloadHook("during-integrity", {
-                candidatePath: path.resolve(options.filePath),
-                realPath: opened.realPath,
-                response: res,
-              });
-              if (responseClosed || res.destroyed) return "aborted";
-            }
-          }
-        } catch (error) {
+        while (offset < opened.size) {
           if (responseClosed || res.destroyed) return "aborted";
-          throw error;
-        } finally {
-          verifier.destroy();
-          verifier = null;
+          const requested = Math.min(buffer.length, opened.size - offset);
+          const { bytesRead } = await opened.handle.read(buffer, 0, requested, offset);
+          if (bytesRead === 0) break;
+          hash.update(buffer.subarray(0, bytesRead));
+          offset += bytesRead;
+          if (!integrityHookCalled && secureDownloadHook) {
+            integrityHookCalled = true;
+            await secureDownloadHook("during-integrity", {
+              candidatePath: path.resolve(options.filePath),
+              realPath: opened.realPath,
+              response: res,
+            });
+            if (responseClosed || res.destroyed) return "aborted";
+          }
         }
       }
       if (responseClosed || res.destroyed) return "aborted";
@@ -320,7 +310,6 @@ export async function sendSecureStoredFile(
     });
   } finally {
     res.off("close", onResponseClose);
-    verifier?.destroy();
     stream?.destroy();
     await closeHandleOnce();
   }

--- a/src/swagger/generated-route-inventory.ts
+++ b/src/swagger/generated-route-inventory.ts
@@ -8,7 +8,7 @@ export type GeneratedRouteContract = {
   rbac: readonly string[];
 };
 
-export const GENERATED_ROUTE_SOURCE_SHA256 = "d82d666b7244413a8c33839fd7bd8817f881d4c56ffcdb3c6529b76ca4dd21fb";
+export const GENERATED_ROUTE_SOURCE_SHA256 = "13ed1f48241a77e539c2f6161df31213617115e8493e1401edd68683a12357b9";
 export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
@@ -389,6 +389,125 @@ export const GENERATED_ROUTE_INVENTORY = [
       "authenticateToken",
       "requireSuperadmin",
       "getAdminAnalytics"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/admin/client-portal/accounts",
+    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:9",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "controller.listAdminAccounts"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/admin/client-portal/accounts",
+    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:10",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "controller.createAdminAccount"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/admin/client-portal/accounts/{accountId}/invitations",
+    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:11",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "controller.createAdminInvitation"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin"
+    ]
+  },
+  {
+    "method": "patch",
+    "path": "/admin/client-portal/accounts/{accountId}/status",
+    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:12",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "controller.patchAdminAccountStatus"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/admin/client-portal/publications",
+    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:13",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "controller.listAdminPublications"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/admin/client-portal/publications",
+    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:14",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "controller.createAdminPublication"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/admin/client-portal/publications/{publicationId}/revoke",
+    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:15",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "controller.revokeAdminPublication"
     ],
     "authenticated": true,
     "rbac": [
@@ -9360,6 +9479,134 @@ export const GENERATED_ROUTE_INVENTORY = [
       "requireProductionOrAdmin",
       "requirePlanningCapability(manage_schedule)"
     ]
+  },
+  {
+    "method": "post",
+    "path": "/portal/auth/activate",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:9",
+    "middleware": [
+      "anonymous",
+      "controller.activate"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "post",
+    "path": "/portal/auth/forgot-password",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:10",
+    "middleware": [
+      "anonymous",
+      "controller.forgotPassword"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "post",
+    "path": "/portal/auth/login",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:8",
+    "middleware": [
+      "anonymous",
+      "controller.login"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "post",
+    "path": "/portal/auth/reset-password",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:11",
+    "middleware": [
+      "anonymous",
+      "controller.resetPassword"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "get",
+    "path": "/portal/deliveries",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:17",
+    "middleware": [
+      "anonymous",
+      "authenticateClientPortal",
+      "controller.listDeliveries"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "get",
+    "path": "/portal/documents",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:19",
+    "middleware": [
+      "anonymous",
+      "authenticateClientPortal",
+      "controller.listDocuments"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "post",
+    "path": "/portal/documents/{publicationId}/acknowledgements",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:21",
+    "middleware": [
+      "anonymous",
+      "authenticateClientPortal",
+      "controller.acknowledgeDocument"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "get",
+    "path": "/portal/documents/{publicationId}/download",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:20",
+    "middleware": [
+      "anonymous",
+      "authenticateClientPortal",
+      "controller.downloadDocument"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "get",
+    "path": "/portal/invoices",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:18",
+    "middleware": [
+      "anonymous",
+      "authenticateClientPortal",
+      "controller.listInvoices"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "get",
+    "path": "/portal/me",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:15",
+    "middleware": [
+      "anonymous",
+      "authenticateClientPortal",
+      "controller.me"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "get",
+    "path": "/portal/orders",
+    "source": "src/module/client-portal/routes/client-portal.routes.ts:16",
+    "middleware": [
+      "anonymous",
+      "authenticateClientPortal",
+      "controller.listOrders"
+    ],
+    "authenticated": false,
+    "rbac": []
   },
   {
     "method": "put",

--- a/src/swagger/openapi-contract.ts
+++ b/src/swagger/openapi-contract.ts
@@ -19,7 +19,21 @@ const PUBLIC_ROUTE_POLICIES: Readonly<Record<string, string>> = {
   "get /environment": "Signal public minimal de routage de base, sans secret ni donnée métier.",
   "get /openapi.json": "Contrat public de la version API déployée.",
   "get /realtime/readiness": "Signal public booléen de disponibilité temps réel, sans détail d’infrastructure.",
+  "post /portal/auth/activate": "Activation par jeton portail à usage unique avec limitation de débit persistée.",
+  "post /portal/auth/forgot-password": "Demande de récupération portail non révélatrice avec limitation de débit persistée.",
+  "post /portal/auth/login": "Échange d’identifiants portail contre une session courte avec limitation de débit persistée.",
+  "post /portal/auth/reset-password": "Réinitialisation portail par jeton à usage unique avec limitation de débit persistée.",
 };
+
+const CLIENT_PORTAL_AUTH_OPERATIONS = new Set([
+  "get /portal/deliveries",
+  "get /portal/documents",
+  "post /portal/documents/{publicationId}/acknowledgements",
+  "get /portal/documents/{publicationId}/download",
+  "get /portal/invoices",
+  "get /portal/me",
+  "get /portal/orders",
+]);
 
 const IDEMPOTENT_OPERATIONS = new Set([
   "post /admin/webhooks/subscriptions",
@@ -57,7 +71,7 @@ function pathParameters(route: GeneratedRouteContract): OpenApiObject[] {
   }));
 }
 
-function genericResponses(route: GeneratedRouteContract): OpenApiObject {
+function genericResponses(route: GeneratedRouteContract, authenticated = route.authenticated): OpenApiObject {
   const responses: OpenApiObject = {
     "200": {
       description: "Réponse conforme au contrat de l’opération.",
@@ -67,7 +81,7 @@ function genericResponses(route: GeneratedRouteContract): OpenApiObject {
     "429": { $ref: "#/components/responses/RateLimited" },
     "500": { $ref: "#/components/responses/InternalError" },
   };
-  if (route.authenticated) {
+  if (authenticated) {
     responses["401"] = { $ref: "#/components/responses/Unauthenticated" };
     responses["403"] = { $ref: "#/components/responses/Forbidden" };
   }
@@ -83,6 +97,7 @@ function generatedOperation(route: GeneratedRouteContract): OpenApiOperation {
   const key = operationKey(route);
   const publicReason = PUBLIC_ROUTE_POLICIES[key];
   const providerSigned = key === "post /electronic-invoicing/webhooks/{providerCode}";
+  const clientPortalAuthenticated = CLIENT_PORTAL_AUTH_OPERATIONS.has(key);
   const idempotent = IDEMPOTENT_OPERATIONS.has(key);
   const parameters = pathParameters(route);
   if (idempotent) parameters.push({ $ref: "#/components/parameters/IdempotencyKey" });
@@ -91,15 +106,29 @@ function generatedOperation(route: GeneratedRouteContract): OpenApiOperation {
     summary: `${route.method.toUpperCase()} ${route.path}`,
     operationId: operationId(route),
     parameters,
-    responses: genericResponses(route),
+    responses: genericResponses(route, route.authenticated || clientPortalAuthenticated),
     security: route.authenticated
       ? [{ bearerAuth: [] }]
+      : clientPortalAuthenticated
+        ? [{ clientPortalBearerAuth: [] }]
       : providerSigned
         ? [{ providerSignature: [] }]
         : [],
     "x-cerp-source": route.source,
-    "x-cerp-authentication": route.authenticated ? "JWT Bearer + compte actif" : providerSigned ? "signature prestataire" : "public contrôlé",
-    "x-cerp-rbac": route.rbac.length > 0 ? [...route.rbac] : route.authenticated ? ["moduleAccessGate"] : [],
+    "x-cerp-authentication": route.authenticated
+      ? "JWT Bearer + compte actif"
+      : clientPortalAuthenticated
+        ? "JWT Bearer portail + compte client actif + session_epoch"
+        : providerSigned
+          ? "signature prestataire"
+          : "public contrôlé",
+    "x-cerp-rbac": route.rbac.length > 0
+      ? [...route.rbac]
+      : route.authenticated
+        ? ["moduleAccessGate"]
+        : clientPortalAuthenticated
+          ? ["clientPortalTenantBoundary"]
+          : [],
     "x-cerp-rate-limit-policy": route.middleware.filter((name) => /RateLimit/i.test(name)),
     "x-cerp-idempotency": idempotent ? "required" : "not-declared",
     ...(publicReason ? { "x-cerp-public-reason": publicReason } : {}),
@@ -208,6 +237,12 @@ function componentSchemas(legacy: OpenApiObject): OpenApiObject {
     ...legacyComponents,
     securitySchemes: {
       bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+      clientPortalBearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+        description: "Jeton de session court du portail client, audience cerp-client-portal.",
+      },
       providerSignature: {
         type: "apiKey",
         in: "header",
@@ -372,7 +407,9 @@ function componentSchemas(legacy: OpenApiObject): OpenApiObject {
 
 export function assertOpenApiRouteSecurity(): void {
   const undocumentedPublic = GENERATED_ROUTE_INVENTORY
-    .filter((route) => !route.authenticated && !PUBLIC_ROUTE_POLICIES[operationKey(route)])
+    .filter((route) => !route.authenticated
+      && !CLIENT_PORTAL_AUTH_OPERATIONS.has(operationKey(route))
+      && !PUBLIC_ROUTE_POLICIES[operationKey(route)])
     .map((route) => operationKey(route));
   if (undocumentedPublic.length > 0) {
     throw new Error(`OPENAPI_PUBLIC_ROUTE_POLICY_MISSING:${undocumentedPublic.join(",")}`);


### PR DESCRIPTION
Promotes the validated SOL-29 backend from dev to main. Includes isolated client accounts, strict tenant projections, GED publication, audit, idempotence, rate limits and the additive migration with preflight/verify/rollback.

## Summary by Sourcery

Introduce an isolated client portal backend with authenticated client-facing and admin routes, backed by a dedicated database schema, security boundary, and documented migration for SOL-29.

New Features:
- Add public client portal authentication endpoints and authenticated portal routes for profile, orders, deliveries, invoices, and document access.
- Expose admin APIs for managing client portal accounts and document publications, including invitations, status changes, and revocations.
- Define a dedicated client portal JWT security scheme and rate-limited auth flow, separate from ERP users, with tenant-bound RBAC.
- Introduce append-only client portal audit, acknowledgements, and idempotent command receipts to support traceable portal operations.

Enhancements:
- Refine secure file download integrity verification to reuse the same file handle without premature closure and expose document integrity headers via CORS.
- Extend the OpenAPI contract and route inventory with client portal and admin endpoints, including portal-specific security schemes and coverage checks.
- Add SOL-29 database migration, preflight, verify, and rollback scripts establishing isolated portal identities, projections, and evidence immutability.
- Improve startup diagnostics for isolated E2E runs and add an isolated client-portal seeding script and related documentation, ADR, and runbooks.

Tests:
- Add unit and integration tests for client portal security, auth middleware, repository tenant isolation, document state mapping, migration guards, and secure download regression.
- Update OpenAPI contract tests to validate client portal security schemes and RBAC for the new portal routes.