### PR TITLE
feat(ops): add read-only operations console (SOL-31)

### DIFF
--- a/docs/adr/ADR-0077-read-only-operations-console.md
+++ b/docs/adr/ADR-0077-read-only-operations-console.md
@@ -1,0 +1,72 @@
+# ADR-0077 — Frontière de la console d’exploitation en lecture seule
+
+- Statut : accepté
+- Date : 2026-08-15
+- Décisionnaire : Keenan Martin
+- Portée : SOL-31
+
+## Contexte
+
+CERP+ dispose déjà de sondes de readiness, de métriques Prometheus, de
+heartbeats externes, d’alertes et de runbooks. Leur consultation restait
+cependant dispersée entre l’API, Grafana et les fichiers de preuve. Recalculer
+ces états dans le navigateur dupliquerait les seuils, exposerait la topologie et
+risquerait de transmettre des jetons de supervision au frontend.
+
+## Décision
+
+L’API expose `GET /api/v1/admin/operations`, après authentification et contrôle
+du marqueur superadministrateur persistant. La réponse est privée, `no-store`
+et strictement en lecture seule.
+
+L’agrégateur réutilise :
+
+- les sondes `collectReadiness` pour PostgreSQL, GED, antivirus et temps réel ;
+- le manifeste SQL de l’image et `cerp_schema_migrations` pour les patches en
+  attente et les divergences d’empreinte ;
+- des comptages SQL sans contenu métier pour les files de relance, webhook et
+  facturation électronique ;
+- les métriques de processus déjà utilisées par Prometheus pour les jobs ;
+- l’API HTTP Prometheus, si elle est configurée, pour les heartbeats de
+  sauvegarde/migration et les alertes actives.
+
+Chaque signal porte état, source, période, unité, fraîcheur, latence, fiabilité,
+dernier succès/échec, périmètre touché et runbook. Une source absente, périmée
+ou inaccessible reste `unavailable`/`stale` ; elle n’est jamais transformée en
+succès.
+
+## Sécurité
+
+- aucun paramètre utilisateur ne choisit une cible réseau ; l’URL Prometheus
+  vient uniquement de la configuration opérateur ;
+- les URL avec identifiants intégrés et les protocoles non HTTP(S) sont refusés ;
+- le jeton Prometheus reste côté serveur et n’apparaît jamais dans la réponse ;
+- aucun secret, PII, payload webhook, adresse destinataire ou contenu GED n’est
+  lu ou retourné ;
+- la console n’offre aucune mutation, réauthentification ou confirmation car
+  SOL-31 n’expose volontairement aucune action sensible.
+
+Une action de réparation future devra être une commande séparée, idempotente,
+auditée, soumise à réauthentification et confirmation explicite. Elle ne pourra
+pas être ajoutée à ce GET.
+
+## Déploiement
+
+Variables non secrètes :
+
+- `CERP_OPERATIONS_PROMETHEUS_URL` : URL interne de Prometheus ;
+- `CERP_OPERATIONS_DASHBOARD_URL` : lien opérateur Grafana ;
+- `CERP_OPERATIONS_LOGS_URL` : lien opérateur vers les logs corrélés ;
+- `CERP_RELEASE_COMMIT` : SHA exact si distinct de `CERP_RELEASE_VERSION` ;
+- `CERP_PATCHES_DIR` : surcharge exceptionnelle du manifeste livré.
+
+Variable secrète optionnelle : `CERP_OPERATIONS_PROMETHEUS_TOKEN`. Elle reste
+dans le gestionnaire de secrets de la cible. Sans URL Prometheus, les sauvegardes
+et leur historique sont honnêtement signalés comme non mesurés.
+
+## Conséquences et rollback
+
+Aucune migration ni donnée n’est créée. Le rollback consiste à redéployer le
+SHA backend précédent puis le SHA frontend précédent. La suppression de l’URL
+Prometheus ne bloque pas l’API métier : elle dégrade seulement les signaux
+externes de la console. Les healthchecks de déploiement restent indépendants.

--- a/docs/execution-reports/SOL-31.md
+++ b/docs/execution-reports/SOL-31.md
@@ -1,0 +1,86 @@
+# SOL-31 — Console d’exploitation CERP+ — rapport backend
+
+- Date : 2026-08-15
+- Issue : `BigFootLime/erp-crp-backend#517`
+- Branche : `feature/517-sol31-operations-console`
+- Base : `origin/dev` au démarrage
+- Projet Office : aucun jeton/API locale disponible dans ce worktree ; issue
+  GitHub créée avant modification, sans écriture dans une base de production.
+
+## Diagnostic et cause racine
+
+Les preuves existaient mais restaient réparties entre `collectReadiness`, les
+métriques de processus, Prometheus, le registre SQL et plusieurs files métier.
+Le navigateur ne disposait d’aucun contrat agrégé et aurait dû connaître la
+topologie ou les jetons de supervision. L’historique des trois workers n’était
+en outre pas uniformément publié dans les métriques communes.
+
+## Choix d’architecture
+
+- endpoint unique `GET /api/v1/admin/operations`, protégé par authentification
+  et marqueur superadmin persistant ;
+- lecture seule, réponse `private, no-store`, aucune action sensible ;
+- réutilisation des sondes et seuils existants ;
+- interrogation Prometheus uniquement depuis le serveur et seulement via une
+  URL de configuration ;
+- absence/péremption/échec explicites, jamais remplacés par un succès ou zéro ;
+- faits exposés avec unité, période, source, fraîcheur et fiabilité ;
+- compteurs de files uniquement, sans payload, PII ni contenu GED ;
+- jobs webhook et facturation électronique rattachés aux métriques communes.
+
+ADR : `docs/adr/ADR-0077-read-only-operations-console.md`.
+
+## Fichiers modifiés
+
+- module admin : contrôleur, repository, service et types de console ;
+- route admin `/operations` ;
+- métriques d’historique des dépendances et snapshot interne ;
+- instrumentation des workers webhook et facturation électronique ;
+- inventaire OpenAPI généré ;
+- tests unitaires et RBAC ;
+- ADR et présent rapport.
+
+## Migrations et données
+
+Aucune migration, aucun patch SQL, aucune donnée test ou production modifiée.
+Le registre de migrations est lu sans écriture et comparé au manifeste livré
+dans l’image.
+
+## Tests exécutés
+
+- `pnpm typecheck` : réussi en 13,7 s ;
+- 2 fichiers ciblés Vitest, 7 tests : réussis ;
+- `pnpm test:run` : 334 fichiers réussis, 2 ignorés ; 4 741 tests
+  réussis, 5 ignorés, en 66,57 s ;
+- `pnpm test:collection` : 336 fichiers vérifiés, manifeste SHA-256
+  `c6369a18b43fa18d91e336d048bb75ea9989520c24cbedb1e6b52e40f93b535e` ;
+- `pnpm build` : réussi en 16,4 s, 1 051 opérations OpenAPI inventoriées
+  à 100 %, contrat construit valide et 724 fichiers émis conformes à la
+  frontière de données de production ;
+- `pnpm openapi:check` et `pnpm security:production-data` : réussis ;
+- scénario Playwright SOL-31 sur la pile jetable SOL-05 : réussi en 21,0 s
+  après 161 migrations isolées et un seed déterministe. Il couvre HTTP 200
+  superadmin, HTTP 403 utilisateur standard et la restitution des signaux réels.
+
+## Sécurité, risques et compatibilité
+
+- un utilisateur anonyme reçoit 401 et un utilisateur non-superadmin 403 avant
+  toute collecte ;
+- les liens avec identifiants intégrés ou protocole dangereux sont rejetés ;
+- le token Prometheus n’est jamais sérialisé ;
+- le timeout Prometheus est borné à 1,5 s et une réponse supérieure à 1 Mo est
+  rejetée ;
+- sans configuration Prometheus, l’API métier reste disponible mais les
+  sauvegardes sont correctement marquées `unavailable`.
+
+## Rollback
+
+Redéployer le SHA backend précédent. Aucune restauration SQL n’est requise.
+Après rollback, valider `/health/live`, `/health/ready`, le login et un flux de
+lecture. La pile Prometheus/Alertmanager reste indépendante.
+
+## Reste réel
+
+- Injecter sur chaque cible l’URL interne Prometheus et les liens Grafana réels ;
+- ces valeurs ne peuvent pas être inventées ou committées car elles dépendent de
+  la topologie opérateur et peuvent être sensibles.

--- a/docs/http/openapi-route-coverage.json
+++ b/docs/http/openapi-route-coverage.json
@@ -1,9 +1,9 @@
 {
   "scope": "/api/v1",
-  "source_sha256": "b238169ee45fa47245481d4844d29489b9a779b9b0cb4060b7cf2667bd54f78a",
-  "discovered_operations": 1050,
-  "documented_operations": 1050,
+  "source_sha256": "3168df1774ce027e7360375ded632ab9c1701e47ad833b1f1211785aab868f22",
+  "discovered_operations": 1051,
+  "documented_operations": 1051,
   "coverage_percent": 100,
-  "authenticated_operations": 1031,
+  "authenticated_operations": 1032,
   "public_operations": 19
 }

