### PR TITLE
fix(migrations): register SOL-29 immutable patch

### DIFF
--- a/docs/execution-reports/SOL-29.md
+++ b/docs/execution-reports/SOL-29.md
@@ -12,6 +12,8 @@ L'ERP ne possédait pas de frontière client dédiée. Réutiliser les comptes i
 
 Pendant l'E2E réel de téléchargement, Node 24 a révélé un second défaut : la lecture d'intégrité via `for await` fermait implicitement le descripteur partagé avant la diffusion HTTP (`EBADF`). Le téléchargement est maintenant vérifié par lectures positionnelles bornées sur le même `FileHandle`, puis diffusé avec ce descripteur encore ouvert.
 
+La première tentative opérateur de migration réelle a également été arrêtée avant écriture : le patch n'était pas inscrit dans le registre immuable accepté par `db:patches --only`. Le correctif enregistre son SHA-256 canonique `d5c203c1c44f61b2b296d8fd08a5a35eb8b65060200119cbf7fe873f215d0f5c` et l'ajoute au test exhaustif du registre.
+
 ## Choix d'architecture et frontière de données
 
 - Les comptes portail sont séparés des utilisateurs ERP. Ils ont leur propre secret JWT, audience `cerp-client-portal`, expiration de 15 minutes, statut et `session_epoch` relus en base à chaque requête.

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -63,6 +63,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "7daeedd829315f64e5bd5752a15047a45c80b0836093d135815305623b61e309",
   "20260814_api_contract_webhooks_sol28.sql":
     "42d9f33de100499836e7c1d58ef49e91daffa4af3861c59536bc2d0ab0f87f1f",
+  "20260814_client_portal_sol29.sql":
+    "d5c203c1c44f61b2b296d8fd08a5a35eb8b65060200119cbf7fe873f215d0f5c",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -104,6 +104,10 @@ const recentSolPatchChecksums = new Map([
     "20260814_api_contract_webhooks_sol28.sql",
     "42d9f33de100499836e7c1d58ef49e91daffa4af3861c59536bc2d0ab0f87f1f",
   ],
+  [
+    "20260814_client_portal_sol29.sql",
+    "d5c203c1c44f61b2b296d8fd08a5a35eb8b65060200119cbf7fe873f215d0f5c",
+  ],
 ]);
 const wave9PatchChecksums = new Map([
   [


### PR DESCRIPTION
Le premier dry-run opérateur a été correctement bloqué avant écriture car SOL-29 manquait au registre --only. Ce correctif enregistre le SHA canonique et ajoute la garde exhaustive. Validation : 21/21 tests du runner et typecheck.

## Summary by Sourcery

Register the SOL-29 client portal migration as an immutable patch and document its inclusion in the db:patches --only registry.

Bug Fixes:
- Add the canonical SHA-256 for the SOL-29 client portal migration to the immutable patch registry used by db:patches --only.

Documentation:
- Update the SOL-29 execution report to record the registry omission and the canonical SHA-256 now enforced by tests.

Tests:
- Extend the db patches runner test to cover the SOL-29 client portal patch checksum in the exhaustive registry validation.