--- a/src/__tests__/operations-console-sol31.routes.test.ts
+++ b/src/__tests__/operations-console-sol31.routes.test.ts
@@ -1,0 +1,86 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const consoleMocks = vi.hoisted(() => ({
+  snapshot: vi.fn(),
+  activeAccount: vi.fn(),
+  isSuperadmin: vi.fn(),
+}));
+
+vi.mock("../module/admin/services/operations-console.service", () => ({
+  getOperationsConsoleSnapshot: consoleMocks.snapshot,
+}));
+
+vi.mock("../module/auth/repository/auth.repository", () => ({
+  findAuthenticatedAccountState: consoleMocks.activeAccount,
+}));
+
+vi.mock("../module/access-control/services/access-control.service", () => ({
+  isSuperadmin: consoleMocks.isSuperadmin,
+}));
+
+import adminRoutes from "../module/admin/routes/admin.routes";
+import { errorHandler } from "../middlewares/errorHandler";
+
+const secret = "sol31-operations-console-route-secret";
+const previousSecret = process.env.JWT_SECRET;
+const app = express();
+app.use(express.json());
+app.use("/api/v1/admin", adminRoutes);
+app.use(errorHandler);
+
+function token(id = 7) {
+  return jwt.sign({ id, username: "ACTOR", email: "actor@example.test", role: "Employee", session_epoch: 0 }, secret);
+}
+
+beforeAll(() => {
+  process.env.JWT_SECRET = secret;
+});
+
+afterAll(() => {
+  if (previousSecret === undefined) delete process.env.JWT_SECRET;
+  else process.env.JWT_SECRET = previousSecret;
+});
+
+beforeEach(() => {
+  consoleMocks.snapshot.mockReset();
+  consoleMocks.activeAccount.mockResolvedValue({ status: "Active", session_epoch: 0 });
+  consoleMocks.isSuperadmin.mockResolvedValue(false);
+});
+
+describe("GET /api/v1/admin/operations", () => {
+  it("rejects anonymous and standard users before collecting operational data", async () => {
+    expect((await request(app).get("/api/v1/admin/operations")).status).toBe(401);
+
+    const standard = await request(app)
+      .get("/api/v1/admin/operations")
+      .set("Authorization", `Bearer ${token()}`);
+    expect(standard.status).toBe(403);
+    expect(consoleMocks.snapshot).not.toHaveBeenCalled();
+  });
+
+  it("returns a no-store read-only snapshot to the live superadministrator", async () => {
+    consoleMocks.isSuperadmin.mockResolvedValueOnce(true);
+    consoleMocks.snapshot.mockResolvedValueOnce({
+      observed_at: "2026-08-15T02:00:00.000Z",
+      overall_state: "degraded",
+      read_only: true,
+      service: { name: "cerp-api", version: "sha", commit: "sha", environment: "test" },
+      signals: [],
+      alerts: [],
+      links: { dashboards: null, logs: null },
+      limitations: ["No repairs."],
+    });
+
+    const response = await request(app)
+      .get("/api/v1/admin/operations")
+      .set("Authorization", `Bearer ${token(4)}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers["cache-control"]).toBe("private, no-store");
+    expect(response.body).toMatchObject({ read_only: true, overall_state: "degraded" });
+    expect(consoleMocks.snapshot).toHaveBeenCalledOnce();
+  });
+});

--- a/src/module/admin/controllers/operations-console.controller.ts
+++ b/src/module/admin/controllers/operations-console.controller.ts
@@ -1,0 +1,9 @@
+import type { RequestHandler } from "express";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { getOperationsConsoleSnapshot } from "../services/operations-console.service";
+
+export const getOperationsConsole: RequestHandler = asyncHandler(async (_req, res) => {
+  res.setHeader("Cache-Control", "private, no-store");
+  res.json(await getOperationsConsoleSnapshot());
+});

--- a/src/module/admin/repository/operations-console.repository.ts
+++ b/src/module/admin/repository/operations-console.repository.ts
@@ -1,0 +1,145 @@
+import pool from "../../../config/database";
+import type {
+  MigrationLedgerSnapshot,
+  QueueSnapshot,
+} from "../types/operations-console.types";
+
+type Queryable = Pick<typeof pool, "query">;
+
+function isoOrNull(value: unknown): string | null {
+  if (value == null) return null;
+  const date = new Date(String(value));
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
+function integer(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+export async function repoMigrationLedger(
+  database: Queryable = pool,
+): Promise<MigrationLedgerSnapshot> {
+  const startedAt = Date.now();
+  const exists = await database.query<{ registry: string | null }>(
+    "SELECT to_regclass('public.cerp_schema_migrations')::text AS registry",
+  );
+  if (!exists.rows[0]?.registry) {
+    return { registry_exists: false, rows: [], latency_ms: Date.now() - startedAt };
+  }
+  const result = await database.query<{
+    filename: string;
+    sha256: string;
+    applied_at: Date | string;
+  }>(
+    `SELECT filename, sha256, applied_at
+       FROM public.cerp_schema_migrations
+      ORDER BY filename`,
+  );
+  return {
+    registry_exists: true,
+    rows: result.rows.map((row) => ({
+      filename: row.filename,
+      sha256: row.sha256,
+      applied_at: new Date(row.applied_at).toISOString(),
+    })),
+    latency_ms: Date.now() - startedAt,
+  };
+}
+
+async function optionalQueue(
+  id: QueueSnapshot["id"],
+  relation: string,
+  sql: string,
+  database: Queryable,
+): Promise<QueueSnapshot> {
+  const startedAt = Date.now();
+  try {
+    const exists = await database.query<{ registry: string | null }>(
+      "SELECT to_regclass($1)::text AS registry",
+      [relation],
+    );
+    if (!exists.rows[0]?.registry) {
+      return {
+        id,
+        available: false,
+        pending: 0,
+        failures: 0,
+        oldest_pending_at: null,
+        last_success_at: null,
+        last_error_at: null,
+        latency_ms: Date.now() - startedAt,
+        reason_code: "QUEUE_SCHEMA_NOT_INSTALLED",
+      };
+    }
+    const result = await database.query<Record<string, unknown>>(sql);
+    const row = result.rows[0] ?? {};
+    return {
+      id,
+      available: true,
+      pending: integer(row.pending),
+      failures: integer(row.failures),
+      oldest_pending_at: isoOrNull(row.oldest_pending_at),
+      last_success_at: isoOrNull(row.last_success_at),
+      last_error_at: isoOrNull(row.last_error_at),
+      latency_ms: Date.now() - startedAt,
+      reason_code: null,
+    };
+  } catch {
+    return {
+      id,
+      available: false,
+      pending: 0,
+      failures: 0,
+      oldest_pending_at: null,
+      last_success_at: null,
+      last_error_at: null,
+      latency_ms: Date.now() - startedAt,
+      reason_code: "QUEUE_PROBE_FAILED",
+    };
+  }
+}
+
+export async function repoQueueSnapshots(database: Queryable = pool): Promise<readonly QueueSnapshot[]> {
+  return Promise.all([
+    optionalQueue(
+      "advanced_reminders",
+      "public.adv_reminder_suggestions",
+      `SELECT
+         COUNT(*) FILTER (WHERE status IN ('APPROVED','CLAIMED','FAILED_RETRYABLE'))::int AS pending,
+         COUNT(*) FILTER (WHERE status = 'FAILED_FINAL')::int AS failures,
+         MIN(created_at) FILTER (WHERE status IN ('APPROVED','CLAIMED','FAILED_RETRYABLE')) AS oldest_pending_at,
+         MAX(sent_at) FILTER (WHERE status = 'SENT') AS last_success_at,
+         MAX(updated_at) FILTER (WHERE status IN ('FAILED_RETRYABLE','FAILED_FINAL')) AS last_error_at
+       FROM public.adv_reminder_suggestions`,
+      database,
+    ),
+    optionalQueue(
+      "webhook_delivery",
+      "public.api_webhook_deliveries",
+      `SELECT
+         COUNT(*) FILTER (WHERE status IN ('PENDING','PROCESSING','RETRY'))::int AS pending,
+         COUNT(*) FILTER (WHERE status = 'DEAD_LETTER')::int AS failures,
+         MIN(created_at) FILTER (WHERE status IN ('PENDING','PROCESSING','RETRY')) AS oldest_pending_at,
+         MAX(delivered_at) FILTER (WHERE status = 'DELIVERED') AS last_success_at,
+         MAX(updated_at) FILTER (WHERE last_error_code IS NOT NULL) AS last_error_at
+       FROM public.api_webhook_deliveries`,
+      database,
+    ),
+    optionalQueue(
+      "electronic_invoicing",
+      "public.einvoice_documents",
+      `SELECT
+         COUNT(*) FILTER (
+           WHERE provider_document_id IS NULL
+             AND (next_retry_at IS NULL OR next_retry_at <= now())
+         )::int AS pending,
+         COUNT(*) FILTER (WHERE last_error_code IS NOT NULL)::int AS failures,
+         MIN(created_at) FILTER (WHERE provider_document_id IS NULL) AS oldest_pending_at,
+         MAX(updated_at) FILTER (WHERE provider_document_id IS NOT NULL AND last_error_code IS NULL) AS last_success_at,
+         MAX(updated_at) FILTER (WHERE last_error_code IS NOT NULL) AS last_error_at
+       FROM public.einvoice_documents`,
+      database,
+    ),
+  ]);
+}

--- a/src/module/admin/routes/admin.routes.ts
+++ b/src/module/admin/routes/admin.routes.ts
@@ -14,6 +14,7 @@ import {
   getAdminAnalytics,
   patchUserAdmin,
 } from "../controllers/admin.controller";
+import { getOperationsConsole } from "../controllers/operations-console.controller";
 
 const router = Router();
 
@@ -32,6 +33,7 @@ router.post("/users/:id/invitations", createAccountInvitationAdmin);
 
 router.get("/login-logs", listLoginLogsAdmin);
 router.get("/analytics", getAdminAnalytics);
+router.get("/operations", getOperationsConsole);
 
 router.post("/users/:id/password-reset-token", createPasswordResetTokenAdmin);
 router.patch("/users/:id/password", resetUserPasswordAdmin);

--- a/src/module/admin/services/operations-console.service.test.ts
+++ b/src/module/admin/services/operations-console.service.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReadinessReport } from "../../../shared/observability/health";
+import {
+  getOperationsConsoleSnapshot,
+  operationsConsoleInternals,
+  type OperationsConsoleDependencies,
+  type PrometheusSnapshot,
+} from "./operations-console.service";
+
+const NOW = new Date("2026-08-15T02:00:00.000Z");
+
+function readiness(status: ReadinessReport["status"] = "ready"): ReadinessReport {
+  const check = (source: string) => ({
+    status: status === "ready" ? "up" as const : "down" as const,
+    required: true,
+    latency_ms: 12,
+    checked_at: NOW.toISOString(),
+    reason_code: status === "ready" ? null : "PROBE_FAILED",
+    affected_scope: "test_scope",
+    source,
+    freshness_seconds: 0,
+    reliability: "MEASURED" as const,
+  });
+  return {
+    status,
+    service: "cerp-api",
+    version: "abc1234",
+    environment: "test",
+    observed_at: NOW.toISOString(),
+    checks: {
+      database: check("postgres_probe"),
+      ged_storage: check("filesystem_probe"),
+      antivirus: check("clamav_live_probe"),
+      realtime: check("realtime_control_plane"),
+    },
+  };
+}
+
+function sample(name: string, value: number, labels: Readonly<Record<string, string>> = {}) {
+  return {
+    metric: { __name__: name, ...labels },
+    value: [NOW.getTime() / 1_000, String(value)] as const,
+  };
+}
+
+function prometheus(overrides: Partial<PrometheusSnapshot> = {}): PrometheusSnapshot {
+  const recent = NOW.getTime() / 1_000 - 60;
+  return {
+    configured: true,
+    available: true,
+    reason_code: null,
+    latency_ms: 24,
+    observed_at: NOW.toISOString(),
+    metrics: [
+      sample("cerp_external_job_last_success_timestamp_seconds", recent, { job: "backup_database" }),
+      sample("cerp_external_job_last_success_timestamp_seconds", recent, { job: "backup_files" }),
+      sample("cerp_external_job_last_success_timestamp_seconds", recent, { job: "backup_complete" }),
+      sample("cerp_external_job_last_success_timestamp_seconds", recent, { job: "migrations" }),
+      sample("cerp_external_job_last_failure_timestamp_seconds", 0, { job: "backup_database" }),
+      sample("cerp_external_job_last_failure_timestamp_seconds", 0, { job: "backup_files" }),
+      sample("cerp_external_job_last_failure_timestamp_seconds", 0, { job: "backup_complete" }),
+      sample("cerp_external_job_last_failure_timestamp_seconds", 0, { job: "migrations" }),
+      sample("cerp_backup_complete", 1),
+      sample("cerp_backup_snapshot_bytes", 1024),
+      sample("cerp_backup_document_references", 12),
+    ],
+    alerts: [],
+    ...overrides,
+  };
+}
+
+function dependencies(
+  overrides: Partial<OperationsConsoleDependencies> = {},
+): Partial<OperationsConsoleDependencies> {
+  return {
+    now: () => NOW,
+    readiness: async () => readiness(),
+    migrationLedger: async () => ({
+      registry_exists: true,
+      rows: [{ filename: "001.sql", sha256: "a".repeat(64), applied_at: "2026-08-14T00:00:00.000Z" }],
+      latency_ms: 8,
+    }),
+    queueSnapshots: async () => [
+      {
+        id: "advanced_reminders",
+        available: true,
+        pending: 0,
+        failures: 0,
+        oldest_pending_at: null,
+        last_success_at: "2026-08-15T01:55:00.000Z",
+        last_error_at: null,
+        latency_ms: 5,
+        reason_code: null,
+      },
+    ],
+    patchManifest: () => ({
+      available: true,
+      rows: [{ filename: "001.sql", sha256: "a".repeat(64) }],
+      reason_code: null,
+    }),
+    prometheus: async () => prometheus(),
+    runtimeMetrics: () => ({
+      dependencies: {
+        database: { up: true, checkedAtMs: NOW.getTime(), latencyMs: 12, lastSucceededAtMs: NOW.getTime(), lastFailedAtMs: 0 },
+      },
+      jobs: {
+        advanced_reminders: { lastStartedAtMs: NOW.getTime() - 100, lastSucceededAtMs: NOW.getTime(), lastFailedAtMs: 0, failures: 0, running: false },
+      },
+      ged_capacity: { capacityBytes: 1000, availableBytes: 400, usedRatio: 0.6, inodeTotal: 100, inodeFree: 50 },
+      ged_quarantine: { pending: 0, clean: 2, infected: 0, scanFailed: 0, oldestAgeSeconds: 0 },
+    }),
+    webhookReadiness: () => ({
+      ready: true,
+      environment: "sandbox",
+      encryption_key_configured: true,
+      delivery_enabled: true,
+      signature_algorithm: "HMAC-SHA256",
+      signature_version: "v1",
+      replay_window_seconds: 300,
+    }),
+    electronicInvoiceReadiness: async () => ({
+      ready: false,
+      environment: "sandbox",
+      reason: "NO_QUALIFIED_PROVIDER",
+      message: "Aucune Plateforme Agréée réelle n'est qualifiée et activée pour cet environnement.",
+      provider: null,
+      registered_adapters: [],
+    }),
+    environment: {
+      CERP_OPERATIONS_LOGS_URL: "https://grafana.example.test/explore",
+      CERP_OPERATIONS_DASHBOARD_URL: "https://grafana.example.test/d/cerp",
+      CERP_RELEASE_COMMIT: "abcdef1234567",
+    },
+    ...overrides,
+  };
+}
+
+describe("SOL-31 operations console snapshot", () => {
+  it("returns an operational, read-only snapshot from measured sources", async () => {
+    const snapshot = await getOperationsConsoleSnapshot(dependencies());
+
+    expect(snapshot.overall_state).toBe("operational");
+    expect(snapshot.read_only).toBe(true);
+    expect(snapshot.service.commit).toBe("abcdef1234567");
+    expect(snapshot.signals.find((signal) => signal.id === "migrations")?.current).toBe("UP_TO_DATE");
+    expect(snapshot.signals.find((signal) => signal.id === "backup_complete")?.facts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: "cerp_backup_document_references", value: 12, unit: "documents" })]),
+    );
+    expect(JSON.stringify(snapshot)).not.toContain("OPERATIONS_PROMETHEUS_TOKEN");
+  });
+
+  it("never turns an absent monitoring source into a healthy backup", async () => {
+    const snapshot = await getOperationsConsoleSnapshot(dependencies({
+      prometheus: async () => prometheus({
+        configured: false,
+        available: false,
+        reason_code: "PROMETHEUS_NOT_CONFIGURED",
+        latency_ms: null,
+        metrics: [],
+      }),
+    }));
+
+    expect(snapshot.overall_state).toBe("degraded");
+    expect(snapshot.signals.find((signal) => signal.id === "backup_complete")).toMatchObject({
+      state: "unavailable",
+      reason_code: "PROMETHEUS_NOT_CONFIGURED",
+      reliability: "UNAVAILABLE",
+    });
+  });
+
+  it("marks stale backup heartbeats and checksum divergence", async () => {
+    const old = NOW.getTime() / 1_000 - 100_000;
+    const snapshot = await getOperationsConsoleSnapshot(dependencies({
+      patchManifest: () => ({
+        available: true,
+        rows: [{ filename: "001.sql", sha256: "b".repeat(64) }],
+        reason_code: null,
+      }),
+      prometheus: async () => prometheus({
+        metrics: [
+          sample("cerp_external_job_last_success_timestamp_seconds", old, { job: "backup_database" }),
+          sample("cerp_external_job_last_success_timestamp_seconds", old, { job: "backup_files" }),
+          sample("cerp_external_job_last_success_timestamp_seconds", old, { job: "backup_complete" }),
+          sample("cerp_external_job_last_success_timestamp_seconds", old, { job: "migrations" }),
+          sample("cerp_backup_complete", 1),
+        ],
+      }),
+    }));
+
+    expect(snapshot.overall_state).toBe("down");
+    expect(snapshot.signals.find((signal) => signal.id === "migrations")?.state).toBe("down");
+    expect(snapshot.signals.find((signal) => signal.id === "backup_complete")?.state).toBe("stale");
+  });
+
+  it("surfaces firing alerts without exposing their payloads", async () => {
+    const snapshot = await getOperationsConsoleSnapshot(dependencies({
+      prometheus: async () => prometheus({
+        alerts: [{
+          metric: { alertname: "CERPDatabaseUnavailable", severity: "P0", affected_scope: "all_transactional_flows" },
+          value: [NOW.getTime() / 1_000, "1"],
+        }],
+      }),
+    }));
+
+    expect(snapshot.alerts).toEqual([expect.objectContaining({
+      name: "CERPDatabaseUnavailable",
+      severity: "P0",
+      runbook_url: expect.stringContaining("database-degraded.md"),
+    })]);
+  });
+
+  it("rejects operator links containing credentials or unsafe schemes", () => {
+    expect(operationsConsoleInternals.safeOperatorUrl("javascript:alert(1)")).toBeNull();
+    expect(operationsConsoleInternals.safeOperatorUrl("https://user:secret@example.test/logs")).toBeNull();
+    expect(operationsConsoleInternals.safeOperatorUrl("https://grafana.example.test/logs")).toBe("https://grafana.example.test/logs");
+    expect(operationsConsoleInternals.safeOperatorUrl("https://grafana.example.test/logs?token=secret#state")).toBe("https://grafana.example.test/logs");
+  });
+});

--- a/src/module/admin/services/operations-console.service.ts
+++ b/src/module/admin/services/operations-console.service.ts
@@ -1,0 +1,729 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import pool from "../../../config/database";
+import { svcElectronicInvoiceReadiness } from "../../facturation/electronic-invoicing/electronic-invoice.service";
+import { webhookReadiness } from "../../integrations/webhooks/webhook.service";
+import { collectReadiness, type ReadinessReport } from "../../../shared/observability/health";
+import { getOperationalMetricsSnapshot } from "../../../shared/observability/metrics";
+import { runtimeMetadata } from "../../../shared/observability/runtime";
+import {
+  repoMigrationLedger,
+  repoQueueSnapshots,
+} from "../repository/operations-console.repository";
+import type {
+  MigrationLedgerSnapshot,
+  OperationsAlert,
+  OperationsConsoleSnapshot,
+  OperationsFact,
+  OperationsReliability,
+  OperationsSignal,
+  OperationsState,
+  QueueSnapshot,
+} from "../types/operations-console.types";
+
+export type PatchManifest = Readonly<{
+  available: boolean;
+  rows: readonly Readonly<{ filename: string; sha256: string }>[];
+  reason_code: string | null;
+}>;
+
+type PrometheusSample = Readonly<{
+  metric: Readonly<Record<string, string>>;
+  value: readonly [number, string];
+}>;
+
+export type PrometheusSnapshot = Readonly<{
+  configured: boolean;
+  available: boolean;
+  reason_code: string | null;
+  latency_ms: number | null;
+  observed_at: string;
+  metrics: readonly PrometheusSample[];
+  alerts: readonly PrometheusSample[];
+}>;
+
+export type OperationsConsoleDependencies = Readonly<{
+  now: () => Date;
+  readiness: () => Promise<ReadinessReport>;
+  migrationLedger: () => Promise<MigrationLedgerSnapshot>;
+  queueSnapshots: () => Promise<readonly QueueSnapshot[]>;
+  patchManifest: () => PatchManifest;
+  prometheus: () => Promise<PrometheusSnapshot>;
+  runtimeMetrics: typeof getOperationalMetricsSnapshot;
+  webhookReadiness: typeof webhookReadiness;
+  electronicInvoiceReadiness: typeof svcElectronicInvoiceReadiness;
+  environment: NodeJS.ProcessEnv;
+}>;
+
+const RUNBOOK_ROOT = "https://github.com/BigFootLime/crp-systems-web/blob/main/docs/runbooks/operations";
+
+const RUNBOOKS = Object.freeze({
+  api: `${RUNBOOK_ROOT}/api-unavailable.md`,
+  database: `${RUNBOOK_ROOT}/database-degraded.md`,
+  documents: `${RUNBOOK_ROOT}/ged-storage-capacity.md`,
+  antivirus: `${RUNBOOK_ROOT}/antivirus-quarantine.md`,
+  jobs: `${RUNBOOK_ROOT}/job-queue-stuck.md`,
+  migrations: `${RUNBOOK_ROOT}/migration-failed.md`,
+  backups: `${RUNBOOK_ROOT}/backup-restore.md`,
+  integrations: `${RUNBOOK_ROOT}/api-unavailable.md`,
+});
+
+const ALERT_RUNBOOKS: Readonly<Record<string, string>> = Object.freeze({
+  CERPApiUnavailable: RUNBOOKS.api,
+  CERPDatabaseUnavailable: RUNBOOKS.database,
+  CERPDatabasePoolSaturated: RUNBOOKS.database,
+  CERPGedStorageUnavailable: RUNBOOKS.documents,
+  CERPGedStorageCritical: RUNBOOKS.documents,
+  CERPAntivirusUnavailable: RUNBOOKS.antivirus,
+  CERPDocumentThreatQuarantined: RUNBOOKS.antivirus,
+  CERPDocumentScanFailedQuarantined: RUNBOOKS.antivirus,
+  CERPDocumentQuarantineBacklog: RUNBOOKS.antivirus,
+  CERPDatabaseBackupStale: RUNBOOKS.backups,
+  CERPFilesBackupStale: RUNBOOKS.backups,
+  CERPCompleteBackupStale: RUNBOOKS.backups,
+  CERPCompleteBackupIncomplete: RUNBOOKS.backups,
+  CERPBackupRepositoryCapacityCritical: RUNBOOKS.backups,
+  CERPCriticalJobFailed: RUNBOOKS.jobs,
+  CERPMigrationFailed: RUNBOOKS.migrations,
+});
+
+const DEPENDENCY_METADATA = Object.freeze({
+  database: { label: "Base PostgreSQL", category: "data" as const, runbook: RUNBOOKS.database },
+  ged_storage: { label: "Stockage GED", category: "documents" as const, runbook: RUNBOOKS.documents },
+  antivirus: { label: "Antivirus documentaire", category: "documents" as const, runbook: RUNBOOKS.antivirus },
+  realtime: { label: "Temps réel", category: "runtime" as const, runbook: RUNBOOKS.api },
+});
+
+const QUEUE_LABELS: Readonly<Record<QueueSnapshot["id"], string>> = Object.freeze({
+  advanced_reminders: "Relances clients",
+  webhook_delivery: "Livraisons webhook",
+  electronic_invoicing: "Facturation électronique",
+});
+
+function isoOrNull(milliseconds: number): string | null {
+  return milliseconds > 0 ? new Date(milliseconds).toISOString() : null;
+}
+
+function freshnessSeconds(now: Date, timestamp: string | null): number | null {
+  if (!timestamp) return null;
+  const milliseconds = new Date(timestamp).getTime();
+  if (!Number.isFinite(milliseconds)) return null;
+  return Math.max(0, Math.floor((now.getTime() - milliseconds) / 1_000));
+}
+
+function safeOperatorUrl(value: string | undefined): string | null {
+  const raw = value?.trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (!(["http:", "https:"] as const).includes(url.protocol as "http:" | "https:")) return null;
+    if (url.username || url.password) return null;
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function fact(params: Omit<OperationsFact, "observed_at"> & { observed_at?: string }, observedAt: string): OperationsFact {
+  return { ...params, observed_at: params.observed_at ?? observedAt };
+}
+
+function readPatchManifest(environment = process.env): PatchManifest {
+  const patchRoot = path.resolve(environment.CERP_PATCHES_DIR?.trim() || path.join(process.cwd(), "db", "patches"));
+  try {
+    const rows = fs.readdirSync(patchRoot, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
+      .map((entry) => {
+        const contents = fs.readFileSync(path.join(patchRoot, entry.name));
+        return {
+          filename: entry.name,
+          sha256: crypto.createHash("sha256").update(contents).digest("hex"),
+        };
+      })
+      .sort((left, right) => left.filename.localeCompare(right.filename));
+    return rows.length > 0
+      ? { available: true, rows, reason_code: null }
+      : { available: false, rows: [], reason_code: "PATCH_MANIFEST_EMPTY" };
+  } catch {
+    return { available: false, rows: [], reason_code: "PATCH_MANIFEST_UNAVAILABLE" };
+  }
+}
+
+function prometheusEndpoint(environment: NodeJS.ProcessEnv): URL | null {
+  const raw = environment.CERP_OPERATIONS_PROMETHEUS_URL?.trim();
+  if (!raw) return null;
+  try {
+    const base = new URL(raw.endsWith("/") ? raw : `${raw}/`);
+    if (!["http:", "https:"].includes(base.protocol) || base.username || base.password) return null;
+    return new URL("api/v1/query", base);
+  } catch {
+    return null;
+  }
+}
+
+async function prometheusQuery(
+  endpoint: URL,
+  query: string,
+  environment: NodeJS.ProcessEnv,
+): Promise<readonly PrometheusSample[]> {
+  const url = new URL(endpoint);
+  url.searchParams.set("query", query);
+  const token = environment.CERP_OPERATIONS_PROMETHEUS_TOKEN?.trim();
+  const response = await fetch(url, {
+    headers: token ? { authorization: `Bearer ${token}` } : undefined,
+    signal: AbortSignal.timeout(1_500),
+  });
+  if (!response.ok) throw new Error("PROMETHEUS_HTTP_ERROR");
+  const raw = await response.text();
+  if (raw.length > 1_000_000) throw new Error("PROMETHEUS_RESPONSE_TOO_LARGE");
+  const body = JSON.parse(raw) as {
+    status?: unknown;
+    data?: { resultType?: unknown; result?: unknown };
+  };
+  if (body.status !== "success" || body.data?.resultType !== "vector" || !Array.isArray(body.data.result)) {
+    throw new Error("PROMETHEUS_RESPONSE_INVALID");
+  }
+  return body.data.result.filter((item): item is PrometheusSample => {
+    if (!item || typeof item !== "object") return false;
+    const candidate = item as { metric?: unknown; value?: unknown };
+    return Boolean(candidate.metric && typeof candidate.metric === "object"
+      && Array.isArray(candidate.value)
+      && candidate.value.length === 2
+      && typeof candidate.value[0] === "number"
+      && typeof candidate.value[1] === "string");
+  });
+}
+
+async function collectPrometheus(environment = process.env): Promise<PrometheusSnapshot> {
+  const observedAt = new Date().toISOString();
+  const endpoint = prometheusEndpoint(environment);
+  if (!endpoint) {
+    return {
+      configured: false,
+      available: false,
+      reason_code: "PROMETHEUS_NOT_CONFIGURED",
+      latency_ms: null,
+      observed_at: observedAt,
+      metrics: [],
+      alerts: [],
+    };
+  }
+  const startedAt = Date.now();
+  try {
+    const [metrics, alerts] = await Promise.all([
+      prometheusQuery(
+        endpoint,
+        '{__name__=~"cerp_external_job_last_(success|failure)_timestamp_seconds|cerp_external_job_last_duration_seconds|cerp_backup_(complete|snapshot_bytes|document_references|duration_seconds|recovery_point_lag_seconds|repository_bytes|repository_capacity_bytes)"}',
+        environment,
+      ),
+      prometheusQuery(endpoint, 'ALERTS{alertstate="firing"}', environment),
+    ]);
+    return {
+      configured: true,
+      available: true,
+      reason_code: null,
+      latency_ms: Date.now() - startedAt,
+      observed_at: observedAt,
+      metrics,
+      alerts,
+    };
+  } catch {
+    return {
+      configured: true,
+      available: false,
+      reason_code: "PROMETHEUS_QUERY_FAILED",
+      latency_ms: Date.now() - startedAt,
+      observed_at: observedAt,
+      metrics: [],
+      alerts: [],
+    };
+  }
+}
+
+function numericMetric(
+  samples: readonly PrometheusSample[],
+  name: string,
+  labels: Readonly<Record<string, string>> = {},
+): number | null {
+  const values = samples
+    .filter((sample) => sample.metric.__name__ === name
+      && Object.entries(labels).every(([key, value]) => sample.metric[key] === value))
+    .map((sample) => Number(sample.value[1]))
+    .filter(Number.isFinite);
+  return values.length > 0 ? Math.max(...values) : null;
+}
+
+function dependencySignals(
+  report: ReadinessReport,
+  metrics: ReturnType<typeof getOperationalMetricsSnapshot>,
+  now: Date,
+  logsUrl: string | null,
+): OperationsSignal[] {
+  return Object.entries(report.checks).map(([id, check]) => {
+    const name = id as keyof typeof DEPENDENCY_METADATA;
+    const metadata = DEPENDENCY_METADATA[name];
+    const history = metrics.dependencies[name];
+    const lastSuccess = isoOrNull(history?.lastSucceededAtMs ?? (check.status === "up" ? now.getTime() : 0));
+    const lastError = isoOrNull(history?.lastFailedAtMs ?? (check.status === "up" ? 0 : now.getTime()));
+    const facts: OperationsFact[] = [
+      fact({ key: "required", label: "Obligatoire", value: check.required, unit: "boolean", period: "instantané", source: check.source, reliability: "MEASURED" }, check.checked_at),
+    ];
+    if (name === "database") {
+      facts.push(
+        fact({ key: "pool_total", label: "Connexions pool", value: pool.totalCount, unit: "connections", period: "instantané", source: "node_pg_pool", reliability: "MEASURED" }, check.checked_at),
+        fact({ key: "pool_idle", label: "Connexions libres", value: pool.idleCount, unit: "connections", period: "instantané", source: "node_pg_pool", reliability: "MEASURED" }, check.checked_at),
+        fact({ key: "pool_waiting", label: "Requêtes en attente", value: pool.waitingCount, unit: "requests", period: "instantané", source: "node_pg_pool", reliability: "MEASURED" }, check.checked_at),
+      );
+    }
+    if (name === "ged_storage" && metrics.ged_capacity) {
+      facts.push(
+        fact({ key: "used_ratio", label: "Occupation", value: metrics.ged_capacity.usedRatio, unit: "ratio", period: "instantané", source: "filesystem_probe", reliability: "MEASURED" }, check.checked_at),
+        fact({ key: "available_bytes", label: "Espace disponible", value: metrics.ged_capacity.availableBytes, unit: "bytes", period: "instantané", source: "filesystem_probe", reliability: "MEASURED" }, check.checked_at),
+      );
+    }
+    if (name === "antivirus" && metrics.ged_quarantine) {
+      facts.push(
+        fact({ key: "pending", label: "Scans en attente", value: metrics.ged_quarantine.pending, unit: "documents", period: "instantané", source: "ged_upload_sessions", reliability: "MEASURED" }, check.checked_at),
+        fact({ key: "infected", label: "Documents infectés", value: metrics.ged_quarantine.infected, unit: "documents", period: "instantané", source: "ged_upload_sessions", reliability: "MEASURED" }, check.checked_at),
+        fact({ key: "scan_failed", label: "Scans échoués", value: metrics.ged_quarantine.scanFailed, unit: "documents", period: "instantané", source: "ged_upload_sessions", reliability: "MEASURED" }, check.checked_at),
+      );
+    }
+    return {
+      id: name,
+      label: metadata.label,
+      category: metadata.category,
+      state: check.status === "up" ? "operational" : check.status,
+      required: check.required,
+      current: check.status.toUpperCase(),
+      reason_code: check.reason_code,
+      affected_scope: check.affected_scope,
+      latency_ms: check.latency_ms,
+      observed_at: check.checked_at,
+      freshness_seconds: check.freshness_seconds,
+      last_success_at: lastSuccess,
+      last_error_at: lastError,
+      source: check.source,
+      reliability: "MEASURED",
+      runbook_url: metadata.runbook,
+      logs_url: logsUrl,
+      facts,
+    } satisfies OperationsSignal;
+  });
+}
+
+function migrationSignal(
+  ledger: MigrationLedgerSnapshot | null,
+  manifest: PatchManifest,
+  now: Date,
+  logsUrl: string | null,
+): OperationsSignal {
+  const observedAt = now.toISOString();
+  if (!ledger || !manifest.available) {
+    return {
+      id: "migrations",
+      label: "Migrations SQL",
+      category: "data",
+      state: "unavailable",
+      required: true,
+      current: "UNAVAILABLE",
+      reason_code: manifest.reason_code ?? "MIGRATION_LEDGER_PROBE_FAILED",
+      affected_scope: "release_database_upgrade",
+      latency_ms: ledger?.latency_ms ?? null,
+      observed_at: observedAt,
+      freshness_seconds: null,
+      last_success_at: null,
+      last_error_at: null,
+      source: "runtime_patch_manifest_and_cerp_schema_migrations",
+      reliability: "UNAVAILABLE",
+      runbook_url: RUNBOOKS.migrations,
+      logs_url: logsUrl,
+      facts: [],
+    };
+  }
+  if (!ledger.registry_exists) {
+    return {
+      id: "migrations",
+      label: "Migrations SQL",
+      category: "data",
+      state: "down",
+      required: true,
+      current: "REGISTRY_MISSING",
+      reason_code: "MIGRATION_REGISTRY_MISSING",
+      affected_scope: "release_database_upgrade",
+      latency_ms: ledger.latency_ms,
+      observed_at: observedAt,
+      freshness_seconds: null,
+      last_success_at: null,
+      last_error_at: observedAt,
+      source: "runtime_patch_manifest_and_cerp_schema_migrations",
+      reliability: "MEASURED",
+      runbook_url: RUNBOOKS.migrations,
+      logs_url: logsUrl,
+      facts: [],
+    };
+  }
+  const applied = new Map(ledger.rows.map((row) => [row.filename, row]));
+  const expected = new Set(manifest.rows.map((row) => row.filename));
+  const pending = manifest.rows.filter((row) => !applied.has(row.filename));
+  const mismatches = manifest.rows.filter((row) => {
+    const installed = applied.get(row.filename);
+    return installed ? installed.sha256 !== row.sha256 : false;
+  });
+  const unexpected = ledger.rows.filter((row) => !expected.has(row.filename));
+  const lastSuccess = ledger.rows
+    .map((row) => row.applied_at)
+    .sort()
+    .at(-1) ?? null;
+  const state: OperationsState = mismatches.length > 0 ? "down" : pending.length > 0 || unexpected.length > 0 ? "degraded" : "operational";
+  const current = mismatches.length > 0 ? "CHECKSUM_MISMATCH" : pending.length > 0 ? "PATCHES_PENDING" : unexpected.length > 0 ? "UNEXPECTED_LEDGER_ROWS" : "UP_TO_DATE";
+  return {
+    id: "migrations",
+    label: "Migrations SQL",
+    category: "data",
+    state,
+    required: true,
+    current,
+    reason_code: state === "operational" ? null : current,
+    affected_scope: "release_database_upgrade",
+    latency_ms: ledger.latency_ms,
+    observed_at: observedAt,
+    freshness_seconds: freshnessSeconds(now, lastSuccess),
+    last_success_at: lastSuccess,
+    last_error_at: mismatches.length > 0 ? observedAt : null,
+    source: "runtime_patch_manifest_and_cerp_schema_migrations",
+    reliability: "MEASURED",
+    runbook_url: RUNBOOKS.migrations,
+    logs_url: logsUrl,
+    facts: [
+      fact({ key: "expected", label: "Patches livrés", value: manifest.rows.length, unit: "patches", period: "release courante", source: "runtime_patch_manifest", reliability: "MEASURED" }, observedAt),
+      fact({ key: "applied", label: "Patches appliqués", value: ledger.rows.length, unit: "patches", period: "historique complet", source: "cerp_schema_migrations", reliability: "MEASURED" }, observedAt),
+      fact({ key: "pending", label: "Patches en attente", value: pending.length, unit: "patches", period: "release courante", source: "manifest_ledger_comparison", reliability: "DERIVED" }, observedAt),
+      fact({ key: "checksum_mismatches", label: "Empreintes divergentes", value: mismatches.length, unit: "patches", period: "release courante", source: "manifest_ledger_comparison", reliability: "DERIVED" }, observedAt),
+    ],
+  };
+}
+
+function queueSignals(queues: readonly QueueSnapshot[], now: Date, logsUrl: string | null): OperationsSignal[] {
+  const observedAt = now.toISOString();
+  return queues.map((queue) => {
+    const age = freshnessSeconds(now, queue.oldest_pending_at);
+    const state: OperationsState = !queue.available
+      ? "unavailable"
+      : queue.failures > 0
+        ? "degraded"
+        : age !== null && age > 3_600
+          ? "stale"
+          : "operational";
+    return {
+      id: `queue_${queue.id}`,
+      label: `File — ${QUEUE_LABELS[queue.id]}`,
+      category: "jobs",
+      state,
+      required: false,
+      current: !queue.available ? "UNAVAILABLE" : queue.pending > 0 ? "PENDING" : "IDLE",
+      reason_code: queue.reason_code ?? (state === "stale" ? "OLDEST_ITEM_OVER_ONE_HOUR" : queue.failures > 0 ? "FAILED_ITEMS_PRESENT" : null),
+      affected_scope: queue.id,
+      latency_ms: queue.latency_ms,
+      observed_at: observedAt,
+      freshness_seconds: age,
+      last_success_at: queue.last_success_at,
+      last_error_at: queue.last_error_at,
+      source: `postgres_${queue.id}_queue`,
+      reliability: queue.available ? "MEASURED" : "UNAVAILABLE",
+      runbook_url: RUNBOOKS.jobs,
+      logs_url: logsUrl,
+      facts: queue.available ? [
+        fact({ key: "pending", label: "En attente", value: queue.pending, unit: "items", period: "instantané", source: `postgres_${queue.id}_queue`, reliability: "MEASURED" }, observedAt),
+        fact({ key: "failures", label: "En échec", value: queue.failures, unit: "items", period: "instantané", source: `postgres_${queue.id}_queue`, reliability: "MEASURED" }, observedAt),
+      ] : [],
+    };
+  });
+}
+
+function runtimeJobSignals(
+  metrics: ReturnType<typeof getOperationalMetricsSnapshot>,
+  now: Date,
+  logsUrl: string | null,
+): OperationsSignal[] {
+  const observedAt = now.toISOString();
+  return Object.entries(metrics.jobs).map(([id, job]) => {
+    const lastSuccess = isoOrNull(job.lastSucceededAtMs);
+    const lastError = isoOrNull(job.lastFailedAtMs);
+    const state: OperationsState = job.running || job.lastSucceededAtMs >= job.lastFailedAtMs
+      ? "operational"
+      : "down";
+    return {
+      id: `job_${id}`,
+      label: `Job — ${id}`,
+      category: "jobs",
+      state,
+      required: id === "advanced_reminders",
+      current: job.running ? "RUNNING" : state === "operational" ? "IDLE" : "FAILED",
+      reason_code: state === "down" ? "LAST_RUN_FAILED" : null,
+      affected_scope: id,
+      latency_ms: null,
+      observed_at: observedAt,
+      freshness_seconds: freshnessSeconds(now, lastSuccess ?? lastError),
+      last_success_at: lastSuccess,
+      last_error_at: lastError,
+      source: "process_job_metrics",
+      reliability: "MEASURED",
+      runbook_url: RUNBOOKS.jobs,
+      logs_url: logsUrl,
+      facts: [
+        fact({ key: "failures", label: "Échecs depuis démarrage", value: job.failures, unit: "runs", period: "depuis démarrage du processus", source: "process_job_metrics", reliability: "MEASURED" }, observedAt),
+      ],
+    };
+  });
+}
+
+function externalJobSignal(params: {
+  id: "backup_database" | "backup_files" | "backup_complete" | "migrations_heartbeat";
+  label: string;
+  required: boolean;
+  maxAgeSeconds: number | null;
+  prometheus: PrometheusSnapshot;
+  now: Date;
+  logsUrl: string | null;
+}): OperationsSignal {
+  const { id, prometheus, now } = params;
+  const metricJob = id === "migrations_heartbeat" ? "migrations" : id;
+  const successSeconds = numericMetric(prometheus.metrics, "cerp_external_job_last_success_timestamp_seconds", { job: metricJob });
+  const failureSeconds = numericMetric(prometheus.metrics, "cerp_external_job_last_failure_timestamp_seconds", { job: metricJob });
+  const durationSeconds = numericMetric(prometheus.metrics, "cerp_external_job_last_duration_seconds", { job: metricJob });
+  const lastSuccess = successSeconds && successSeconds > 0 ? new Date(successSeconds * 1_000).toISOString() : null;
+  const lastError = failureSeconds && failureSeconds > 0 ? new Date(failureSeconds * 1_000).toISOString() : null;
+  const freshness = freshnessSeconds(now, lastSuccess);
+  const complete = id === "backup_complete" ? numericMetric(prometheus.metrics, "cerp_backup_complete") : null;
+  let state: OperationsState = "operational";
+  let reasonCode: string | null = null;
+  if (!prometheus.available) {
+    state = "unavailable";
+    reasonCode = prometheus.reason_code;
+  } else if (!lastSuccess) {
+    state = "unavailable";
+    reasonCode = "JOB_SUCCESS_HEARTBEAT_MISSING";
+  } else if (lastError && new Date(lastError).getTime() > new Date(lastSuccess).getTime()) {
+    state = "down";
+    reasonCode = "LAST_RUN_FAILED";
+  } else if (complete !== null && complete !== 1) {
+    state = "down";
+    reasonCode = "BACKUP_RECOVERY_SET_INCOMPLETE";
+  } else if (params.maxAgeSeconds !== null && freshness !== null && freshness > params.maxAgeSeconds) {
+    state = "stale";
+    reasonCode = "SUCCESS_HEARTBEAT_STALE";
+  }
+  const facts: OperationsFact[] = [];
+  if (durationSeconds !== null) {
+    facts.push(fact({ key: "duration", label: "Durée du dernier passage", value: durationSeconds, unit: "seconds", period: "dernier passage", source: "prometheus_textfile_heartbeat", reliability: "MEASURED" }, prometheus.observed_at));
+  }
+  if (id === "backup_complete") {
+    for (const [metric, label, unit] of [
+      ["cerp_backup_snapshot_bytes", "Taille logique", "bytes"],
+      ["cerp_backup_document_references", "Références documentaires", "documents"],
+      ["cerp_backup_recovery_point_lag_seconds", "Décalage du point de reprise", "seconds"],
+      ["cerp_backup_repository_bytes", "Dépôt hors site utilisé", "bytes"],
+      ["cerp_backup_repository_capacity_bytes", "Capacité déclarée du dépôt", "bytes"],
+    ] as const) {
+      const value = numericMetric(prometheus.metrics, metric);
+      if (value !== null) facts.push(fact({ key: metric, label, value, unit, period: "dernier recovery set", source: "prometheus_backup_metrics", reliability: "MEASURED" }, prometheus.observed_at));
+    }
+  }
+  return {
+    id,
+    label: params.label,
+    category: id === "migrations_heartbeat" ? "data" : "backups",
+    state,
+    required: params.required,
+    current: state === "operational" ? "OK" : state.toUpperCase(),
+    reason_code: reasonCode,
+    affected_scope: id === "backup_database" ? "database_recovery" : id === "backup_files" ? "ged_and_generated_files_recovery" : id === "backup_complete" ? "complete_db_and_documents_recovery" : "release_database_upgrade",
+    latency_ms: prometheus.latency_ms,
+    observed_at: prometheus.observed_at,
+    freshness_seconds: freshness,
+    last_success_at: lastSuccess,
+    last_error_at: lastError,
+    source: "prometheus_external_job_heartbeat",
+    reliability: prometheus.available ? "MEASURED" : "UNAVAILABLE",
+    runbook_url: id === "migrations_heartbeat" ? RUNBOOKS.migrations : RUNBOOKS.backups,
+    logs_url: params.logsUrl,
+    facts,
+  };
+}
+
+function integrationSignals(
+  webhook: ReturnType<typeof webhookReadiness>,
+  electronicInvoice: Awaited<ReturnType<typeof svcElectronicInvoiceReadiness>> | null,
+  queues: readonly QueueSnapshot[],
+  now: Date,
+  logsUrl: string | null,
+): OperationsSignal[] {
+  const observedAt = now.toISOString();
+  const queueById = new Map(queues.map((queue) => [queue.id, queue]));
+  const webhookQueue = queueById.get("webhook_delivery");
+  const invoiceQueue = queueById.get("electronic_invoicing");
+  return [
+    {
+      id: "integration_webhooks",
+      label: "API partenaires — webhooks",
+      category: "integrations",
+      state: webhook.ready ? "operational" : "unavailable",
+      required: false,
+      current: webhook.ready ? "READY" : "NOT_CONFIGURED",
+      reason_code: webhook.ready ? null : !webhook.encryption_key_configured ? "ENCRYPTION_KEY_NOT_CONFIGURED" : "DELIVERY_DISABLED",
+      affected_scope: "partner_webhook_delivery",
+      latency_ms: null,
+      observed_at: observedAt,
+      freshness_seconds: freshnessSeconds(now, webhookQueue?.last_success_at ?? null),
+      last_success_at: webhookQueue?.last_success_at ?? null,
+      last_error_at: webhookQueue?.last_error_at ?? null,
+      source: "webhook_runtime_configuration",
+      reliability: "CONFIGURED",
+      runbook_url: RUNBOOKS.integrations,
+      logs_url: logsUrl,
+      facts: [
+        fact({ key: "delivery_enabled", label: "Livraison activée", value: webhook.delivery_enabled, unit: "boolean", period: "configuration courante", source: "webhook_runtime_configuration", reliability: "CONFIGURED" }, observedAt),
+      ],
+    },
+    {
+      id: "integration_electronic_invoicing",
+      label: "Facturation électronique — PA",
+      category: "integrations",
+      state: electronicInvoice?.ready ? "operational" : "unavailable",
+      required: false,
+      current: electronicInvoice?.ready ? "READY" : "NOT_QUALIFIED",
+      reason_code: electronicInvoice?.reason ?? "EINVOICE_READINESS_FAILED",
+      affected_scope: "electronic_invoice_exchange",
+      latency_ms: null,
+      observed_at: observedAt,
+      freshness_seconds: freshnessSeconds(now, invoiceQueue?.last_success_at ?? null),
+      last_success_at: invoiceQueue?.last_success_at ?? null,
+      last_error_at: invoiceQueue?.last_error_at ?? null,
+      source: "einvoice_provider_registry",
+      reliability: electronicInvoice ? "MEASURED" : "UNAVAILABLE",
+      runbook_url: RUNBOOKS.integrations,
+      logs_url: logsUrl,
+      facts: electronicInvoice ? [
+        fact({ key: "adapter_count", label: "Adaptateurs chargés", value: electronicInvoice.registered_adapters.length, unit: "adapters", period: "release courante", source: "einvoice_provider_registry", reliability: "MEASURED" }, observedAt),
+      ] : [],
+    },
+  ];
+}
+
+function activeAlerts(prometheus: PrometheusSnapshot): OperationsAlert[] {
+  if (!prometheus.available) return [];
+  return prometheus.alerts
+    .filter((sample) => Boolean(sample.metric.alertname))
+    .map((sample) => ({
+      name: sample.metric.alertname,
+      severity: (["P0", "P1", "P2"] as const).includes(sample.metric.severity as "P0" | "P1" | "P2")
+        ? sample.metric.severity as "P0" | "P1" | "P2"
+        : "UNKNOWN",
+      affected_scope: sample.metric.affected_scope ?? "unknown",
+      observed_at: new Date(sample.value[0] * 1_000).toISOString(),
+      source: "prometheus_alerts",
+      runbook_url: ALERT_RUNBOOKS[sample.metric.alertname] ?? null,
+    }));
+}
+
+const defaultDependencies: OperationsConsoleDependencies = {
+  now: () => new Date(),
+  readiness: () => collectReadiness(pool),
+  migrationLedger: () => repoMigrationLedger(),
+  queueSnapshots: () => repoQueueSnapshots(),
+  patchManifest: () => readPatchManifest(),
+  prometheus: () => collectPrometheus(),
+  runtimeMetrics: getOperationalMetricsSnapshot,
+  webhookReadiness,
+  electronicInvoiceReadiness: svcElectronicInvoiceReadiness,
+  environment: process.env,
+};
+
+export async function getOperationsConsoleSnapshot(
+  overrides: Partial<OperationsConsoleDependencies> = {},
+): Promise<OperationsConsoleSnapshot> {
+  const dependencies = { ...defaultDependencies, ...overrides };
+  const now = dependencies.now();
+  const environment = dependencies.environment;
+  const logsUrl = safeOperatorUrl(environment.CERP_OPERATIONS_LOGS_URL);
+  const dashboardsUrl = safeOperatorUrl(environment.CERP_OPERATIONS_DASHBOARD_URL);
+  const manifest = dependencies.patchManifest();
+  const [readiness, ledgerResult, queues, prometheus, electronicInvoice] = await Promise.all([
+    dependencies.readiness(),
+    dependencies.migrationLedger().catch(() => null),
+    dependencies.queueSnapshots().catch(() => []),
+    dependencies.prometheus(),
+    dependencies.electronicInvoiceReadiness().catch(() => null),
+  ]);
+  const runtimeMetrics = dependencies.runtimeMetrics();
+  const signals: OperationsSignal[] = [
+    {
+      id: "api",
+      label: "API CERP+",
+      category: "runtime",
+      state: readiness.status === "ready" ? "operational" : "down",
+      required: true,
+      current: readiness.status.toUpperCase(),
+      reason_code: readiness.status === "ready" ? null : "REQUIRED_DEPENDENCY_NOT_READY",
+      affected_scope: "all_user_flows",
+      latency_ms: null,
+      observed_at: readiness.observed_at,
+      freshness_seconds: 0,
+      last_success_at: readiness.status === "ready" ? readiness.observed_at : null,
+      last_error_at: readiness.status === "ready" ? null : readiness.observed_at,
+      source: "application_readiness",
+      reliability: "MEASURED",
+      runbook_url: RUNBOOKS.api,
+      logs_url: logsUrl,
+      facts: [
+        fact({ key: "uptime", label: "Disponibilité du processus", value: Math.floor(process.uptime()), unit: "seconds", period: "depuis démarrage du processus", source: "node_process", reliability: "MEASURED" }, readiness.observed_at),
+      ],
+    },
+    ...dependencySignals(readiness, runtimeMetrics, now, logsUrl),
+    migrationSignal(ledgerResult, manifest, now, logsUrl),
+    ...queueSignals(queues, now, logsUrl),
+    ...runtimeJobSignals(runtimeMetrics, now, logsUrl),
+    externalJobSignal({ id: "backup_database", label: "Sauvegarde PostgreSQL", required: true, maxAgeSeconds: 93_600, prometheus, now, logsUrl }),
+    externalJobSignal({ id: "backup_files", label: "Sauvegarde GED et fichiers", required: true, maxAgeSeconds: 93_600, prometheus, now, logsUrl }),
+    externalJobSignal({ id: "backup_complete", label: "Recovery set complet hors site", required: true, maxAgeSeconds: 90_000, prometheus, now, logsUrl }),
+    externalJobSignal({ id: "migrations_heartbeat", label: "Dernière exécution du gate migrations", required: false, maxAgeSeconds: null, prometheus, now, logsUrl }),
+    ...integrationSignals(dependencies.webhookReadiness(), electronicInvoice, queues, now, logsUrl),
+  ];
+  const required = signals.filter((signal) => signal.required);
+  const overall = required.some((signal) => signal.state === "down")
+    ? "down"
+    : required.some((signal) => signal.state !== "operational")
+      ? "degraded"
+      : "operational";
+  const version = runtimeMetadata.version;
+  const commitCandidate = environment.CERP_RELEASE_COMMIT?.trim() || (version !== "unknown" ? version : "");
+  return {
+    observed_at: now.toISOString(),
+    overall_state: overall,
+    read_only: true,
+    service: {
+      name: runtimeMetadata.service,
+      version,
+      commit: /^[a-zA-Z0-9._:-]{7,64}$/.test(commitCandidate) ? commitCandidate : null,
+      environment: runtimeMetadata.environment,
+    },
+    signals,
+    alerts: activeAlerts(prometheus),
+    links: { dashboards: dashboardsUrl, logs: logsUrl },
+    limitations: [
+      "Cette console n'exécute aucune réparation, migration, restauration, purge de file ni libération de quarantaine.",
+      "Les historiques de jobs applicatifs sont limités à la durée de vie du processus ; Prometheus porte l'historique durable.",
+      "Une source non configurée ou inaccessible reste indisponible et n'est jamais assimilée à un succès.",
+    ],
+  };
+}
+
+export const operationsConsoleInternals = {
+  collectPrometheus,
+  readPatchManifest,
+  safeOperatorUrl,
+};

--- a/src/module/admin/types/operations-console.types.ts
+++ b/src/module/admin/types/operations-console.types.ts
@@ -1,0 +1,81 @@
+export type OperationsState = "operational" | "degraded" | "down" | "stale" | "unavailable";
+
+export type OperationsReliability = "MEASURED" | "DERIVED" | "CONFIGURED" | "UNAVAILABLE";
+
+export type OperationsFact = Readonly<{
+  key: string;
+  label: string;
+  value: string | number | boolean | null;
+  unit: string;
+  period: string;
+  source: string;
+  observed_at: string;
+  reliability: OperationsReliability;
+}>;
+
+export type OperationsSignal = Readonly<{
+  id: string;
+  label: string;
+  category: "runtime" | "data" | "documents" | "jobs" | "backups" | "integrations";
+  state: OperationsState;
+  required: boolean;
+  current: string;
+  reason_code: string | null;
+  affected_scope: string;
+  latency_ms: number | null;
+  observed_at: string;
+  freshness_seconds: number | null;
+  last_success_at: string | null;
+  last_error_at: string | null;
+  source: string;
+  reliability: OperationsReliability;
+  runbook_url: string;
+  logs_url: string | null;
+  facts: readonly OperationsFact[];
+}>;
+
+export type OperationsAlert = Readonly<{
+  name: string;
+  severity: "P0" | "P1" | "P2" | "UNKNOWN";
+  affected_scope: string;
+  observed_at: string;
+  source: "prometheus_alerts";
+  runbook_url: string | null;
+}>;
+
+export type OperationsConsoleSnapshot = Readonly<{
+  observed_at: string;
+  overall_state: "operational" | "degraded" | "down";
+  read_only: true;
+  service: Readonly<{
+    name: string;
+    version: string;
+    commit: string | null;
+    environment: string;
+  }>;
+  signals: readonly OperationsSignal[];
+  alerts: readonly OperationsAlert[];
+  links: Readonly<{
+    dashboards: string | null;
+    logs: string | null;
+  }>;
+  limitations: readonly string[];
+}>;
+
+export type QueueSnapshot = Readonly<{
+  id: "advanced_reminders" | "webhook_delivery" | "electronic_invoicing";
+  available: boolean;
+  pending: number;
+  failures: number;
+  oldest_pending_at: string | null;
+  last_success_at: string | null;
+  last_error_at: string | null;
+  latency_ms: number;
+  reason_code: string | null;
+}>;
+
+export type MigrationLedgerSnapshot = Readonly<{
+  registry_exists: boolean;
+  rows: readonly Readonly<{ filename: string; sha256: string; applied_at: string }>[];
+  latency_ms: number;
+}>;

--- a/src/module/facturation/electronic-invoicing/electronic-invoice.service.ts
+++ b/src/module/facturation/electronic-invoicing/electronic-invoice.service.ts
@@ -1,4 +1,5 @@
 import { logger } from "../../../shared/observability/logger";
+import { markJobFinished, markJobStarted } from "../../../shared/observability/metrics";
 import { HttpError } from "../../../utils/httpError";
 import { canonicalJson } from "../domain/finance-policy";
 import type { FinanceActorContext } from "../repository/workflow.repository.shared";
@@ -248,11 +249,14 @@ export function startElectronicInvoiceMaintenance(): () => void {
   const cycle = async () => {
     if (running) return;
     running = true;
+    markJobStarted("electronic_invoicing");
     try {
       for (let processed = 0; processed < 25; processed += 1) {
         if (!(await svcProcessNextElectronicInvoice())) break;
       }
+      markJobFinished("electronic_invoicing", true);
     } catch (error) {
+      markJobFinished("electronic_invoicing", false);
       logger.error("electronic_invoice_worker_failed", {
         failure_code: stringField(error, "code") ?? "EINVOICE_WORKER_ERROR",
       });

--- a/src/module/integrations/webhooks/webhook.service.ts
+++ b/src/module/integrations/webhooks/webhook.service.ts
@@ -4,6 +4,7 @@ import https from "node:https";
 import net from "node:net";
 
 import { logger } from "../../../shared/observability/logger";
+import { markJobFinished, markJobStarted } from "../../../shared/observability/metrics";
 import { HttpError } from "../../../utils/httpError";
 import {
   WEBHOOK_EVENT_REGISTRY,
@@ -404,11 +405,14 @@ export function startWebhookDeliveryMaintenance(): () => void {
   const cycle = async () => {
     if (running) return;
     running = true;
+    markJobStarted("webhook_delivery");
     try {
       for (let processed = 0; processed < 25; processed += 1) {
         if (!(await processNextWebhookDelivery())) break;
       }
+      markJobFinished("webhook_delivery", true);
     } catch (error) {
+      markJobFinished("webhook_delivery", false);
       logger.error("webhook_delivery_worker_failed", { failure_code: safeDeliveryError(error) });
     } finally {
       running = false;

--- a/src/shared/observability/metrics.ts
+++ b/src/shared/observability/metrics.ts
@@ -5,7 +5,13 @@ import { runtimeMetadata } from "./runtime";
 const HTTP_BUCKETS_SECONDS = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10] as const;
 
 type DependencyName = "database" | "ged_storage" | "antivirus" | "realtime";
-type DependencyState = Readonly<{ up: boolean; checkedAtMs: number; latencyMs: number }>;
+type DependencyState = Readonly<{
+  up: boolean;
+  checkedAtMs: number;
+  latencyMs: number;
+  lastSucceededAtMs: number;
+  lastFailedAtMs: number;
+}>;
 type JobState = Readonly<{
   lastStartedAtMs: number;
   lastSucceededAtMs: number;
@@ -69,7 +75,14 @@ export function setDependencyState(
   latencyMs: number,
   checkedAtMs = Date.now()
 ): void {
-  dependencies.set(name, { up, latencyMs, checkedAtMs });
+  const previous = dependencies.get(name);
+  dependencies.set(name, {
+    up,
+    latencyMs,
+    checkedAtMs,
+    lastSucceededAtMs: up ? checkedAtMs : previous?.lastSucceededAtMs ?? 0,
+    lastFailedAtMs: up ? previous?.lastFailedAtMs ?? 0 : checkedAtMs,
+  });
 }
 
 export function setGedCapacity(capacity: {
@@ -126,6 +139,20 @@ export function setGedQuarantineMetrics(input: {
   oldestAgeSeconds: number;
 } | null): void {
   gedQuarantine = input;
+}
+
+export function getOperationalMetricsSnapshot(): Readonly<{
+  dependencies: Readonly<Record<string, DependencyState>>;
+  jobs: Readonly<Record<string, JobState>>;
+  ged_capacity: typeof gedCapacity;
+  ged_quarantine: typeof gedQuarantine;
+}> {
+  return {
+    dependencies: Object.fromEntries(dependencies.entries()),
+    jobs: Object.fromEntries(jobs.entries()),
+    ged_capacity: gedCapacity ? { ...gedCapacity } : null,
+    ged_quarantine: gedQuarantine ? { ...gedQuarantine } : null,
+  };
 }
 
 export function renderPrometheusMetrics(pool?: Pool): string {

--- a/src/swagger/generated-route-inventory.ts
+++ b/src/swagger/generated-route-inventory.ts
@@ -8,7 +8,7 @@ export type GeneratedRouteContract = {
   rbac: readonly string[];
 };
 
-export const GENERATED_ROUTE_SOURCE_SHA256 = "b238169ee45fa47245481d4844d29489b9a779b9b0cb4060b7cf2667bd54f78a";
+export const GENERATED_ROUTE_SOURCE_SHA256 = "3168df1774ce027e7360375ded632ab9c1701e47ad833b1f1211785aab868f22";
 export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
@@ -381,7 +381,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/admin/analytics",
-    "source": "src/module/admin/routes/admin.routes.ts:34",
+    "source": "src/module/admin/routes/admin.routes.ts:35",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -518,7 +518,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/admin/login-logs",
-    "source": "src/module/admin/routes/admin.routes.ts:33",
+    "source": "src/module/admin/routes/admin.routes.ts:34",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -535,8 +535,26 @@ export const GENERATED_ROUTE_INVENTORY = [
   },
   {
     "method": "get",
+    "path": "/admin/operations",
+    "source": "src/module/admin/routes/admin.routes.ts:36",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "getOperationsConsole"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/admin/roles",
-    "source": "src/module/admin/routes/admin.routes.ts:27",
+    "source": "src/module/admin/routes/admin.routes.ts:28",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -554,7 +572,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/admin/users",
-    "source": "src/module/admin/routes/admin.routes.ts:26",
+    "source": "src/module/admin/routes/admin.routes.ts:27",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -572,7 +590,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/admin/users",
-    "source": "src/module/admin/routes/admin.routes.ts:29",
+    "source": "src/module/admin/routes/admin.routes.ts:30",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -590,7 +608,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/admin/users/{id}",
-    "source": "src/module/admin/routes/admin.routes.ts:28",
+    "source": "src/module/admin/routes/admin.routes.ts:29",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -608,7 +626,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/admin/users/{id}",
-    "source": "src/module/admin/routes/admin.routes.ts:30",
+    "source": "src/module/admin/routes/admin.routes.ts:31",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -626,7 +644,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/admin/users/{id}/invitations",
-    "source": "src/module/admin/routes/admin.routes.ts:31",
+    "source": "src/module/admin/routes/admin.routes.ts:32",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -644,7 +662,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/admin/users/{id}/password",
-    "source": "src/module/admin/routes/admin.routes.ts:37",
+    "source": "src/module/admin/routes/admin.routes.ts:39",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -662,7 +680,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/admin/users/{id}/password-reset-token",
-    "source": "src/module/admin/routes/admin.routes.ts:36",
+    "source": "src/module/admin/routes/admin.routes.ts:38",
     "middleware": [
       "anonymous",
       "authenticateToken",


### PR DESCRIPTION
# SOL-31 — Console d’exploitation CERP+ — rapport backend

- Date : 2026-08-15
- Issue : `BigFootLime/erp-crp-backend#517`
- Branche : `feature/517-sol31-operations-console`
- Base : `origin/dev` au démarrage
- Projet Office : aucun jeton/API locale disponible dans ce worktree ; issue
  GitHub créée avant modification, sans écriture dans une base de production.

## Diagnostic et cause racine

Les preuves existaient mais restaient réparties entre `collectReadiness`, les
métriques de processus, Prometheus, le registre SQL et plusieurs files métier.
Le navigateur ne disposait d’aucun contrat agrégé et aurait dû connaître la
topologie ou les jetons de supervision. L’historique des trois workers n’était
en outre pas uniformément publié dans les métriques communes.

## Choix d’architecture

- endpoint unique `GET /api/v1/admin/operations`, protégé par authentification
  et marqueur superadmin persistant ;
- lecture seule, réponse `private, no-store`, aucune action sensible ;
- réutilisation des sondes et seuils existants ;
- interrogation Prometheus uniquement depuis le serveur et seulement via une
  URL de configuration ;
- absence/péremption/échec explicites, jamais remplacés par un succès ou zéro ;
- faits exposés avec unité, période, source, fraîcheur et fiabilité ;
- compteurs de files uniquement, sans payload, PII ni contenu GED ;
- jobs webhook et facturation électronique rattachés aux métriques communes.

ADR : `docs/adr/ADR-0077-read-only-operations-console.md`.

## Fichiers modifiés

- module admin : contrôleur, repository, service et types de console ;
- route admin `/operations` ;
- métriques d’historique des dépendances et snapshot interne ;
- instrumentation des workers webhook et facturation électronique ;
- inventaire OpenAPI généré ;
- tests unitaires et RBAC ;
- ADR et présent rapport.

## Migrations et données

Aucune migration, aucun patch SQL, aucune donnée test ou production modifiée.
Le registre de migrations est lu sans écriture et comparé au manifeste livré
dans l’image.

## Tests exécutés

- `pnpm typecheck` : réussi en 13,7 s ;
- 2 fichiers ciblés Vitest, 7 tests : réussis ;
- `pnpm test:run` : 334 fichiers réussis, 2 ignorés ; 4 741 tests
  réussis, 5 ignorés, en 66,57 s ;
- `pnpm test:collection` : 336 fichiers vérifiés, manifeste SHA-256
  `c6369a18b43fa18d91e336d048bb75ea9989520c24cbedb1e6b52e40f93b535e` ;
- `pnpm build` : réussi en 16,4 s, 1 051 opérations OpenAPI inventoriées
  à 100 %, contrat construit valide et 724 fichiers émis conformes à la
  frontière de données de production ;
- `pnpm openapi:check` et `pnpm security:production-data` : réussis ;
- scénario Playwright SOL-31 sur la pile jetable SOL-05 : réussi en 21,0 s
  après 161 migrations isolées et un seed déterministe. Il couvre HTTP 200
  superadmin, HTTP 403 utilisateur standard et la restitution des signaux réels.

## Sécurité, risques et compatibilité

- un utilisateur anonyme reçoit 401 et un utilisateur non-superadmin 403 avant
  toute collecte ;
- les liens avec identifiants intégrés ou protocole dangereux sont rejetés ;
- le token Prometheus n’est jamais sérialisé ;
- le timeout Prometheus est borné à 1,5 s et une réponse supérieure à 1 Mo est
  rejetée ;
- sans configuration Prometheus, l’API métier reste disponible mais les
  sauvegardes sont correctement marquées `unavailable`.

## Rollback

Redéployer le SHA backend précédent. Aucune restauration SQL n’est requise.
Après rollback, valider `/health/live`, `/health/ready`, le login et un flux de
lecture. La pile Prometheus/Alertmanager reste indépendante.

## Reste réel

- Injecter sur chaque cible l’URL interne Prometheus et les liens Grafana réels ;
- ces valeurs ne peuvent pas être inventées ou committées car elles dépendent de
  la topologie opérateur et peuvent être sensibles.

## Summary by Sourcery

Introduce a read-only backend operations console endpoint for superadministrators, aggregating runtime health, queue, backup, and integration signals into a single operational snapshot.

New Features:
- Add protected /api/v1/admin/operations endpoint that returns a read-only operational snapshot for superadmin users.
- Define operations console domain types and services to aggregate readiness checks, queue states, migrations, process metrics, Prometheus data, and alerts into a single snapshot.

Enhancements:
- Extend dependency and job metrics to track last success and failure timestamps and expose an internal operational metrics snapshot.
- Instrument webhook and electronic invoicing workers to emit job lifecycle metrics consumed by the operations console.
- Add repository queries to summarize queue contents and migration ledger without exposing payload data.
- Update generated route inventory and OpenAPI coverage to include the new operations console endpoint.

Documentation:
- Add ADR documenting the design and security boundaries of the read-only operations console, plus an execution report for SOL-31.

Tests:
- Add unit tests for operations console snapshot aggregation, Prometheus and operator URL handling, and ensure secrets are not leaked in responses.
- Add route-level tests to verify RBAC, caching headers, and read-only behavior of the /api/v1/admin/operations endpoint.