### PR TITLE
Promote SOL-32 privileged MFA to main

### DIFF
--- a/db/patches/20260815_privileged_mfa_sol32.sql
+++ b/db/patches/20260815_privileged_mfa_sol32.sql
@@ -1,0 +1,107 @@
+-- SOL-32 — privileged-account TOTP MFA.
+-- Additive, idempotent and safe to replay. Secrets are encrypted by the
+-- application; recovery codes and challenge tokens are stored as keyed or
+-- one-way hashes only.
+
+BEGIN;
+
+DO $preconditions$
+BEGIN
+  IF current_setting('server_version_num')::integer < 140000 THEN
+    RAISE EXCEPTION 'SOL-32 requires PostgreSQL 14 or newer';
+  END IF;
+  IF to_regclass('public.users') IS NULL
+     OR to_regclass('public.realtime_session_epochs') IS NULL
+     OR to_regclass('public.erp_audit_logs') IS NULL THEN
+    RAISE EXCEPTION 'SOL-32 prerequisite relation is missing';
+  END IF;
+END
+$preconditions$;
+
+CREATE TABLE IF NOT EXISTS public.user_mfa_factors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  factor_type text NOT NULL DEFAULT 'TOTP',
+  state text NOT NULL DEFAULT 'PENDING',
+  encrypted_secret bytea NOT NULL,
+  encryption_iv bytea NOT NULL,
+  encryption_tag bytea NOT NULL,
+  key_id text NOT NULL,
+  version integer NOT NULL DEFAULT 1,
+  last_verified_step bigint NULL,
+  failed_attempts integer NOT NULL DEFAULT 0,
+  locked_until timestamptz NULL,
+  pending_expires_at timestamptz NULL,
+  enrolled_at timestamptz NULL,
+  revoked_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_mfa_factor_type_ck CHECK (factor_type = 'TOTP'),
+  CONSTRAINT user_mfa_factor_state_ck CHECK (state IN ('PENDING','ACTIVE','REVOKED')),
+  CONSTRAINT user_mfa_factor_crypto_ck CHECK (
+    octet_length(encrypted_secret) BETWEEN 16 AND 256
+    AND octet_length(encryption_iv) = 12
+    AND octet_length(encryption_tag) = 16
+    AND char_length(key_id) BETWEEN 1 AND 80
+  ),
+  CONSTRAINT user_mfa_factor_counters_ck CHECK (version > 0 AND failed_attempts >= 0),
+  CONSTRAINT user_mfa_factor_lifecycle_ck CHECK (
+    (state = 'PENDING' AND pending_expires_at IS NOT NULL AND enrolled_at IS NULL AND revoked_at IS NULL)
+    OR (state = 'ACTIVE' AND pending_expires_at IS NULL AND enrolled_at IS NOT NULL AND revoked_at IS NULL)
+    OR (state = 'REVOKED' AND revoked_at IS NOT NULL)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_mfa_factors_one_active_uq
+  ON public.user_mfa_factors(user_id) WHERE state = 'ACTIVE';
+CREATE UNIQUE INDEX IF NOT EXISTS user_mfa_factors_one_pending_uq
+  ON public.user_mfa_factors(user_id) WHERE state = 'PENDING';
+CREATE INDEX IF NOT EXISTS user_mfa_factors_user_history_idx
+  ON public.user_mfa_factors(user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.user_mfa_recovery_codes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  factor_id uuid NOT NULL REFERENCES public.user_mfa_factors(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  code_hash text NOT NULL,
+  used_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_mfa_recovery_hash_ck CHECK (code_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT user_mfa_recovery_uq UNIQUE (factor_id, code_hash)
+);
+
+CREATE INDEX IF NOT EXISTS user_mfa_recovery_available_idx
+  ON public.user_mfa_recovery_codes(factor_id, created_at) WHERE used_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS public.auth_mfa_challenges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  factor_id uuid NOT NULL REFERENCES public.user_mfa_factors(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  purpose text NOT NULL,
+  token_hash text NOT NULL UNIQUE,
+  session_epoch integer NOT NULL,
+  attempt_count integer NOT NULL DEFAULT 0,
+  locked_until timestamptz NULL,
+  expires_at timestamptz NOT NULL,
+  used_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT auth_mfa_challenge_purpose_ck CHECK (purpose IN ('LOGIN','ENROLL','REPLACE')),
+  CONSTRAINT auth_mfa_challenge_hash_ck CHECK (token_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT auth_mfa_challenge_counters_ck CHECK (session_epoch >= 0 AND attempt_count >= 0),
+  CONSTRAINT auth_mfa_challenge_expiry_ck CHECK (expires_at > created_at)
+);
+
+CREATE INDEX IF NOT EXISTS auth_mfa_challenges_user_active_idx
+  ON public.auth_mfa_challenges(user_id, purpose, expires_at DESC)
+  WHERE used_at IS NULL;
+
+DO $grants$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT, INSERT, UPDATE ON public.user_mfa_factors TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON public.user_mfa_recovery_codes TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON public.auth_mfa_challenges TO cerp_app;
+  END IF;
+END
+$grants$;
+
+COMMIT;

--- a/db/patches/support/20260815_privileged_mfa_sol32.preflight.sql
+++ b/db/patches/support/20260815_privileged_mfa_sol32.preflight.sql
@@ -1,0 +1,31 @@
+-- Read-only SOL-32 preflight. Run only after a verified backup.
+DO $preflight$
+DECLARE
+  privileged_without_email bigint;
+BEGIN
+  IF current_setting('server_version_num')::integer < 140000 THEN
+    RAISE EXCEPTION 'SOL-32 preflight: PostgreSQL 14 or newer is required';
+  END IF;
+  IF to_regclass('public.users') IS NULL
+     OR to_regclass('public.realtime_session_epochs') IS NULL
+     OR to_regclass('public.erp_audit_logs') IS NULL THEN
+    RAISE EXCEPTION 'SOL-32 preflight: users, realtime_session_epochs and erp_audit_logs are required';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'gen_random_uuid' AND pg_function_is_visible(oid)) THEN
+    RAISE EXCEPTION 'SOL-32 preflight: gen_random_uuid() is unavailable';
+  END IF;
+  SELECT count(*) INTO privileged_without_email
+    FROM public.users
+   WHERE is_superadmin IS TRUE AND status = 'Active' AND NULLIF(btrim(email), '') IS NULL;
+  IF privileged_without_email > 0 THEN
+    RAISE NOTICE 'SOL-32: % active privileged account(s) lack email; recovery remains out-of-band only', privileged_without_email;
+  END IF;
+END
+$preflight$;
+
+SELECT current_database() AS database_name,
+       current_setting('server_version') AS postgres_version,
+       pg_database_size(current_database()) AS database_size_bytes,
+       count(*) FILTER (WHERE is_superadmin IS TRUE AND status = 'Active') AS active_privileged_accounts,
+       now() AS checked_at
+FROM public.users;

--- a/db/patches/support/20260815_privileged_mfa_sol32.rollback.sql
+++ b/db/patches/support/20260815_privileged_mfa_sol32.rollback.sql
@@ -1,0 +1,32 @@
+-- Rollback is permitted only before any factor has been activated. Once MFA
+-- was enrolled, deploy the previous application and retain the evidence.
+BEGIN;
+
+DO $rollback_guard$
+DECLARE
+  active_or_historic bigint := 0;
+BEGIN
+  IF to_regclass('public.user_mfa_factors') IS NOT NULL THEN
+    EXECUTE $$SELECT count(*) FROM public.user_mfa_factors WHERE state <> 'PENDING'$$ INTO active_or_historic;
+  END IF;
+  IF active_or_historic > 0 THEN
+    RAISE EXCEPTION 'SOL-32 rollback refused: enrolled or revoked MFA evidence exists';
+  END IF;
+END
+$rollback_guard$;
+
+DROP TABLE IF EXISTS public.auth_mfa_challenges;
+DROP TABLE IF EXISTS public.user_mfa_recovery_codes;
+DROP TABLE IF EXISTS public.user_mfa_factors;
+
+COMMIT;
+
+DO $verify_rollback$
+BEGIN
+  IF to_regclass('public.user_mfa_factors') IS NOT NULL
+     OR to_regclass('public.user_mfa_recovery_codes') IS NOT NULL
+     OR to_regclass('public.auth_mfa_challenges') IS NOT NULL THEN
+    RAISE EXCEPTION 'SOL-32 rollback verification failed';
+  END IF;
+END
+$verify_rollback$;

--- a/db/patches/support/20260815_privileged_mfa_sol32.verify.sql
+++ b/db/patches/support/20260815_privileged_mfa_sol32.verify.sql
@@ -1,0 +1,38 @@
+DO $verify$
+DECLARE
+  invalid bigint;
+BEGIN
+  IF to_regclass('public.user_mfa_factors') IS NULL
+     OR to_regclass('public.user_mfa_recovery_codes') IS NULL
+     OR to_regclass('public.auth_mfa_challenges') IS NULL THEN
+    RAISE EXCEPTION 'SOL-32 verify: MFA relation is missing';
+  END IF;
+
+  SELECT count(*) INTO invalid
+    FROM public.user_mfa_factors
+   WHERE (state = 'ACTIVE' AND (enrolled_at IS NULL OR revoked_at IS NOT NULL OR pending_expires_at IS NOT NULL))
+      OR (state = 'PENDING' AND (pending_expires_at IS NULL OR enrolled_at IS NOT NULL OR revoked_at IS NOT NULL))
+      OR octet_length(encryption_iv) <> 12
+      OR octet_length(encryption_tag) <> 16;
+  IF invalid > 0 THEN RAISE EXCEPTION 'SOL-32 verify: % invalid MFA factor row(s)', invalid; END IF;
+
+  SELECT count(*) INTO invalid FROM (
+    SELECT user_id FROM public.user_mfa_factors WHERE state = 'ACTIVE' GROUP BY user_id HAVING count(*) > 1
+  ) duplicated;
+  IF invalid > 0 THEN RAISE EXCEPTION 'SOL-32 verify: duplicate active factor'; END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') AND (
+    NOT has_table_privilege('cerp_app', 'public.user_mfa_factors', 'SELECT,INSERT,UPDATE')
+    OR NOT has_table_privilege('cerp_app', 'public.user_mfa_recovery_codes', 'SELECT,INSERT,UPDATE,DELETE')
+    OR NOT has_table_privilege('cerp_app', 'public.auth_mfa_challenges', 'SELECT,INSERT,UPDATE,DELETE')
+  ) THEN
+    RAISE EXCEPTION 'SOL-32 verify: cerp_app grants are invalid';
+  END IF;
+END
+$verify$;
+
+SELECT current_database() AS database_name,
+       (SELECT count(*) FROM public.user_mfa_factors WHERE state = 'ACTIVE') AS active_factors,
+       (SELECT count(*) FROM public.user_mfa_factors WHERE state = 'PENDING') AS pending_factors,
+       (SELECT count(*) FROM public.user_mfa_recovery_codes WHERE used_at IS NULL) AS unused_recovery_codes,
+       now() AS verified_at;

--- a/docs/adr/ADR-0078-privileged-mfa-boundary.md
+++ b/docs/adr/ADR-0078-privileged-mfa-boundary.md
@@ -1,0 +1,77 @@
+# ADR-0078 — Frontière MFA des comptes privilégiés
+
+- Statut : accepté
+- Date : 2026-08-15
+- Décisionnaire : Keenan Martin
+- Portée : SOL-32
+
+## Contexte
+
+Les sessions CERP+ reposaient sur le mot de passe et un JWT. Les actions les
+plus sensibles étaient protégées par le RBAC serveur, mais un mot de passe ou
+un jeton volé suffisait encore à exercer les privilèges d’un superadministrateur.
+Le produit est servi depuis plusieurs origines (Coolify, HYPERBOX2, Electron et
+loopback), ce qui rend un premier déploiement WebAuthn dépendant d’une politique
+de domaines et de RP ID qui n’est pas encore stabilisée.
+
+## Décision
+
+Tout compte actif dont `users.is_superadmin` vaut vrai doit posséder un facteur
+TOTP RFC 6238 actif. Le marqueur persistant est l’autorité ; aucun nom de rôle
+frontend ne peut rendre ou retirer cette obligation.
+
+Après validation du mot de passe, l’API ne délivre pas de session privilégiée :
+elle crée un challenge opaque, court, stocké uniquement sous forme SHA-256 et
+limité en débit. Le premier accès impose l’enrôlement TOTP. Les accès suivants
+acceptent un TOTP dans une dérive de ±30 secondes ou un code de secours à usage
+unique. Un pas TOTP déjà accepté ne peut pas être rejoué.
+
+Le JWT final contient la méthode, la date, l’identifiant et la version du
+facteur. À chaque requête, le backend compare ces preuves au compte et au
+facteur actifs en base. La révocation, le remplacement ou la récupération hors
+bande invalide les anciennes sessions via `realtime_session_epochs`.
+
+Les mutations administratives, de contrôle d’accès, de portail client et de
+webhooks demandent en plus une preuve MFA datant de moins de cinq minutes. Une
+réponse `428 MFA_STEP_UP_REQUIRED` déclenche une boîte de confirmation puis un
+unique rejeu de la requête originale avec le nouveau jeton.
+
+## Secrets, codes et anti-bruteforce
+
+- les graines TOTP sont chiffrées AES-256-GCM avec AAD ;
+- `MFA_ROOT_KEY` contient exactement 32 octets et reste dans le gestionnaire de
+  secrets, séparé des sauvegardes ; `MFA_KEY_ID` trace la version active ;
+- le service refuse de démarrer en production si la clé est absente ou invalide ;
+- les codes de secours ont 80 bits issus du CSPRNG, sont retournés une seule
+  fois et stockés sous HMAC-SHA-256 normalisé ;
+- cinq échecs verrouillent facteur et challenge pendant quinze minutes ; la
+  limite de débit distribuée de l’authentification s’applique aussi aux routes
+  MFA ;
+- les graines, QR codes, codes, mots de passe et jetons ne sont jamais audités
+  ni journalisés.
+
+Une clé est commune uniquement aux instances qui lisent la même base. Les clés
+des environnements séparés restent distinctes. Une rotation de clé racine exige
+une fenêtre opérateur et le remplacement contrôlé des facteurs ; changer la clé
+seule rendrait les graines existantes indéchiffrables et est interdit.
+
+## Cycle de vie et récupération
+
+L’utilisateur peut remplacer son facteur ou régénérer ses codes après mot de
+passe et MFA courante. La révocation du dernier facteur d’un administrateur
+privilégié est refusée. Le seul secours est la commande hors bande documentée :
+elle est en lecture seule par défaut, exige `--apply`, un acquittement daté, un
+motif, verrouille les lignes, révoque le facteur, invalide les sessions et écrit
+un audit durable. Le prochain login impose un nouvel enrôlement.
+
+## Conséquences et rollback
+
+La migration ajoute trois tables sans réécrire `users`. Avant tout enrôlement,
+le rollback SQL peut supprimer ces tables. Dès qu’une preuve active ou révoquée
+existe, le rollback SQL se ferme volontairement : revenir au logiciel précédent
+doit conserver les preuves et s’accompagner d’une restauration cohérente si le
+schéma doit réellement être retiré.
+
+WebAuthn reste une évolution possible lorsque les origines officielles et le
+cycle des clés matérielles seront contractualisés ; TOTP est aujourd’hui le
+facteur interopérable entre les cibles existantes.

--- a/docs/http/openapi-route-coverage.json
+++ b/docs/http/openapi-route-coverage.json
@@ -1,9 +1,9 @@
 {
   "scope": "/api/v1",
-  "source_sha256": "3168df1774ce027e7360375ded632ab9c1701e47ad833b1f1211785aab868f22",
-  "discovered_operations": 1051,
-  "documented_operations": 1051,
+  "source_sha256": "41438efe227fe1d0c476cf21800d48e815f854348d796c10247790e2250dcd10",
+  "discovered_operations": 1057,
+  "documented_operations": 1057,
   "coverage_percent": 100,
-  "authenticated_operations": 1032,
-  "public_operations": 19
+  "authenticated_operations": 1037,
+  "public_operations": 20
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-14T23:34:36.623Z",
+  "started_at": "2026-08-15T04:38:46.103Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 19474,
+    "source_migration": 18133,
     "source_seed": 207,
-    "backup": 800,
-    "preflight": 150,
-    "integrity_before": 616,
-    "migration": 816,
-    "verify": 249,
-    "replay": 122,
-    "integrity_after": 1591,
-    "negative_gate": 47,
-    "rollback": 483,
-    "restore": 4144
+    "backup": 797,
+    "preflight": 159,
+    "integrity_before": 589,
+    "migration": 771,
+    "verify": 254,
+    "replay": 129,
+    "integrity_after": 1527,
+    "negative_gate": 40,
+    "rollback": 434,
+    "restore": 3935
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-14T23:34:59.993Z",
-    "duration_ms": 90,
+    "checked_at": "2026-08-15T04:39:07.937Z",
+    "duration_ms": 108,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36355095"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-UD3u7w\\cerp-test-before-sol06.dump",
-      "bytes": 1968402,
-      "sha256": "3bce4d50b8383a1c0903885dc7143dae47492b34dd4fa32375c7d237feddb8e9",
-      "free_bytes": 412550639616
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-VbkOWG\\cerp-test-before-sol06.dump",
+      "bytes": 1968432,
+      "sha256": "1715b92f0dbdcade9019bf3523018d9893a3927dfaaac7a1f1aa352835d8f1ce",
+      "free_bytes": 406424678400
     },
     "ledger": {
       "applied": 140,
@@ -61,7 +61,8 @@
         "20260814_identification_labels_sol30.sql",
         "20260814_planning_execution_intelligence_0021.sql",
         "20260814_project_operations_sol24.sql",
-        "20260814_sol22_quality_intelligence.sql"
+        "20260814_sol22_quality_intelligence.sql",
+        "20260815_privileged_mfa_sol32.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
@@ -464,13 +465,14 @@
         "20260814_identification_labels_sol30.sql",
         "20260814_planning_execution_intelligence_0021.sql",
         "20260814_project_operations_sol24.sql",
-        "20260814_sol22_quality_intelligence.sql"
+        "20260814_sol22_quality_intelligence.sql",
+        "20260815_privileged_mfa_sol32.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "571b3c86ead55da65df5c337d5e6d7176e9de6a207c7b23c60b765ee4c912c47"
+    "fingerprint": "ca12781f9d6271d3cd9c95ac408d7f83c2d96b765aae62fbefaa3a4a636a9b71"
   },
   "replay": {
     "applied_zero": true,
@@ -478,8 +480,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-14T23:35:03.393Z",
-    "duration_ms": 1576,
+    "checked_at": "2026-08-15T04:39:11.212Z",
+    "duration_ms": 1513,
     "table_counts": {
       "accounting_export_batch_sources": "0",
       "accounting_export_batches": "0",
@@ -541,6 +543,7 @@
       "articles_traitement_families": "0",
       "asbuilt_pack_versions": "0",
       "auth_login_logs": "0",
+      "auth_mfa_challenges": "0",
       "auth_rate_limit_buckets": "0",
       "avoir": "0",
       "avoir_ligne": "0",
@@ -557,7 +560,7 @@
       "centres_frais": "1",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "161",
+      "cerp_schema_migrations": "162",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -909,12 +912,14 @@
       "surface_finishes": "0",
       "traceability_links": "0",
       "units": "4",
+      "user_mfa_factors": "0",
+      "user_mfa_recovery_codes": "0",
       "user_role_assignment_events": "1",
       "user_role_assignments": "14",
       "users": "8",
       "warehouses": "4"
     },
-    "table_count": 432,
+    "table_count": 435,
     "unvalidated_constraints": [
       {
         "table_name": "avoir",
@@ -991,7 +996,7 @@
         "groups": 0
       }
     ],
-    "foreign_key_count": 1212,
+    "foreign_key_count": 1216,
     "orphans": [],
     "readiness": [
       {
@@ -1000,10 +1005,10 @@
         "ready": true,
         "definition": "Calendrier de capacité actif avec jours et horaires explicites.",
         "unit": "calendriers",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1017,10 +1022,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1035,10 +1040,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1061,10 +1066,10 @@
         "ready": true,
         "definition": "Calendrier de capacité actif avec jours et horaires explicites.",
         "unit": "calendriers",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1078,10 +1083,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1096,10 +1101,10 @@
         "ready": true,
         "definition": "Unités canoniques utilisables sans conversion implicite.",
         "unit": "unités",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1116,10 +1121,10 @@
         "ready": true,
         "definition": "Chaque centre de frais actif possède un taux horaire versionné applicable et sourcé.",
         "unit": "EUR/heure",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1134,10 +1139,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1160,10 +1165,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1178,10 +1183,10 @@
         "ready": true,
         "definition": "Au moins un magasin et un emplacement actifs sont reliés au référentiel warehouse/location.",
         "unit": "emplacements",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1197,10 +1202,10 @@
         "ready": true,
         "definition": "Unités canoniques utilisables sans conversion implicite.",
         "unit": "unités",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1235,10 +1240,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-13T22:00:00.000Z",
+        "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-14T23:35:01.821Z",
+        "freshness_at": "2026-08-15T04:39:09.702Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1257,13 +1262,13 @@
       }
     ],
     "ledger": {
-      "applied": 161,
+      "applied": 162,
       "pending": [],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "d869443b127732742355e1abeba144306e68730d69b56959ff85d00a200a3d03"
+    "fingerprint": "9fa0976a5861bceb28157c3a019c0d6d0c4389d83607f70b211c3e1dad25dd7c"
   },
   "negative_gate": {
     "status": "passed",
@@ -1306,7 +1311,7 @@
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "571b3c86ead55da65df5c337d5e6d7176e9de6a207c7b23c60b765ee4c912c47",
+    "fingerprint": "ca12781f9d6271d3cd9c95ac408d7f83c2d96b765aae62fbefaa3a4a636a9b71",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1331,12 +1336,13 @@
         "20260814_identification_labels_sol30.sql",
         "20260814_planning_execution_intelligence_0021.sql",
         "20260814_project_operations_sol24.sql",
-        "20260814_sol22_quality_intelligence.sql"
+        "20260814_sol22_quality_intelligence.sql",
+        "20260815_privileged_mfa_sol32.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-14T23:35:08.257Z"
+  "completed_at": "2026-08-15T04:39:15.783Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-14T23:35:08.257Z
+- Exécutée : 2026-08-15T04:39:15.783Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36355095 octets
-- Sauvegarde : 1968402 octets, SHA-256 `3bce4d50b8383a1c0903885dc7143dae47492b34dd4fa32375c7d237feddb8e9`
-- Patches avant/après : 140 / 161
+- Sauvegarde : 1968432 octets, SHA-256 `1715b92f0dbdcade9019bf3523018d9893a3927dfaaac7a1f1aa352835d8f1ce`
+- Patches avant/après : 140 / 162
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `571b3c86ead55da65df5c337d5e6d7176e9de6a207c7b23c60b765ee4c912c47` / `571b3c86ead55da65df5c337d5e6d7176e9de6a207c7b23c60b765ee4c912c47`
+- Empreinte source/restaurée : `ca12781f9d6271d3cd9c95ac408d7f83c2d96b765aae62fbefaa3a4a636a9b71` / `ca12781f9d6271d3cd9c95ac408d7f83c2d96b765aae62fbefaa3a4a636a9b71`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 19474 |
+| source_migration | 18133 |
 | source_seed | 207 |
-| backup | 800 |
-| preflight | 150 |
-| integrity_before | 616 |
-| migration | 816 |
-| verify | 249 |
-| replay | 122 |
-| integrity_after | 1591 |
-| negative_gate | 47 |
-| rollback | 483 |
-| restore | 4144 |
+| backup | 797 |
+| preflight | 159 |
+| integrity_before | 589 |
+| migration | 771 |
+| verify | 254 |
+| replay | 129 |
+| integrity_after | 1527 |
+| negative_gate | 40 |
+| rollback | 434 |
+| restore | 3935 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/docs/runbooks/privileged-mfa-sol32.md
+++ b/docs/runbooks/privileged-mfa-sol32.md
@@ -1,0 +1,107 @@
+# Runbook — MFA des comptes privilégiés SOL-32
+
+- Propriétaire : Keenan Martin
+- Version : 1, 2026-08-15
+- Gravité : P0 si aucun administrateur ne peut s’authentifier ; P1 pour un seul compte
+
+## Préparation et déploiement
+
+1. Conserver les SHA frontend/backend précédents et passer par la procédure
+   `docs/runbooks/database-upgrade-sol06.md` : sauvegarde complète, checksum,
+   `pg_restore --list`, preflight et fenêtre de migration.
+2. Injecter dans le gestionnaire de secrets de chaque cible :
+   `MFA_ROOT_KEY` (32 octets encodés en 64 caractères hexadécimaux ou base64)
+   et `MFA_KEY_ID=production-v1`. Ne jamais afficher la valeur dans le terminal,
+   un ticket, Git ou le journal Coolify.
+3. Les instances connectées à une même base doivent recevoir exactement la même
+   clé. Les bases test et production séparées doivent utiliser des clés distinctes.
+4. Vérifier la sauvegarde, puis exécuter avec `ON_ERROR_STOP=1` :
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f db/patches/support/20260815_privileged_mfa_sol32.preflight.sql
+corepack pnpm db:patches:up
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f db/patches/support/20260815_privileged_mfa_sol32.verify.sql
+corepack pnpm db:migrations:integrity
+```
+
+5. Déployer le backend, vérifier `/health/live` et `/health/ready`, puis le
+   frontend. Un backend de production sans clé doit échouer au démarrage.
+6. Faire enrôler un second superadministrateur avant toute opération risquée.
+   Vérifier connexion, step-up et conservation hors ligne des codes de secours.
+
+## Symptômes et vérifications sûres
+
+- `MFA_REQUIRED` : l’ancienne session ou le facteur n’est plus valable ; refaire
+  une connexion complète.
+- `MFA_STEP_UP_REQUIRED` : la preuve a plus de cinq minutes ; saisir un nouveau
+  TOTP dans la boîte de confirmation.
+- `MFA_LOCKED` : cinq échecs ; attendre quinze minutes et vérifier l’heure du
+  poste. Ne pas modifier `locked_until` en SQL.
+- `MFA_CHALLENGE_EXPIRED` : recommencer la connexion ; ne pas prolonger le
+  challenge.
+- erreur de déchiffrement ou `Unsupported MFA key id` : arrêter la promotion,
+  vérifier uniquement l’identifiant de clé et la cible du secret. Ne pas créer
+  de nouvelle clé au hasard.
+
+Pour diagnostiquer sans secret : corréler `request_id`, consulter les actions
+`AUTH_MFA_*` dans l’audit et compter facteurs actifs/codes disponibles. Ne jamais
+sélectionner `encrypted_secret`, ni joindre une capture du QR code.
+
+## Remplacement, codes et révocation normale
+
+Dans Administration → Sécurité MFA :
+
+1. confirmer mot de passe et TOTP/code de secours courant ;
+2. choisir le remplacement du facteur ou la régénération des codes ;
+3. pour un remplacement, scanner le nouveau QR et le valider avant de retirer
+   l’ancien appareil ;
+4. sauvegarder les nouveaux codes, qui ne sont montrés qu’une fois ;
+5. vérifier que l’ancienne session ou l’ancien facteur est refusé.
+
+La révocation du dernier facteur privilégié est bloquée. Ne pas contourner le
+RBAC ou modifier directement `user_mfa_factors`.
+
+## Récupération hors bande d’un administrateur verrouillé
+
+Préconditions : console sécurisée sur le backend exact déployé, URL DB injectée
+par le gestionnaire de secrets, sauvegarde vérifiée, deuxième personne informée
+et motif de 12 à 500 caractères.
+
+Lecture seule obligatoire en premier :
+
+```bash
+corepack pnpm auth:mfa:recover -- --username=KEENAN
+```
+
+La sortie donne l’acquittement daté attendu. Après validation humaine, injecter
+`MFA_RECOVERY_APPROVAL=SOL32:KEENAN:AAAA-MM-JJ` et
+`MFA_RECOVERY_REASON=<motif du ticket>`, puis :
+
+```bash
+corepack pnpm auth:mfa:recover -- --username=KEENAN --apply
+```
+
+Critères de succès : `applied:true`, anciennes sessions refusées, événement
+`AUTH_MFA_OUT_OF_BAND_RECOVERY` présent, puis nouvel enrôlement imposé au login.
+Retirer immédiatement les deux variables de récupération du processus.
+
+## Arbre de décision et rollback
+
+- clé absente avant déploiement : ne pas migrer ; provisionner le secret ;
+- migration non appliquée : redéployer les SHA précédents ;
+- tables créées, aucun facteur actif/révoqué : exécuter le rollback SQL seulement
+  après sauvegarde et preflight, puis redéployer les SHA précédents ;
+- un facteur a existé : conserver les tables et redéployer temporairement le
+  backend précédent, ou restaurer la sauvegarde dans une base neuve selon le
+  runbook SOL-06 ; le script de rollback refusera la perte de preuve ;
+- clé perdue : restaurer la clé depuis son coffre séparé. Sans elle, révoquer les
+  facteurs un par un via la procédure hors bande ; ne jamais réinitialiser les
+  graines par SQL.
+
+## Retour au service et post-mortem
+
+Le service est rétabli lorsque deux administrateurs peuvent se connecter avec
+MFA, qu’une mutation exige un step-up, qu’un code de secours est consommé une
+seule fois, que `/health/ready` est vert et que les audits sont corrélables.
+Pour un P0, communiquer début, périmètre, contournement sûr et heure de reprise ;
+conserver SHA, request IDs, chronologie et identifiants d’audit, sans secret.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "db:migrations:preflight": "node scripts/migrations/release-gate.js preflight",
     "db:migrations:integrity": "node scripts/migrations/release-gate.js integrity",
     "db:migrations:rehearse": "node scripts/migrations/release-gate.js rehearse",
+    "auth:mfa:recover": "node scripts/auth/recover-privileged-mfa.mjs",
     "e2e:migrate:isolated": "node scripts/e2e/migrate-isolated.js",
     "e2e:seed:isolated": "node scripts/e2e/seed-isolated.js",
     "e2e:accounting-export:isolated": "node scripts/e2e/accounting-export-sol27-run.js",

--- a/scripts/auth/recover-privileged-mfa.mjs
+++ b/scripts/auth/recover-privileged-mfa.mjs
@@ -1,0 +1,93 @@
+import process from "node:process";
+import dotenv from "dotenv";
+import pg from "pg";
+
+dotenv.config();
+
+const usernameArg = process.argv.find((value) => value.startsWith("--username="));
+const username = usernameArg?.slice("--username=".length).trim().toUpperCase() ?? "";
+const apply = process.argv.includes("--apply");
+const reason = process.env.MFA_RECOVERY_REASON?.trim() ?? "";
+const approval = process.env.MFA_RECOVERY_APPROVAL?.trim() ?? "";
+const expectedApproval = `SOL32:${username}:${new Date().toISOString().slice(0, 10)}`;
+
+if (!username || !/^[A-Z0-9._-]{3,80}$/.test(username)) {
+  throw new Error("Pass --username=ACCOUNT with a canonical privileged username");
+}
+if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is required");
+
+const client = new pg.Client({ connectionString: process.env.DATABASE_URL });
+await client.connect();
+try {
+  const { rows } = await client.query(
+    `SELECT u.id, u.username, u.status, u.is_superadmin,
+            f.id::text AS factor_id, f.version AS factor_version
+       FROM public.users u
+       LEFT JOIN public.user_mfa_factors f ON f.user_id=u.id AND f.state='ACTIVE'
+      WHERE u.username=$1`,
+    [username],
+  );
+  const user = rows[0];
+  if (!user || user.is_superadmin !== true) throw new Error("Privileged account not found");
+  process.stdout.write(JSON.stringify({
+    mode: apply ? "apply" : "dry-run",
+    database: new URL(process.env.DATABASE_URL).pathname.replace(/^\//u, ""),
+    username: user.username,
+    status: user.status,
+    activeFactor: Boolean(user.factor_id),
+    factorVersion: user.factor_version ?? null,
+    requiredApproval: expectedApproval,
+  }, null, 2) + "\n");
+  if (!apply) process.exit(0);
+  if (approval !== expectedApproval) throw new Error("MFA_RECOVERY_APPROVAL does not match the dated approval token");
+  if (reason.length < 12 || reason.length > 500) throw new Error("MFA_RECOVERY_REASON must contain 12 to 500 characters");
+  if (!user.factor_id) throw new Error("No active factor to recover");
+
+  await client.query("BEGIN");
+  const locked = await client.query(
+    `SELECT u.id, f.id::text AS factor_id, f.version
+       FROM public.users u
+       JOIN public.user_mfa_factors f ON f.user_id=u.id AND f.state='ACTIVE'
+      WHERE u.id=$1 AND u.is_superadmin IS TRUE
+      FOR UPDATE OF u, f`,
+    [user.id],
+  );
+  if (!locked.rows[0]) throw new Error("Factor changed since dry-run");
+  await client.query(
+    `UPDATE public.user_mfa_factors
+        SET state='REVOKED', revoked_at=now(), updated_at=now()
+      WHERE id=$1 AND state='ACTIVE'`,
+    [user.factor_id],
+  );
+  await client.query(
+    `INSERT INTO public.realtime_session_epochs(user_id, session_epoch, updated_at)
+     VALUES ($1,1,now())
+     ON CONFLICT (user_id) DO UPDATE
+       SET session_epoch=public.realtime_session_epochs.session_epoch+1, updated_at=now()`,
+    [user.id],
+  );
+  await client.query(
+    `INSERT INTO public.erp_audit_logs
+       (user_id,event_type,action,page_key,entity_type,entity_id,path,details)
+     VALUES ($1,'ACTION','AUTH_MFA_OUT_OF_BAND_RECOVERY','auth-mfa','user_mfa_factor',$2,
+             'cli:recover-privileged-mfa',$3::jsonb)`,
+    [
+      user.id,
+      String(user.id),
+      JSON.stringify({
+        factor_id: user.factor_id,
+        factor_version: user.factor_version,
+        reason,
+        approval: expectedApproval,
+        next_action: "Password login must enroll a new TOTP factor",
+      }),
+    ],
+  );
+  await client.query("COMMIT");
+  process.stdout.write(JSON.stringify({ applied: true, username, sessionsRevoked: true, nextAction: "re-enroll-at-login" }) + "\n");
+} catch (error) {
+  await client.query("ROLLBACK").catch(() => undefined);
+  throw error;
+} finally {
+  await client.end();
+}

--- a/scripts/e2e/seed-mfa-sol32.js
+++ b/scripts/e2e/seed-mfa-sol32.js
@@ -1,0 +1,46 @@
+const bcrypt = require("bcryptjs");
+const { Client } = require("pg");
+
+const { encryptMfaSecret } = require("../../dist/module/auth/domain/mfa.js");
+
+async function main() {
+  const secret = process.env.E2E_MFA_SECRET;
+  const password = process.env.E2E_PASSWORD;
+  if (!secret || !password) throw new Error("E2E_MFA_SECRET and E2E_PASSWORD are required");
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query("BEGIN");
+    const { rows } = await client.query(`SELECT id FROM public.users WHERE username='KEENAN' FOR UPDATE`);
+    const keenan = rows[0];
+    if (!keenan) throw new Error("KEENAN fixture missing");
+    const encrypted = encryptMfaSecret(secret);
+    await client.query(`UPDATE public.user_mfa_factors SET state='REVOKED', revoked_at=now(), updated_at=now() WHERE user_id=$1 AND state<>'REVOKED'`, [keenan.id]);
+    await client.query(
+      `INSERT INTO public.user_mfa_factors
+         (id,user_id,state,encrypted_secret,encryption_iv,encryption_tag,key_id,version,enrolled_at)
+       VALUES ('32000000-0000-4000-8000-000000000001',$1,'ACTIVE',$2,$3,$4,$5,1,now())`,
+      [keenan.id, encrypted.encrypted, encrypted.iv, encrypted.tag, encrypted.keyId],
+    );
+
+    const passwordHash = await bcrypt.hash(password, 10);
+    await client.query(
+      `INSERT INTO public.users(username,password,name,surname,email,role,status,is_superadmin)
+       VALUES ('SOL32ADMIN',$1,'SOL32','Admin','sol32-admin@invalid.example','Administrateur Systeme et Reseau','Active',true)
+       ON CONFLICT (username) DO UPDATE SET password=EXCLUDED.password,status='Active',is_superadmin=true`,
+      [passwordHash],
+    );
+    await client.query("COMMIT");
+    process.stdout.write(JSON.stringify({ seeded: true, activeFactorUser: "KEENAN", enrollmentUser: "SOL32ADMIN" }) + "\n");
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/__tests__/auth-active-account.middleware.test.ts
+++ b/src/__tests__/auth-active-account.middleware.test.ts
@@ -19,6 +19,21 @@ function token(sessionEpoch = 3) {
   return jwt.sign({ id: 9, username: "USER", email: "user@example.test", role: "Employee", session_epoch: sessionEpoch }, secret);
 }
 
+function mfaToken(sessionEpoch = 3) {
+  return jwt.sign({
+    id: 9,
+    username: "ADMIN",
+    email: "admin@example.test",
+    role: "Admin",
+    session_epoch: sessionEpoch,
+    mfa: true,
+    amr: ["pwd", "totp"],
+    mfa_verified_at: Math.floor(Date.now() / 1000),
+    mfa_factor_id: "8c2a19e7-65f3-4cc6-810f-262581aedfc5",
+    mfa_factor_version: 2,
+  }, secret);
+}
+
 describe("live authenticated account lifecycle", () => {
   beforeAll(() => { process.env.JWT_SECRET = secret; });
   afterAll(() => {
@@ -38,5 +53,26 @@ describe("live authenticated account lifecycle", () => {
   it("allows only an active account with the current epoch", async () => {
     mocks.findState.mockResolvedValueOnce({ status: "Active", session_epoch: 3 });
     await request(app).get("/protected").set("Authorization", `Bearer ${token()}`).expect(200, { ok: true });
+  });
+
+  it("rejects privileged legacy or stale-factor sessions and accepts the live factor", async () => {
+    const state = {
+      status: "Active",
+      session_epoch: 3,
+      is_superadmin: true,
+      mfa_required: true,
+      mfa_factor_id: "8c2a19e7-65f3-4cc6-810f-262581aedfc5",
+      mfa_factor_version: 2,
+    };
+    mocks.findState.mockResolvedValueOnce(state);
+    const legacy = await request(app).get("/protected").set("Authorization", `Bearer ${token()}`);
+    expect(legacy.status).toBe(401);
+    expect(legacy.body.code).toBe("MFA_REQUIRED");
+
+    mocks.findState.mockResolvedValueOnce({ ...state, mfa_factor_version: 3 });
+    expect((await request(app).get("/protected").set("Authorization", `Bearer ${mfaToken()}`)).status).toBe(401);
+
+    mocks.findState.mockResolvedValueOnce(state);
+    await request(app).get("/protected").set("Authorization", `Bearer ${mfaToken()}`).expect(200, { ok: true });
   });
 });

--- a/src/__tests__/mfa-assurance.middleware.test.ts
+++ b/src/__tests__/mfa-assurance.middleware.test.ts
@@ -1,0 +1,27 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import { requireRecentMfa, requireRecentMfaForMutations } from "../module/auth/middlewares/mfa-assurance.middleware";
+
+function appWith(user: Record<string, unknown>, mutationsOnly = false) {
+  const app = express();
+  app.use((req, _res, next) => { req.user = user as Express.Request["user"]; next(); });
+  app.all("/critical", mutationsOnly ? requireRecentMfaForMutations : requireRecentMfa(300), (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe("SOL-32 recent MFA assurance", () => {
+  it("requires a recent timestamp when a token carries MFA assurance", async () => {
+    const old = Math.floor(Date.now() / 1000) - 301;
+    const response = await request(appWith({ id: 1, mfa: true, mfa_verified_at: old })).post("/critical");
+    expect(response.status).toBe(428);
+    expect(response.body.code).toBe("MFA_STEP_UP_REQUIRED");
+  });
+
+  it("accepts a recent assurance and leaves reads unchanged", async () => {
+    const recent = Math.floor(Date.now() / 1000) - 10;
+    await request(appWith({ id: 1, mfa: true, mfa_verified_at: recent })).post("/critical").expect(200);
+    await request(appWith({ id: 1, mfa: true, mfa_verified_at: 0 }, true)).get("/critical").expect(200);
+  });
+});

--- a/src/__tests__/mfa.domain.test.ts
+++ b/src/__tests__/mfa.domain.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  assertMfaStartupConfiguration,
+  buildOtpAuthUri,
+  decryptMfaSecret,
+  encryptMfaSecret,
+  generateRecoveryCodes,
+  hashRecoveryCode,
+  totpForStep,
+  verifyTotp,
+} from "../module/auth/domain/mfa";
+
+const originalRootKey = process.env.MFA_ROOT_KEY;
+const originalKeyId = process.env.MFA_KEY_ID;
+
+describe("SOL-32 MFA cryptography", () => {
+  beforeEach(() => {
+    process.env.MFA_ROOT_KEY = "11".repeat(32);
+    process.env.MFA_KEY_ID = "test-v1";
+  });
+  afterEach(() => {
+    if (originalRootKey === undefined) delete process.env.MFA_ROOT_KEY;
+    else process.env.MFA_ROOT_KEY = originalRootKey;
+    if (originalKeyId === undefined) delete process.env.MFA_KEY_ID;
+    else process.env.MFA_KEY_ID = originalKeyId;
+  });
+
+  it("matches the RFC 6238 SHA-1 vector truncated to six digits", () => {
+    const secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+    expect(totpForStep(secret, 1)).toBe("287082");
+    expect(verifyTotp({ secret, code: "287082", nowMs: 59_000, driftSteps: 0 })).toBe(1);
+  });
+
+  it("accepts only the bounded clock-drift window", () => {
+    const secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+    const previous = totpForStep(secret, 9);
+    expect(verifyTotp({ secret, code: previous, nowMs: 10 * 30_000, driftSteps: 1 })).toBe(9);
+    expect(verifyTotp({ secret, code: previous, nowMs: 11 * 30_000, driftSteps: 1 })).toBeNull();
+  });
+
+  it("encrypts the seed with authenticated encryption and detects the wrong key", () => {
+    const encrypted = encryptMfaSecret("JBSWY3DPEHPK3PXP");
+    expect(encrypted.encrypted.toString("utf8")).not.toContain("JBSWY3DPEHPK3PXP");
+    expect(decryptMfaSecret(encrypted)).toBe("JBSWY3DPEHPK3PXP");
+    process.env.MFA_ROOT_KEY = "22".repeat(32);
+    expect(() => decryptMfaSecret(encrypted)).toThrow();
+  });
+
+  it("uses keyed, normalized recovery hashes and unique display codes", () => {
+    expect(hashRecoveryCode("abcd-1234-efgh")).toBe(hashRecoveryCode("ABCD 1234 EFGH"));
+    const codes = generateRecoveryCodes(10);
+    expect(new Set(codes).size).toBe(10);
+    expect(codes.every((code) => /^[A-Z0-9]{4}(?:-[A-Z0-9]{4}){3}$/.test(code))).toBe(true);
+  });
+
+  it("builds an interoperable otpauth URI without leaking it to logs", () => {
+    const uri = buildOtpAuthUri({ username: "KEENAN", secret: "JBSWY3DPEHPK3PXP" });
+    expect(uri).toContain("otpauth://totp/CERP%2B%3AKEENAN");
+    expect(uri).toContain("algorithm=SHA1&digits=6&period=30");
+  });
+
+  it("fails closed at startup when production key material is absent or malformed", () => {
+    expect(() => assertMfaStartupConfiguration({ NODE_ENV: "production" })).toThrow(/MFA_ROOT_KEY is required/);
+    expect(() => assertMfaStartupConfiguration({ NODE_ENV: "production", MFA_ROOT_KEY: "too-short" })).toThrow(
+      /exactly 32 bytes/,
+    );
+    expect(() => assertMfaStartupConfiguration({
+      NODE_ENV: "production",
+      MFA_ROOT_KEY: "33".repeat(32),
+      MFA_KEY_ID: "production-v1",
+    })).not.toThrow();
+  });
+});

--- a/src/__tests__/privileged-mfa-sol32.migration-guards.test.ts
+++ b/src/__tests__/privileged-mfa-sol32.migration-guards.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "../..");
+const read = (relative: string) => fs.readFileSync(path.join(root, relative), "utf8");
+
+describe("SOL-32 migration guards", () => {
+  const patch = read("db/patches/20260815_privileged_mfa_sol32.sql");
+  const preflight = read("db/patches/support/20260815_privileged_mfa_sol32.preflight.sql");
+  const verify = read("db/patches/support/20260815_privileged_mfa_sol32.verify.sql");
+  const rollback = read("db/patches/support/20260815_privileged_mfa_sol32.rollback.sql");
+  const recoveryCli = read("scripts/auth/recover-privileged-mfa.mjs");
+
+  it("stores only encrypted factor material and one-way challenge evidence", () => {
+    expect(patch).toContain("encrypted_secret bytea NOT NULL");
+    expect(patch).toContain("encryption_tag bytea NOT NULL");
+    expect(patch).toContain("token_hash text NOT NULL UNIQUE");
+    expect(patch).toContain("code_hash text NOT NULL");
+    expect(patch).not.toMatch(/\bsecret\s+text\b/iu);
+  });
+
+  it("prevents concurrent active factors and bounds lifecycle state", () => {
+    expect(patch).toContain("user_mfa_factors_one_active_uq");
+    expect(patch).toContain("WHERE state = 'ACTIVE'");
+    expect(patch).toContain("purpose IN ('LOGIN','ENROLL','REPLACE')");
+    expect(verify).toContain("duplicate active factor");
+  });
+
+  it("ships preflight, postflight and evidence-preserving rollback", () => {
+    expect(preflight).toContain("active_privileged_accounts");
+    expect(verify).toContain("cerp_app grants are invalid");
+    expect(rollback).toContain("rollback refused: enrolled or revoked MFA evidence exists");
+  });
+
+  it("keeps privileged recovery dry-run by default and auditable when applied", () => {
+    expect(recoveryCli).toContain('process.argv.includes("--apply")');
+    expect(recoveryCli).toContain("MFA_RECOVERY_APPROVAL");
+    expect(recoveryCli).toContain("MFA_RECOVERY_REASON");
+    expect(recoveryCli).toContain("AUTH_MFA_OUT_OF_BAND_RECOVERY");
+    expect(recoveryCli).toContain("session_epoch=public.realtime_session_epochs.session_epoch+1");
+    expect(patch).toContain("SELECT, INSERT, UPDATE, DELETE ON public.user_mfa_recovery_codes");
+  });
+});

--- a/src/config/auth-rate-limit.ts
+++ b/src/config/auth-rate-limit.ts
@@ -3,6 +3,7 @@ export type AuthRateLimitEndpoint =
   | "register"
   | "forgotPassword"
   | "resetPassword"
+  | "mfa"
   | "einvoiceWebhook";
 
 export type AuthRateLimitDimension = "ip" | "username" | "email" | "token";
@@ -122,6 +123,13 @@ export function loadAuthRateLimitConfig(env: NodeJS.ProcessEnv = process.env): A
     MINUTE_MS,
     24 * HOUR_MS
   );
+  const mfaWindowMs = readBoundedInteger(
+    env,
+    "AUTH_RATE_LIMIT_MFA_WINDOW_MS",
+    15 * MINUTE_MS,
+    MINUTE_MS,
+    24 * HOUR_MS
+  );
 
   return {
     enabled,
@@ -195,6 +203,16 @@ export function loadAuthRateLimitConfig(env: NodeJS.ProcessEnv = process.env): A
         token: {
           limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_RESET_TOKEN_LIMIT", 10, 1, 10_000),
           windowMs: resetWindowMs,
+        },
+      }),
+      mfa: endpointConfig("closed-error", {
+        ip: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_MFA_IP_LIMIT", 30, 1, 10_000),
+          windowMs: mfaWindowMs,
+        },
+        token: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_MFA_TOKEN_LIMIT", 10, 1, 10_000),
+          windowMs: mfaWindowMs,
         },
       }),
       einvoiceWebhook: endpointConfig("closed-error", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { createServer } from "http";
 
 import pool from "./config/database";
 import { assertE2EIsolation } from "./config/e2e-isolation";
+import { assertMfaStartupConfiguration } from "./module/auth/domain/mfa";
 import { startAuthRateLimitMaintenance } from "./module/auth/services/auth-rate-limit.service";
 import { startExpiredLockMaintenance } from "./module/locks/services/locks.service";
 import { startReminderMaintenance } from "./module/facturation/services/reminder-job.service";
@@ -21,6 +22,7 @@ installStructuredConsole();
 
 async function start(): Promise<void> {
   assertE2EIsolation();
+  assertMfaStartupConfiguration();
   // Run before importing routes: several upload middlewares allocate their
   // private quarantine during module initialization.
   const uploadRoots = preflightSecureUploadStorageRoots();

--- a/src/module/access-control/routes/access-control.routes.ts
+++ b/src/module/access-control/routes/access-control.routes.ts
@@ -2,6 +2,7 @@
 import { Router } from "express";
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { requireRecentMfaForMutations } from "../../auth/middlewares/mfa-assurance.middleware";
 import * as controller from "../controllers/access-control.controller";
 import { requireSuperadmin } from "../middlewares/require-superadmin";
 
@@ -9,7 +10,7 @@ const router = Router();
 
 // Aucun `authorizeRole` ici : le statut superadmin n'est pas un rôle métier et ne
 // doit pas pouvoir être obtenu par une attribution de rôle depuis /admin/users.
-router.use(authenticateToken, requireSuperadmin);
+router.use(authenticateToken, requireSuperadmin, requireRecentMfaForMutations);
 
 router.get("/overview", controller.getOverview);
 router.get("/events", controller.getAccessEvents);

--- a/src/module/admin/routes/admin.routes.ts
+++ b/src/module/admin/routes/admin.routes.ts
@@ -1,6 +1,7 @@
 // src/module/admin/routes/admin.routes.ts
 import { Router } from "express";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { requireRecentMfaForMutations } from "../../auth/middlewares/mfa-assurance.middleware";
 import { requireSuperadmin } from "../../access-control/middlewares/require-superadmin";
 import {
   createPasswordResetTokenAdmin,
@@ -23,6 +24,7 @@ router.use(authenticateToken);
 // module model. The live database marker is authoritative; role labels and a
 // granted Administration module can never authorize account provisioning.
 router.use(requireSuperadmin);
+router.use(requireRecentMfaForMutations);
 
 router.get("/users", listUsersAdmin);
 router.get("/roles", listRolesAdmin);

--- a/src/module/auth/controllers/mfa.controller.ts
+++ b/src/module/auth/controllers/mfa.controller.ts
@@ -1,0 +1,73 @@
+import type { Request, Response } from "express";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import {
+  manageMfaSchema,
+  stepUpMfaSchema,
+  verifyMfaChallengeSchema,
+} from "../validators/auth.validator";
+import {
+  beginMfaReplacement,
+  getMfaStatus,
+  regenerateRecoveryCodes,
+  revokeOwnMfa,
+  stepUpMfa,
+  verifyMfaChallenge,
+  type MfaAuditMeta,
+} from "../services/mfa.service";
+
+function meta(req: Request): MfaAuditMeta {
+  const userAgent = req.headers["user-agent"]?.toString() ?? null;
+  const device = parseDevice(userAgent);
+  return {
+    ip: getClientIp(req),
+    user_agent: userAgent,
+    device_type: device.device_type,
+    os: device.os,
+    browser: device.browser,
+    path: req.originalUrl.split("?", 1)[0] ?? req.path,
+    request_id: req.requestId ?? null,
+  };
+}
+
+function authenticatedUserId(req: Request): number {
+  if (!req.user || typeof req.user.id !== "number") throw new Error("Authenticated user missing");
+  return req.user.id;
+}
+
+export const verifyChallenge = asyncHandler(async (req: Request, res: Response) => {
+  const body = verifyMfaChallengeSchema.parse(req.body);
+  const result = await verifyMfaChallenge(body.challenge_token, body.code, meta(req));
+  return res.status(200).json({ message: "Authentification renforcée validée", ...result });
+});
+
+export const status = asyncHandler(async (req: Request, res: Response) => {
+  return res.status(200).json(await getMfaStatus(authenticatedUserId(req)));
+});
+
+export const stepUp = asyncHandler(async (req: Request, res: Response) => {
+  const body = stepUpMfaSchema.parse(req.body);
+  return res.status(200).json(await stepUpMfa(authenticatedUserId(req), body.code, meta(req)));
+});
+
+export const startReplacement = asyncHandler(async (req: Request, res: Response) => {
+  const body = manageMfaSchema.parse(req.body);
+  return res.status(200).json(await beginMfaReplacement(
+    authenticatedUserId(req), body.current_password, body.code, meta(req),
+  ));
+});
+
+export const recoveryCodes = asyncHandler(async (req: Request, res: Response) => {
+  const body = manageMfaSchema.parse(req.body);
+  return res.status(200).json(await regenerateRecoveryCodes(
+    authenticatedUserId(req), body.current_password, body.code, meta(req),
+  ));
+});
+
+export const revoke = asyncHandler(async (req: Request, res: Response) => {
+  const body = manageMfaSchema.parse(req.body);
+  return res.status(200).json(await revokeOwnMfa(
+    authenticatedUserId(req), body.current_password, body.code, meta(req),
+  ));
+});

--- a/src/module/auth/domain/mfa.ts
+++ b/src/module/auth/domain/mfa.ts
@@ -1,0 +1,186 @@
+import crypto from "node:crypto";
+
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+const TOTP_PERIOD_SECONDS = 30;
+const TOTP_DIGITS = 6;
+const NON_PRODUCTION_ROOT_KEY = Buffer.from(
+  "9ddf1be3a6d4ae10ce5f4d410dd82f30a0e15b5de8388e251ad95ce87eb5206b",
+  "hex",
+);
+
+export type EncryptedMfaSecret = {
+  encrypted: Buffer;
+  iv: Buffer;
+  tag: Buffer;
+  keyId: string;
+};
+
+let warnedAboutFallback = false;
+
+function rootKey(env: NodeJS.ProcessEnv = process.env): Buffer {
+  const raw = env.MFA_ROOT_KEY?.trim();
+  if (raw) {
+    const decoded = /^[0-9a-f]{64}$/i.test(raw)
+      ? Buffer.from(raw, "hex")
+      : Buffer.from(raw, "base64");
+    if (decoded.length !== 32) {
+      throw new Error("MFA_ROOT_KEY must encode exactly 32 bytes");
+    }
+    return decoded;
+  }
+  if (env.NODE_ENV === "production") {
+    throw new Error("MFA_ROOT_KEY is required in production");
+  }
+  if (!warnedAboutFallback && env.NODE_ENV !== "test") {
+    warnedAboutFallback = true;
+    console.warn(JSON.stringify({
+      type: "mfa_non_production_key",
+      message: "MFA_ROOT_KEY is absent; the disposable non-production key is active",
+    }));
+  }
+  return NON_PRODUCTION_ROOT_KEY;
+}
+
+function deriveKey(purpose: "encryption" | "recovery", env: NodeJS.ProcessEnv = process.env): Buffer {
+  return Buffer.from(crypto.hkdfSync(
+    "sha256",
+    rootKey(env),
+    Buffer.from("cerp-sol32-mfa-v1", "utf8"),
+    Buffer.from(purpose, "utf8"),
+    32,
+  ));
+}
+
+export function currentMfaKeyId(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env.MFA_KEY_ID?.trim();
+  if (configured) {
+    if (!/^[A-Za-z0-9._-]{1,80}$/.test(configured)) throw new Error("MFA_KEY_ID is invalid");
+    return configured;
+  }
+  return env.NODE_ENV === "production" ? "production-v1" : "non-production-v1";
+}
+
+export function assertMfaStartupConfiguration(env: NodeJS.ProcessEnv = process.env): void {
+  rootKey(env);
+  currentMfaKeyId(env);
+}
+
+export function encryptMfaSecret(secret: string, env: NodeJS.ProcessEnv = process.env): EncryptedMfaSecret {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", deriveKey("encryption", env), iv);
+  cipher.setAAD(Buffer.from("cerp:user-mfa-factor:v1", "utf8"));
+  const encrypted = Buffer.concat([cipher.update(secret, "utf8"), cipher.final()]);
+  return { encrypted, iv, tag: cipher.getAuthTag(), keyId: currentMfaKeyId(env) };
+}
+
+export function decryptMfaSecret(value: EncryptedMfaSecret, env: NodeJS.ProcessEnv = process.env): string {
+  if (value.keyId !== currentMfaKeyId(env)) {
+    throw new Error(`Unsupported MFA key id: ${value.keyId}`);
+  }
+  const decipher = crypto.createDecipheriv("aes-256-gcm", deriveKey("encryption", env), value.iv);
+  decipher.setAAD(Buffer.from("cerp:user-mfa-factor:v1", "utf8"));
+  decipher.setAuthTag(value.tag);
+  return Buffer.concat([decipher.update(value.encrypted), decipher.final()]).toString("utf8");
+}
+
+export function encodeBase32(input: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let output = "";
+  for (const byte of input) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      output += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) output += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  return output;
+}
+
+export function decodeBase32(input: string): Buffer {
+  const normalized = input.toUpperCase().replace(/=+$/u, "").replace(/\s+/gu, "");
+  let bits = 0;
+  let value = 0;
+  const output: number[] = [];
+  for (const character of normalized) {
+    const index = BASE32_ALPHABET.indexOf(character);
+    if (index < 0) throw new Error("Invalid base32 secret");
+    value = (value << 5) | index;
+    bits += 5;
+    if (bits >= 8) {
+      output.push((value >>> (bits - 8)) & 255);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(output);
+}
+
+export function generateTotpSecret(): string {
+  return encodeBase32(crypto.randomBytes(20));
+}
+
+export function totpForStep(secret: string, step: number): string {
+  const counter = Buffer.alloc(8);
+  counter.writeBigUInt64BE(BigInt(step));
+  const digest = crypto.createHmac("sha1", decodeBase32(secret)).update(counter).digest();
+  const offset = (digest[digest.length - 1] ?? 0) & 0x0f;
+  const binary = ((digest[offset] ?? 0) & 0x7f) << 24
+    | ((digest[offset + 1] ?? 0) & 0xff) << 16
+    | ((digest[offset + 2] ?? 0) & 0xff) << 8
+    | ((digest[offset + 3] ?? 0) & 0xff);
+  return String(binary % 10 ** TOTP_DIGITS).padStart(TOTP_DIGITS, "0");
+}
+
+export function verifyTotp(params: {
+  secret: string;
+  code: string;
+  nowMs?: number;
+  driftSteps?: number;
+}): number | null {
+  const code = params.code.replace(/\s+/gu, "");
+  if (!/^\d{6}$/.test(code)) return null;
+  const currentStep = Math.floor((params.nowMs ?? Date.now()) / 1000 / TOTP_PERIOD_SECONDS);
+  const drift = params.driftSteps ?? 1;
+  for (let delta = -drift; delta <= drift; delta += 1) {
+    const step = currentStep + delta;
+    const expected = totpForStep(params.secret, step);
+    if (crypto.timingSafeEqual(Buffer.from(code), Buffer.from(expected))) return step;
+  }
+  return null;
+}
+
+export function buildOtpAuthUri(params: { username: string; issuer?: string; secret: string }): string {
+  const issuer = params.issuer?.trim() || "CERP+";
+  const label = `${issuer}:${params.username}`;
+  return `otpauth://totp/${encodeURIComponent(label)}?secret=${params.secret}`
+    + `&issuer=${encodeURIComponent(issuer)}&algorithm=SHA1&digits=${TOTP_DIGITS}&period=${TOTP_PERIOD_SECONDS}`;
+}
+
+export function opaqueChallengeToken(): { token: string; hash: string } {
+  const token = crypto.randomBytes(32).toString("base64url");
+  return { token, hash: crypto.createHash("sha256").update(token).digest("hex") };
+}
+
+export function hashChallengeToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+export function normalizeRecoveryCode(code: string): string {
+  return code.toUpperCase().replace(/[^A-Z0-9]/gu, "");
+}
+
+export function hashRecoveryCode(code: string, env: NodeJS.ProcessEnv = process.env): string {
+  return crypto.createHmac("sha256", deriveKey("recovery", env))
+    .update(normalizeRecoveryCode(code))
+    .digest("hex");
+}
+
+export function generateRecoveryCodes(count = 10): string[] {
+  return Array.from({ length: count }, () => {
+    const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    const raw = Array.from({ length: 16 }, () => alphabet[crypto.randomInt(0, alphabet.length)]).join("");
+    return raw.match(/.{1,4}/gu)?.join("-") ?? raw;
+  });
+}

--- a/src/module/auth/domain/session-token.ts
+++ b/src/module/auth/domain/session-token.ts
@@ -1,0 +1,56 @@
+import crypto from "node:crypto";
+import jwt from "jsonwebtoken";
+
+import { authorizationRole, normalizeAssignedRoles } from "./roles";
+
+export type SessionIdentity = {
+  id: number;
+  username: string;
+  email: string | null;
+  role: string;
+  roles?: string[] | null;
+  realtime_session_epoch?: string | number | null;
+};
+
+export type MfaAssurance = {
+  factorId: string;
+  factorVersion: number;
+  verifiedAt: Date;
+  method: "totp" | "recovery_code";
+};
+
+export function issueSessionToken(user: SessionIdentity, mfa?: MfaAssurance) {
+  const assignedRoles = normalizeAssignedRoles(user.role, user.roles ?? undefined);
+  const effectiveRole = authorizationRole(user.role, assignedRoles);
+  const parsedEpoch = Number.parseInt(String(user.realtime_session_epoch ?? "0"), 10);
+  const sessionEpoch = Number.isSafeInteger(parsedEpoch) && parsedEpoch >= 0 ? parsedEpoch : 0;
+  const payload = {
+    id: user.id,
+    username: user.username,
+    email: user.email,
+    role: effectiveRole,
+    primary_role: user.role,
+    roles: assignedRoles,
+    session_epoch: sessionEpoch,
+    jti: crypto.randomUUID(),
+    ...(mfa ? {
+      mfa: true,
+      amr: ["pwd", mfa.method],
+      mfa_verified_at: Math.floor(mfa.verifiedAt.getTime() / 1000),
+      mfa_factor_id: mfa.factorId,
+      mfa_factor_version: mfa.factorVersion,
+    } : {}),
+  };
+  const token = jwt.sign(payload, process.env.JWT_SECRET as string, { expiresIn: "1d" });
+  return {
+    token,
+    user: {
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      role: effectiveRole,
+      primary_role: user.role,
+      roles: assignedRoles,
+    },
+  };
+}

--- a/src/module/auth/middlewares/auth-rate-limit.middleware.ts
+++ b/src/module/auth/middlewares/auth-rate-limit.middleware.ts
@@ -82,6 +82,13 @@ function subjectsFor(endpoint: AuthRateLimitEndpoint, req: Request): AuthRateLim
         { dimension: "token", value: token === null ? null : preserveOpaqueAuthToken(token) },
       ];
     }
+    case "mfa": {
+      const token = bodyString(req, "challenge_token") ?? bodyString(req, "code");
+      return [
+        ip,
+        { dimension: "token", value: token === null ? null : preserveOpaqueAuthToken(token) },
+      ];
+    }
     case "einvoiceWebhook":
       return [ip];
   }
@@ -150,4 +157,5 @@ export const registerRateLimit = createAuthRateLimitMiddleware("register");
 export const loginRateLimit = createAuthRateLimitMiddleware("login");
 export const forgotPasswordRateLimit = createAuthRateLimitMiddleware("forgotPassword");
 export const resetPasswordRateLimit = createAuthRateLimitMiddleware("resetPassword");
+export const mfaRateLimit = createAuthRateLimitMiddleware("mfa");
 export const electronicInvoiceWebhookRateLimit = createAuthRateLimitMiddleware("einvoiceWebhook");

--- a/src/module/auth/middlewares/auth.middleware.ts
+++ b/src/module/auth/middlewares/auth.middleware.ts
@@ -20,6 +20,11 @@ interface JwtPayload {
   primary_role?: string;
   roles?: string[];
   session_epoch?: number;
+  mfa?: boolean;
+  amr?: string[];
+  mfa_verified_at?: number;
+  mfa_factor_id?: string;
+  mfa_factor_version?: number;
 }
 
 declare global {
@@ -99,10 +104,32 @@ export const requireActiveAccount: RequestHandler = (req, res, next) => {
         res.status(401).json({ error: "Token invalide ou expiré" });
         return;
       }
+      if (state.mfa_required && (
+        user.mfa !== true
+        || !user.amr?.some((method) => method === "totp" || method === "recovery_code")
+        || user.mfa_factor_id !== state.mfa_factor_id
+        || user.mfa_factor_version !== state.mfa_factor_version
+      )) {
+        console.warn(JSON.stringify({
+          type: "auth_forbidden",
+          reason: "mfa_assurance_missing_or_stale",
+          requestId: req.requestId ?? null,
+          method: req.method,
+          path: stripQueryFromUrl(req.originalUrl),
+          userId: user.id,
+        }));
+        res.status(401).json({
+          success: false,
+          code: "MFA_REQUIRED",
+          message: "Une nouvelle connexion avec authentification renforcée est requise.",
+        });
+        return;
+      }
       next();
     })
     .catch(next);
 };
+
 
 /**
  * Compatibility wrapper kept for existing routes.

--- a/src/module/auth/middlewares/mfa-assurance.middleware.ts
+++ b/src/module/auth/middlewares/mfa-assurance.middleware.ts
@@ -1,0 +1,31 @@
+import type { RequestHandler } from "express";
+
+export const requireRecentMfa = (maxAgeSeconds = 5 * 60): RequestHandler => (req, res, next) => {
+  // The global authenticateToken middleware rejects a privileged token with no
+  // MFA claim. Keeping this compatibility branch lets isolated route tests and
+  // non-privileged legacy callers exercise their original contracts.
+  if (req.user?.mfa !== true) {
+    next();
+    return;
+  }
+  const verifiedAt = req.user.mfa_verified_at;
+  const age = typeof verifiedAt === "number" ? Math.floor(Date.now() / 1000) - verifiedAt : Number.POSITIVE_INFINITY;
+  if (age >= 0 && age <= maxAgeSeconds) {
+    next();
+    return;
+  }
+  res.status(428).json({
+    success: false,
+    code: "MFA_STEP_UP_REQUIRED",
+    message: "Confirmez votre facteur MFA pour cette action sensible.",
+    details: { max_age_seconds: maxAgeSeconds },
+  });
+};
+
+export const requireRecentMfaForMutations: RequestHandler = (req, res, next) => {
+  if (req.method === "GET" || req.method === "HEAD" || req.method === "OPTIONS") {
+    next();
+    return;
+  }
+  requireRecentMfa()(req, res, next);
+};

--- a/src/module/auth/repository/auth.repository.ts
+++ b/src/module/auth/repository/auth.repository.ts
@@ -99,6 +99,10 @@ export type AuthUserLookupRow = {
 export type AuthenticatedAccountState = {
   status: string | null;
   session_epoch: number;
+  is_superadmin: boolean;
+  mfa_required: boolean;
+  mfa_factor_id: string | null;
+  mfa_factor_version: number | null;
 };
 
 /**
@@ -112,13 +116,20 @@ export const findAuthenticatedAccountState = async (
   const { rows } = await pool.query<{
     status: string | null;
     session_epoch: string;
+    is_superadmin: boolean;
+    mfa_factor_id: string | null;
+    mfa_factor_version: number | null;
   }>(
     `
       SELECT
         users.status,
+        users.is_superadmin,
+        factor.id::text AS mfa_factor_id,
+        factor.version AS mfa_factor_version,
         COALESCE(epochs.session_epoch, 0)::text AS session_epoch
       FROM public.users
       LEFT JOIN public.realtime_session_epochs epochs ON epochs.user_id = users.id
+      LEFT JOIN public.user_mfa_factors factor ON factor.user_id = users.id AND factor.state = 'ACTIVE'
       WHERE users.id = $1
       LIMIT 1
     `,
@@ -130,6 +141,10 @@ export const findAuthenticatedAccountState = async (
   return {
     status: row.status,
     session_epoch: Number.isSafeInteger(sessionEpoch) && sessionEpoch >= 0 ? sessionEpoch : 0,
+    is_superadmin: row.is_superadmin === true,
+    mfa_required: row.is_superadmin === true || Boolean(row.mfa_factor_id),
+    mfa_factor_id: row.mfa_factor_id ?? null,
+    mfa_factor_version: row.mfa_factor_version ?? null,
   };
 };
 

--- a/src/module/auth/routes/auth.routes.ts
+++ b/src/module/auth/routes/auth.routes.ts
@@ -8,12 +8,22 @@ import { getAccessProfile } from '../../access-control/controllers/access-contro
 import {
   forgotPasswordRateLimit,
   loginRateLimit,
+  mfaRateLimit,
   resetPasswordRateLimit,
 } from '../middlewares/auth-rate-limit.middleware';
+import {
+  recoveryCodes,
+  revoke,
+  startReplacement,
+  status,
+  stepUp,
+  verifyChallenge,
+} from '../controllers/mfa.controller';
 
 const router: Router = Router();
 
 router.post('/login', loginRateLimit, login);
+router.post('/mfa/verify', mfaRateLimit, verifyChallenge);
 router.post('/forgot-password', forgotPasswordRateLimit, forgotPassword);
 router.post('/reset-password', resetPasswordRateLimit, resetPassword);
 router.post('/activate', resetPasswordRateLimit, activateAccount);
@@ -26,6 +36,11 @@ router.get(
 // Profil d'accès module (#326) — volontairement SANS authorizeRole : chaque compte,
 // opérateur compris, doit pouvoir charger la navigation à laquelle il a droit.
 router.get('/access-profile', authenticateToken, getAccessProfile);
+router.get('/mfa/status', authenticateToken, status);
+router.post('/mfa/step-up', authenticateToken, mfaRateLimit, stepUp);
+router.post('/mfa/replacement', authenticateToken, mfaRateLimit, startReplacement);
+router.post('/mfa/recovery-codes', authenticateToken, mfaRateLimit, recoveryCodes);
+router.post('/mfa/revoke', authenticateToken, mfaRateLimit, revoke);
 
 
 export default router;

--- a/src/module/auth/services/auth.service.ts
+++ b/src/module/auth/services/auth.service.ts
@@ -1,5 +1,4 @@
 import bcrypt from 'bcryptjs';
-import jwt from 'jsonwebtoken';
 import crypto from "node:crypto";
 import { findUserByUsername } from '../repository/auth.repository';
 import { findUserByUsernameOrEmail, updateUserPassword } from "../repository/auth.repository";
@@ -23,7 +22,6 @@ import {
 
 import { sendPasswordResetEmail } from "./password-reset-email.service";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
-import { authorizationRole, normalizeAssignedRoles } from "../domain/roles";
 import { revokeUserRealtimeSessions } from "../../../sockets/sockeServer";
 import {
   canonicalizeAuthUsername,
@@ -34,6 +32,8 @@ import {
   verifyAccountInvitationToken,
 } from "../domain/account-invitation";
 import { repoActivateAccountInvitation } from "../repository/account-invitation.repository";
+import { issueSessionToken } from "../domain/session-token";
+import { beginMfaAfterPassword } from "./mfa.service";
 
 export const loginUser = async (
   username: string,
@@ -87,23 +87,12 @@ export const loginUser = async (
     throw new ApiError(401, "AUTH_INVALID", invalidMsg);
   }
 
-  const assignedRoles = normalizeAssignedRoles(user.role, user.roles);
-  const effectiveRole = authorizationRole(user.role, assignedRoles);
-  const sessionEpoch = Number.parseInt(String(user.realtime_session_epoch ?? "0"), 10);
-  const token = jwt.sign(
-    {
-      id: user.id,
-      username: user.username,
-      email: user.email,
-      role: effectiveRole,
-      primary_role: user.role,
-      roles: assignedRoles,
-      session_epoch: Number.isSafeInteger(sessionEpoch) && sessionEpoch >= 0 ? sessionEpoch : 0,
-      jti: crypto.randomUUID(),
-    },
-    process.env.JWT_SECRET as string,
-    { expiresIn: "1d" }
-  );
+  const mfa = await beginMfaAfterPassword(user, {
+    ...meta,
+    path: "/api/v1/auth/login",
+  });
+
+  if (mfa) return mfa;
 
   await insertLoginLog({
     user_id: user.id,
@@ -113,17 +102,7 @@ export const loginUser = async (
     ...meta,
   });
 
-  return {
-    token,
-    user: {
-      id: user.id,
-      username: user.username,
-      email: user.email,
-      role: effectiveRole,
-      primary_role: user.role,
-      roles: assignedRoles,
-    },
-  };
+  return issueSessionToken(user);
 };
 
 export async function activateAccountWithInvitation(

--- a/src/module/auth/services/mfa.service.ts
+++ b/src/module/auth/services/mfa.service.ts
@@ -1,0 +1,648 @@
+import bcrypt from "bcryptjs";
+import bwipjs from "bwip-js";
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { withRealtimeOutboxTransaction } from "../../../shared/realtime/realtime-outbox-transaction";
+import { bumpRealtimeSessionEpoch } from "../../../shared/realtime/realtime-control-plane";
+import { ApiError } from "../../../utils/apiError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import {
+  buildOtpAuthUri,
+  decryptMfaSecret,
+  encryptMfaSecret,
+  generateRecoveryCodes,
+  generateTotpSecret,
+  hashChallengeToken,
+  hashRecoveryCode,
+  opaqueChallengeToken,
+  verifyTotp,
+} from "../domain/mfa";
+import { issueSessionToken, type MfaAssurance, type SessionIdentity } from "../domain/session-token";
+import { insertLoginLog } from "../repository/authLog.repository";
+
+const CHALLENGE_TTL_MS = 5 * 60_000;
+const ENROLLMENT_TTL_MS = 15 * 60_000;
+const LOCK_MS = 15 * 60_000;
+const MAX_ATTEMPTS = 5;
+
+export type MfaAuditMeta = {
+  ip: string | null;
+  user_agent: string | null;
+  device_type: string | null;
+  os: string | null;
+  browser: string | null;
+  path: string;
+  request_id?: string | null;
+};
+
+type FactorRow = {
+  id: string;
+  user_id: number;
+  state: "PENDING" | "ACTIVE" | "REVOKED";
+  encrypted_secret: Buffer;
+  encryption_iv: Buffer;
+  encryption_tag: Buffer;
+  key_id: string;
+  version: number;
+  last_verified_step: string | null;
+  failed_attempts: number;
+  locked_until: Date | null;
+  pending_expires_at: Date | null;
+  enrolled_at: Date | null;
+};
+
+type ChallengeRow = {
+  id: string;
+  user_id: number;
+  factor_id: string;
+  purpose: "LOGIN" | "ENROLL" | "REPLACE";
+  session_epoch: number;
+  attempt_count: number;
+  locked_until: Date | null;
+  expires_at: Date;
+  used_at: Date | null;
+  username: string;
+  email: string | null;
+  role: string;
+  roles: string[];
+  status: string;
+  is_superadmin: boolean;
+  realtime_session_epoch: string;
+  factor_state: "PENDING" | "ACTIVE" | "REVOKED";
+  encrypted_secret: Buffer;
+  encryption_iv: Buffer;
+  encryption_tag: Buffer;
+  key_id: string;
+  factor_version: number;
+  last_verified_step: string | null;
+  factor_failed_attempts: number;
+  factor_locked_until: Date | null;
+  pending_expires_at: Date | null;
+};
+
+type UserMfaRow = SessionIdentity & {
+  password: string;
+  status: string;
+  is_superadmin: boolean;
+};
+
+function asSecret(factor: Pick<FactorRow, "encrypted_secret" | "encryption_iv" | "encryption_tag" | "key_id">): string {
+  return decryptMfaSecret({
+    encrypted: factor.encrypted_secret,
+    iv: factor.encryption_iv,
+    tag: factor.encryption_tag,
+    keyId: factor.key_id,
+  });
+}
+
+async function audit(tx: PoolClient, userId: number, action: string, meta: MfaAuditMeta, details: Record<string, unknown>) {
+  await repoInsertAuditLog({
+    user_id: userId,
+    body: {
+      event_type: "ACTION",
+      action,
+      page_key: "auth-mfa",
+      entity_type: "user_mfa_factor",
+      entity_id: String(userId),
+      path: meta.path,
+      details: { ...details, request_id: meta.request_id ?? null },
+    },
+    ip: meta.ip,
+    user_agent: meta.user_agent,
+    device_type: meta.device_type,
+    os: meta.os,
+    browser: meta.browser,
+    tx,
+  });
+}
+
+async function qrDataUrl(uri: string): Promise<string> {
+  const png = await bwipjs.toBuffer({
+    bcid: "qrcode",
+    text: uri,
+    scale: 4,
+    paddingwidth: 4,
+    paddingheight: 4,
+    includetext: false,
+  });
+  return `data:image/png;base64,${Buffer.from(png).toString("base64")}`;
+}
+
+async function loadFactor(tx: PoolClient, userId: number, state: "ACTIVE" | "PENDING", forUpdate = false) {
+  const { rows } = await tx.query<FactorRow>(
+    `SELECT * FROM public.user_mfa_factors
+      WHERE user_id = $1 AND state = $2
+      ORDER BY created_at DESC LIMIT 1${forUpdate ? " FOR UPDATE" : ""}`,
+    [userId, state],
+  );
+  return rows[0] ?? null;
+}
+
+async function loadUser(tx: PoolClient, userId: number, forUpdate = false): Promise<UserMfaRow | null> {
+  const { rows } = await tx.query<UserMfaRow>(
+    `SELECT u.id, u.username, u.email, u.password, u.role, u.status, u.is_superadmin,
+            COALESCE(rse.session_epoch, 0)::text AS realtime_session_epoch,
+            COALESCE((SELECT array_agg(ura.role_key ORDER BY (ura.role_key = u.role) DESC, ura.role_key)
+                        FROM public.user_role_assignments ura WHERE ura.user_id = u.id),
+                     ARRAY[u.role]::text[]) AS roles
+       FROM public.users u
+       LEFT JOIN public.realtime_session_epochs rse ON rse.user_id = u.id
+      WHERE u.id = $1${forUpdate ? " FOR UPDATE OF u" : ""}`,
+    [userId],
+  );
+  return rows[0] ?? null;
+}
+
+async function insertChallenge(
+  tx: PoolClient,
+  params: { userId: number; factorId: string; purpose: ChallengeRow["purpose"]; sessionEpoch: number },
+) {
+  const opaque = opaqueChallengeToken();
+  const ttl = params.purpose === "LOGIN" ? CHALLENGE_TTL_MS : ENROLLMENT_TTL_MS;
+  await tx.query(
+    `UPDATE public.auth_mfa_challenges SET used_at = now()
+      WHERE user_id = $1 AND purpose = $2 AND used_at IS NULL`,
+    [params.userId, params.purpose],
+  );
+  await tx.query(
+    `INSERT INTO public.auth_mfa_challenges
+       (user_id, factor_id, purpose, token_hash, session_epoch, expires_at)
+     VALUES ($1,$2,$3,$4,$5,$6)`,
+    [params.userId, params.factorId, params.purpose, opaque.hash, params.sessionEpoch, new Date(Date.now() + ttl)],
+  );
+  return opaque.token;
+}
+
+async function createPendingFactor(tx: PoolClient, user: UserMfaRow): Promise<{ factor: FactorRow; secret: string }> {
+  const existing = await loadFactor(tx, user.id, "PENDING", true);
+  if (existing && existing.pending_expires_at && existing.pending_expires_at.getTime() > Date.now()) {
+    return { factor: existing, secret: asSecret(existing) };
+  }
+  if (existing) {
+    await tx.query(
+      `UPDATE public.user_mfa_factors SET state='REVOKED', revoked_at=now(), updated_at=now()
+        WHERE id=$1`,
+      [existing.id],
+    );
+  }
+  const active = await loadFactor(tx, user.id, "ACTIVE", true);
+  const secret = generateTotpSecret();
+  const encrypted = encryptMfaSecret(secret);
+  const { rows } = await tx.query<FactorRow>(
+    `INSERT INTO public.user_mfa_factors
+       (user_id, encrypted_secret, encryption_iv, encryption_tag, key_id, version, pending_expires_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7)
+     RETURNING *`,
+    [
+      user.id,
+      encrypted.encrypted,
+      encrypted.iv,
+      encrypted.tag,
+      encrypted.keyId,
+      (active?.version ?? 0) + 1,
+      new Date(Date.now() + ENROLLMENT_TTL_MS),
+    ],
+  );
+  return { factor: rows[0]!, secret };
+}
+
+export type PasswordLoginUser = UserMfaRow;
+
+export async function beginMfaAfterPassword(user: PasswordLoginUser, meta: MfaAuditMeta) {
+  const client = await pool.connect();
+  const result = await withRealtimeOutboxTransaction(client, async (tx) => {
+    const active = await loadFactor(tx, user.id, "ACTIVE", true);
+    const sessionEpoch = Number.parseInt(String(user.realtime_session_epoch ?? "0"), 10) || 0;
+    if (active) {
+      const challenge = await insertChallenge(tx, {
+        userId: user.id,
+        factorId: active.id,
+        purpose: "LOGIN",
+        sessionEpoch,
+      });
+      return { kind: "verify" as const, challenge };
+    }
+    if (!user.is_superadmin) return { kind: "none" as const };
+    const { factor, secret } = await createPendingFactor(tx, user);
+    const challenge = await insertChallenge(tx, {
+      userId: user.id,
+      factorId: factor.id,
+      purpose: "ENROLL",
+      sessionEpoch,
+    });
+    await audit(tx, user.id, "AUTH_MFA_ENROLLMENT_STARTED", meta, {
+      factor_id: factor.id,
+      factor_version: factor.version,
+      method: "TOTP",
+    });
+    return { kind: "enroll" as const, challenge, secret };
+  });
+
+  if (result.kind === "none") return null;
+  if (result.kind === "verify") {
+    return {
+      status: "mfa_required" as const,
+      challenge_token: result.challenge,
+      challenge_expires_in_seconds: CHALLENGE_TTL_MS / 1000,
+      methods: ["totp", "recovery_code"] as const,
+    };
+  }
+  const uri = buildOtpAuthUri({ username: user.username, secret: result.secret });
+  return {
+    status: "mfa_enrollment_required" as const,
+    challenge_token: result.challenge,
+    challenge_expires_in_seconds: ENROLLMENT_TTL_MS / 1000,
+    totp: {
+      issuer: "CERP+",
+      account: user.username,
+      secret: result.secret,
+      otpauth_uri: uri,
+      qr_data_url: await qrDataUrl(uri),
+      digits: 6,
+      period_seconds: 30,
+      algorithm: "SHA1" as const,
+    },
+  };
+}
+
+async function loadChallengeForUpdate(tx: PoolClient, tokenHash: string): Promise<ChallengeRow | null> {
+  const { rows } = await tx.query<ChallengeRow>(
+    `SELECT c.*,
+            u.username, u.email, u.role, u.status, u.is_superadmin,
+            COALESCE(rse.session_epoch, 0)::text AS realtime_session_epoch,
+            COALESCE((SELECT array_agg(ura.role_key ORDER BY (ura.role_key = u.role) DESC, ura.role_key)
+                        FROM public.user_role_assignments ura WHERE ura.user_id = u.id),
+                     ARRAY[u.role]::text[]) AS roles,
+            f.state AS factor_state, f.encrypted_secret, f.encryption_iv, f.encryption_tag,
+            f.key_id, f.version AS factor_version, f.last_verified_step,
+            f.failed_attempts AS factor_failed_attempts, f.locked_until AS factor_locked_until,
+            f.pending_expires_at
+       FROM public.auth_mfa_challenges c
+       JOIN public.users u ON u.id = c.user_id
+       JOIN public.user_mfa_factors f ON f.id = c.factor_id
+       LEFT JOIN public.realtime_session_epochs rse ON rse.user_id = u.id
+      WHERE c.token_hash = $1
+      FOR UPDATE OF c, f, u`,
+    [tokenHash],
+  );
+  return rows[0] ?? null;
+}
+
+function challengeFailure(row: ChallengeRow): { code: string; message: string } | null {
+  const now = Date.now();
+  if (row.used_at) return { code: "MFA_CHALLENGE_USED", message: "Ce défi MFA a déjà été utilisé." };
+  if (row.expires_at.getTime() <= now) return { code: "MFA_CHALLENGE_EXPIRED", message: "Le défi MFA a expiré." };
+  if (row.locked_until && row.locked_until.getTime() > now) return { code: "MFA_LOCKED", message: "Le facteur MFA est temporairement verrouillé." };
+  if (row.factor_locked_until && row.factor_locked_until.getTime() > now) return { code: "MFA_LOCKED", message: "Le facteur MFA est temporairement verrouillé." };
+  if (row.status !== "Active") return { code: "AUTH_INVALID", message: "Identifiants invalides" };
+  if (row.session_epoch !== Number.parseInt(row.realtime_session_epoch, 10)) {
+    return { code: "MFA_CHALLENGE_STALE", message: "La session a changé. Reconnectez-vous." };
+  }
+  if (row.purpose === "LOGIN" && row.factor_state !== "ACTIVE") return { code: "MFA_FACTOR_INVALID", message: "Le facteur MFA n'est plus actif." };
+  if (row.purpose !== "LOGIN" && (row.factor_state !== "PENDING" || !row.pending_expires_at || row.pending_expires_at.getTime() <= now)) {
+    return { code: "MFA_ENROLLMENT_EXPIRED", message: "L'enrôlement MFA a expiré." };
+  }
+  return null;
+}
+
+async function consumeRecoveryCode(tx: PoolClient, factorId: string, code: string): Promise<boolean> {
+  const hash = hashRecoveryCode(code);
+  const { rowCount } = await tx.query(
+    `UPDATE public.user_mfa_recovery_codes SET used_at=now()
+      WHERE factor_id=$1 AND code_hash=$2 AND used_at IS NULL`,
+    [factorId, hash],
+  );
+  return (rowCount ?? 0) === 1;
+}
+
+async function recordFailedAttempt(tx: PoolClient, row: ChallengeRow, meta: MfaAuditMeta) {
+  const next = Math.max(row.attempt_count, row.factor_failed_attempts) + 1;
+  const lockedUntil = next >= MAX_ATTEMPTS ? new Date(Date.now() + LOCK_MS) : null;
+  await tx.query(
+    `UPDATE public.auth_mfa_challenges
+        SET attempt_count=attempt_count+1, locked_until=COALESCE($2, locked_until)
+      WHERE id=$1`,
+    [row.id, lockedUntil],
+  );
+  await tx.query(
+    `UPDATE public.user_mfa_factors
+        SET failed_attempts=failed_attempts+1, locked_until=COALESCE($2, locked_until), updated_at=now()
+      WHERE id=$1`,
+    [row.factor_id, lockedUntil],
+  );
+  await audit(tx, row.user_id, lockedUntil ? "AUTH_MFA_LOCKED" : "AUTH_MFA_VERIFICATION_FAILED", meta, {
+    factor_id: row.factor_id,
+    purpose: row.purpose,
+    attempt: next,
+    locked_until: lockedUntil?.toISOString() ?? null,
+  });
+}
+
+async function recordActiveFactorFailedAttempt(
+  tx: PoolClient,
+  factor: FactorRow,
+  userId: number,
+  meta: MfaAuditMeta,
+) {
+  const next = factor.failed_attempts + 1;
+  const lockedUntil = next >= MAX_ATTEMPTS ? new Date(Date.now() + LOCK_MS) : null;
+  await tx.query(
+    `UPDATE public.user_mfa_factors
+        SET failed_attempts=failed_attempts+1, locked_until=COALESCE($2, locked_until), updated_at=now()
+      WHERE id=$1`,
+    [factor.id, lockedUntil],
+  );
+  await audit(tx, userId, lockedUntil ? "AUTH_MFA_LOCKED" : "AUTH_MFA_VERIFICATION_FAILED", meta, {
+    factor_id: factor.id,
+    purpose: "STEP_UP",
+    attempt: next,
+    locked_until: lockedUntil?.toISOString() ?? null,
+  });
+}
+
+async function insertRecoveryCodes(tx: PoolClient, factorId: string): Promise<string[]> {
+  const codes = generateRecoveryCodes();
+  await tx.query(`DELETE FROM public.user_mfa_recovery_codes WHERE factor_id=$1`, [factorId]);
+  for (const code of codes) {
+    await tx.query(
+      `INSERT INTO public.user_mfa_recovery_codes(factor_id, code_hash) VALUES ($1,$2)`,
+      [factorId, hashRecoveryCode(code)],
+    );
+  }
+  return codes;
+}
+
+export async function verifyMfaChallenge(challengeToken: string, code: string, meta: MfaAuditMeta) {
+  const client = await pool.connect();
+  const outcome = await withRealtimeOutboxTransaction(client, async (tx) => {
+    const row = await loadChallengeForUpdate(tx, hashChallengeToken(challengeToken));
+    if (!row) return { ok: false as const, status: 400, code: "MFA_CHALLENGE_INVALID", message: "Défi MFA invalide." };
+    const failure = challengeFailure(row);
+    if (failure) return { ok: false as const, status: failure.code === "MFA_LOCKED" ? 423 : 400, ...failure };
+
+    const secret = asSecret(row);
+    let method: MfaAssurance["method"] = "totp";
+    const verifiedStep = verifyTotp({ secret, code });
+    let valid = verifiedStep !== null;
+    if (valid && row.last_verified_step !== null && verifiedStep! <= Number.parseInt(row.last_verified_step, 10)) {
+      valid = false;
+    }
+    if (!valid && row.purpose === "LOGIN") {
+      valid = await consumeRecoveryCode(tx, row.factor_id, code);
+      if (valid) method = "recovery_code";
+    }
+    if (!valid) {
+      await recordFailedAttempt(tx, row, meta);
+      return { ok: false as const, status: 401, code: "MFA_CODE_INVALID", message: "Code MFA invalide." };
+    }
+
+    let recoveryCodes: string[] | undefined;
+    if (row.purpose !== "LOGIN") {
+      await tx.query(
+        `UPDATE public.user_mfa_factors
+            SET state='REVOKED', revoked_at=now(), updated_at=now()
+          WHERE user_id=$1 AND state='ACTIVE' AND id<>$2`,
+        [row.user_id, row.factor_id],
+      );
+      await tx.query(
+        `UPDATE public.user_mfa_factors
+            SET state='ACTIVE', enrolled_at=now(), pending_expires_at=NULL,
+                last_verified_step=$2, failed_attempts=0, locked_until=NULL, updated_at=now()
+          WHERE id=$1`,
+        [row.factor_id, verifiedStep],
+      );
+      recoveryCodes = await insertRecoveryCodes(tx, row.factor_id);
+      await bumpRealtimeSessionEpoch(tx, row.user_id);
+      await audit(tx, row.user_id, row.purpose === "REPLACE" ? "AUTH_MFA_FACTOR_REPLACED" : "AUTH_MFA_ENROLLED", meta, {
+        factor_id: row.factor_id,
+        factor_version: row.factor_version,
+        method: "TOTP",
+      });
+    } else {
+      await tx.query(
+        `UPDATE public.user_mfa_factors
+            SET last_verified_step=CASE WHEN $2::bigint IS NULL THEN last_verified_step ELSE $2::bigint END,
+                failed_attempts=0, locked_until=NULL, updated_at=now()
+          WHERE id=$1`,
+        [row.factor_id, verifiedStep],
+      );
+      await audit(tx, row.user_id, method === "recovery_code" ? "AUTH_MFA_RECOVERY_CODE_USED" : "AUTH_MFA_VERIFIED", meta, {
+        factor_id: row.factor_id,
+        factor_version: row.factor_version,
+        method,
+      });
+    }
+    await tx.query(`UPDATE public.auth_mfa_challenges SET used_at=now() WHERE id=$1`, [row.id]);
+    const user = await loadUser(tx, row.user_id);
+    if (!user) return { ok: false as const, status: 401, code: "AUTH_INVALID", message: "Identifiants invalides" };
+    return {
+      ok: true as const,
+      user,
+      factorId: row.factor_id,
+      factorVersion: row.factor_version,
+      method,
+      recoveryCodes,
+    };
+  });
+
+  if (!outcome.ok) throw new ApiError(outcome.status, outcome.code, outcome.message);
+  await insertLoginLog({
+    user_id: outcome.user.id,
+    username_attempt: outcome.user.username,
+    success: true,
+    failure_reason: null,
+    ip: meta.ip,
+    user_agent: meta.user_agent,
+    device_type: meta.device_type,
+    os: meta.os,
+    browser: meta.browser,
+  });
+  const assurance: MfaAssurance = {
+    factorId: outcome.factorId,
+    factorVersion: outcome.factorVersion,
+    verifiedAt: new Date(),
+    method: outcome.method,
+  };
+  return { ...issueSessionToken(outcome.user, assurance), recovery_codes: outcome.recoveryCodes };
+}
+
+async function verifyActiveCode(tx: PoolClient, user: UserMfaRow, code: string, meta: MfaAuditMeta) {
+  const factor = await loadFactor(tx, user.id, "ACTIVE", true);
+  if (!factor) return { ok: false as const, status: 409, code: "MFA_NOT_ENROLLED", message: "Aucun facteur MFA actif." };
+  if (factor.locked_until && factor.locked_until.getTime() > Date.now()) {
+    return { ok: false as const, status: 423, code: "MFA_LOCKED", message: "Le facteur MFA est temporairement verrouillé." };
+  }
+  const step = verifyTotp({ secret: asSecret(factor), code });
+  let method: MfaAssurance["method"] = "totp";
+  let valid = step !== null && (factor.last_verified_step === null || step > Number.parseInt(factor.last_verified_step, 10));
+  if (!valid) {
+    valid = await consumeRecoveryCode(tx, factor.id, code);
+    if (valid) method = "recovery_code";
+  }
+  if (!valid) {
+    await recordActiveFactorFailedAttempt(tx, factor, user.id, meta);
+    return { ok: false as const, status: 401, code: "MFA_CODE_INVALID", message: "Code MFA invalide." };
+  }
+  await tx.query(
+    `UPDATE public.user_mfa_factors
+        SET last_verified_step=CASE WHEN $2::bigint IS NULL THEN last_verified_step ELSE $2::bigint END,
+            failed_attempts=0, locked_until=NULL, updated_at=now()
+      WHERE id=$1`,
+    [factor.id, step],
+  );
+  return { ok: true as const, factor, method };
+}
+
+export async function getMfaStatus(userId: number) {
+  const { rows } = await pool.query<{
+    is_superadmin: boolean;
+    factor_id: string | null;
+    factor_version: number | null;
+    enrolled_at: Date | null;
+    locked_until: Date | null;
+    recovery_codes_remaining: string;
+  }>(
+    `SELECT u.is_superadmin,
+            f.id AS factor_id, f.version AS factor_version, f.enrolled_at, f.locked_until,
+            COALESCE((SELECT count(*) FROM public.user_mfa_recovery_codes rc
+                       WHERE rc.factor_id=f.id AND rc.used_at IS NULL),0)::text AS recovery_codes_remaining
+       FROM public.users u
+       LEFT JOIN public.user_mfa_factors f ON f.user_id=u.id AND f.state='ACTIVE'
+      WHERE u.id=$1`,
+    [userId],
+  );
+  const row = rows[0];
+  if (!row) throw new ApiError(404, "USER_NOT_FOUND", "Utilisateur inconnu.");
+  return {
+    required: row.is_superadmin,
+    enrolled: Boolean(row.factor_id),
+    method: row.factor_id ? "TOTP" : null,
+    factor_version: row.factor_version,
+    enrolled_at: row.enrolled_at?.toISOString() ?? null,
+    locked_until: row.locked_until?.toISOString() ?? null,
+    recovery_codes_remaining: Number.parseInt(row.recovery_codes_remaining, 10),
+  };
+}
+
+async function authenticatedMutation<T>(
+  userId: number,
+  password: string,
+  code: string,
+  meta: MfaAuditMeta,
+  work: (tx: PoolClient, user: UserMfaRow, factor: FactorRow, method: MfaAssurance["method"]) => Promise<T>,
+): Promise<T> {
+  const client = await pool.connect();
+  const outcome = await withRealtimeOutboxTransaction(client, async (tx) => {
+    const user = await loadUser(tx, userId, true);
+    if (!user || user.status !== "Active" || !(await bcrypt.compare(password, user.password))) {
+      return { ok: false as const, status: 401, code: "AUTH_INVALID", message: "Identifiants invalides" };
+    }
+    const verified = await verifyActiveCode(tx, user, code, meta);
+    if (!verified.ok) return verified;
+    return { ok: true as const, value: await work(tx, user, verified.factor, verified.method) };
+  });
+  if (!outcome.ok) throw new ApiError(outcome.status, outcome.code, outcome.message);
+  return outcome.value;
+}
+
+export async function stepUpMfa(userId: number, code: string, meta: MfaAuditMeta) {
+  const client = await pool.connect();
+  const outcome = await withRealtimeOutboxTransaction(client, async (tx) => {
+    const user = await loadUser(tx, userId, true);
+    if (!user || user.status !== "Active") return { ok: false as const, status: 401, code: "AUTH_INVALID", message: "Identifiants invalides" };
+    const verified = await verifyActiveCode(tx, user, code, meta);
+    if (!verified.ok) return verified;
+    await audit(tx, user.id, "AUTH_MFA_STEP_UP", meta, {
+      factor_id: verified.factor.id,
+      factor_version: verified.factor.version,
+      method: verified.method,
+    });
+    return { ok: true as const, user, factor: verified.factor, method: verified.method };
+  });
+  if (!outcome.ok) throw new ApiError(outcome.status, outcome.code, outcome.message);
+  return issueSessionToken(outcome.user, {
+    factorId: outcome.factor.id,
+    factorVersion: outcome.factor.version,
+    verifiedAt: new Date(),
+    method: outcome.method,
+  });
+}
+
+export async function beginMfaReplacement(userId: number, password: string, code: string, meta: MfaAuditMeta) {
+  const value = await authenticatedMutation(userId, password, code, meta, async (tx, user, _factor, method) => {
+    const pending = await createPendingFactor(tx, user);
+    const challenge = await insertChallenge(tx, {
+      userId,
+      factorId: pending.factor.id,
+      purpose: "REPLACE",
+      sessionEpoch: Number.parseInt(String(user.realtime_session_epoch ?? "0"), 10) || 0,
+    });
+    await audit(tx, userId, "AUTH_MFA_REPLACEMENT_STARTED", meta, {
+      factor_id: pending.factor.id,
+      factor_version: pending.factor.version,
+      authorization_method: method,
+    });
+    return { challenge, secret: pending.secret, username: user.username };
+  });
+  const uri = buildOtpAuthUri({ username: value.username, secret: value.secret });
+  return {
+    status: "mfa_replacement_pending" as const,
+    challenge_token: value.challenge,
+    challenge_expires_in_seconds: ENROLLMENT_TTL_MS / 1000,
+    totp: {
+      issuer: "CERP+",
+      account: value.username,
+      secret: value.secret,
+      otpauth_uri: uri,
+      qr_data_url: await qrDataUrl(uri),
+      digits: 6,
+      period_seconds: 30,
+      algorithm: "SHA1" as const,
+    },
+  };
+}
+
+export async function regenerateRecoveryCodes(userId: number, password: string, code: string, meta: MfaAuditMeta) {
+  return authenticatedMutation(userId, password, code, meta, async (tx, user, factor, method) => {
+    const recoveryCodes = await insertRecoveryCodes(tx, factor.id);
+    await audit(tx, user.id, "AUTH_MFA_RECOVERY_CODES_REGENERATED", meta, {
+      factor_id: factor.id,
+      factor_version: factor.version,
+      authorization_method: method,
+      code_count: recoveryCodes.length,
+    });
+    return { recovery_codes: recoveryCodes };
+  });
+}
+
+export async function revokeOwnMfa(userId: number, password: string, code: string, meta: MfaAuditMeta) {
+  return authenticatedMutation(userId, password, code, meta, async (tx, user, factor, method) => {
+    if (user.is_superadmin) {
+      const { rows } = await tx.query<{ count: string }>(
+        `SELECT count(DISTINCT u.id)::text AS count
+           FROM public.users u
+           JOIN public.user_mfa_factors f ON f.user_id=u.id AND f.state='ACTIVE'
+          WHERE u.is_superadmin IS TRUE AND u.status='Active'`,
+      );
+      if (Number.parseInt(rows[0]?.count ?? "0", 10) <= 1) {
+        throw new ApiError(
+          409,
+          "MFA_LAST_PRIVILEGED_FACTOR",
+          "Révocation refusée pour le dernier administrateur protégé. Utilisez le runbook hors bande.",
+        );
+      }
+    }
+    await tx.query(
+      `UPDATE public.user_mfa_factors SET state='REVOKED', revoked_at=now(), updated_at=now() WHERE id=$1`,
+      [factor.id],
+    );
+    await bumpRealtimeSessionEpoch(tx, user.id);
+    await audit(tx, user.id, "AUTH_MFA_REVOKED", meta, {
+      factor_id: factor.id,
+      factor_version: factor.version,
+      authorization_method: method,
+    });
+    return { revoked: true };
+  });
+}

--- a/src/module/auth/validators/auth.validator.ts
+++ b/src/module/auth/validators/auth.validator.ts
@@ -50,3 +50,21 @@ export const activateAccountSchema = z
   .strict();
 
 export type ActivateAccountDTO = z.infer<typeof activateAccountSchema>;
+
+const mfaCode = z
+  .string({ required_error: "Code MFA requis" })
+  .trim()
+  .min(6, "Code MFA invalide")
+  .max(32, "Code MFA invalide");
+
+export const verifyMfaChallengeSchema = z.object({
+  challenge_token: z.string().trim().min(32).max(256),
+  code: mfaCode,
+}).strict();
+
+export const stepUpMfaSchema = z.object({ code: mfaCode }).strict();
+
+export const manageMfaSchema = z.object({
+  current_password: z.string().min(1, "Mot de passe requis").max(512),
+  code: mfaCode,
+}).strict();

--- a/src/module/client-portal/routes/client-portal-admin.routes.ts
+++ b/src/module/client-portal/routes/client-portal-admin.routes.ts
@@ -1,11 +1,13 @@
 import { Router } from "express";
 
 import { requireSuperadmin } from "../../access-control/middlewares/require-superadmin";
+import { requireRecentMfaForMutations } from "../../auth/middlewares/mfa-assurance.middleware";
 import * as controller from "../controllers/client-portal.controller";
 
 const router = Router();
 
 router.use(requireSuperadmin);
+router.use(requireRecentMfaForMutations);
 router.get("/accounts", controller.listAdminAccounts);
 router.post("/accounts", controller.createAdminAccount);
 router.post("/accounts/:accountId/invitations", controller.createAdminInvitation);

--- a/src/module/integrations/webhooks/webhook.routes.ts
+++ b/src/module/integrations/webhooks/webhook.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 
 import { requireSuperadmin } from "../../access-control/middlewares/require-superadmin";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { requireRecentMfaForMutations } from "../../auth/middlewares/mfa-assurance.middleware";
 import {
   getWebhookDeliveries,
   getWebhookEvents,
@@ -19,6 +20,7 @@ const router = Router();
 
 router.use(authenticateToken);
 router.use(requireSuperadmin);
+router.use(requireRecentMfaForMutations);
 
 router.get("/readiness", getWebhookReadiness);
 router.get("/events", getWebhookEvents);

--- a/src/swagger/generated-route-inventory.ts
+++ b/src/swagger/generated-route-inventory.ts
@@ -8,7 +8,7 @@ export type GeneratedRouteContract = {
   rbac: readonly string[];
 };
 
-export const GENERATED_ROUTE_SOURCE_SHA256 = "3168df1774ce027e7360375ded632ab9c1701e47ad833b1f1211785aab868f22";
+export const GENERATED_ROUTE_SOURCE_SHA256 = "41438efe227fe1d0c476cf21800d48e815f854348d796c10247790e2250dcd10";
 export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
@@ -183,60 +183,6 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/admin/access/events",
-    "source": "src/module/access-control/routes/access-control.routes.ts:15",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "authenticateToken",
-      "requireSuperadmin",
-      "controller.getAccessEvents"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "put",
-    "path": "/admin/access/modules/{moduleKey}/default",
-    "source": "src/module/access-control/routes/access-control.routes.ts:21",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "authenticateToken",
-      "requireSuperadmin",
-      "controller.putModuleDefault"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/admin/access/overview",
-    "source": "src/module/access-control/routes/access-control.routes.ts:14",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "authenticateToken",
-      "requireSuperadmin",
-      "controller.getOverview"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/admin/access/reviews",
     "source": "src/module/access-control/routes/access-control.routes.ts:16",
     "middleware": [
       "anonymous",
@@ -244,16 +190,58 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "controller.getAccessReviews"
+      "requireRecentMfaForMutations",
+      "controller.getAccessEvents"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "post",
+    "method": "put",
+    "path": "/admin/access/modules/{moduleKey}/default",
+    "source": "src/module/access-control/routes/access-control.routes.ts:22",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "controller.putModuleDefault"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/admin/access/overview",
+    "source": "src/module/access-control/routes/access-control.routes.ts:15",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "controller.getOverview"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/admin/access/reviews",
     "source": "src/module/access-control/routes/access-control.routes.ts:17",
     "middleware": [
@@ -262,17 +250,19 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "controller.postAccessReview"
+      "requireRecentMfaForMutations",
+      "controller.getAccessReviews"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "get",
-    "path": "/admin/access/reviews/{reviewId}",
+    "method": "post",
+    "path": "/admin/access/reviews",
     "source": "src/module/access-control/routes/access-control.routes.ts:18",
     "middleware": [
       "anonymous",
@@ -280,35 +270,19 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "controller.getAccessReview"
+      "requireRecentMfaForMutations",
+      "controller.postAccessReview"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/admin/access/reviews/{reviewId}/close",
-    "source": "src/module/access-control/routes/access-control.routes.ts:20",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "authenticateToken",
       "requireSuperadmin",
-      "controller.postCloseAccessReview"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "put",
-    "path": "/admin/access/reviews/{reviewId}/users/{userId}/decision",
+    "method": "get",
+    "path": "/admin/access/reviews/{reviewId}",
     "source": "src/module/access-control/routes/access-control.routes.ts:19",
     "middleware": [
       "anonymous",
@@ -316,17 +290,79 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "controller.getAccessReview"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/admin/access/reviews/{reviewId}/close",
+    "source": "src/module/access-control/routes/access-control.routes.ts:21",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "controller.postCloseAccessReview"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "put",
+    "path": "/admin/access/reviews/{reviewId}/users/{userId}/decision",
+    "source": "src/module/access-control/routes/access-control.routes.ts:20",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "controller.putAccessReviewDecision"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "post",
     "path": "/admin/access/unlock-all",
+    "source": "src/module/access-control/routes/access-control.routes.ts:25",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "controller.postUnlockAll"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "put",
+    "path": "/admin/access/users/{userId}/modules",
     "source": "src/module/access-control/routes/access-control.routes.ts:24",
     "middleware": [
       "anonymous",
@@ -334,17 +370,19 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "controller.postUnlockAll"
+      "requireRecentMfaForMutations",
+      "controller.putUserModulesBulk"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "put",
-    "path": "/admin/access/users/{userId}/modules",
+    "path": "/admin/access/users/{userId}/modules/{moduleKey}",
     "source": "src/module/access-control/routes/access-control.routes.ts:23",
     "middleware": [
       "anonymous",
@@ -352,190 +390,172 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "controller.putUserModulesBulk"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "put",
-    "path": "/admin/access/users/{userId}/modules/{moduleKey}",
-    "source": "src/module/access-control/routes/access-control.routes.ts:22",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "authenticateToken",
-      "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "controller.putUserModuleAccess"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "get",
     "path": "/admin/analytics",
-    "source": "src/module/admin/routes/admin.routes.ts:35",
+    "source": "src/module/admin/routes/admin.routes.ts:37",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "getAdminAnalytics"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "get",
     "path": "/admin/client-portal/accounts",
-    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:9",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "requireSuperadmin",
-      "controller.listAdminAccounts"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/admin/client-portal/accounts",
-    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:10",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "requireSuperadmin",
-      "controller.createAdminAccount"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/admin/client-portal/accounts/{accountId}/invitations",
     "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:11",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "requireSuperadmin",
-      "controller.createAdminInvitation"
+      "requireRecentMfaForMutations",
+      "controller.listAdminAccounts"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "patch",
-    "path": "/admin/client-portal/accounts/{accountId}/status",
+    "method": "post",
+    "path": "/admin/client-portal/accounts",
     "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:12",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "requireSuperadmin",
-      "controller.patchAdminAccountStatus"
+      "requireRecentMfaForMutations",
+      "controller.createAdminAccount"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "get",
-    "path": "/admin/client-portal/publications",
+    "method": "post",
+    "path": "/admin/client-portal/accounts/{accountId}/invitations",
     "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:13",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "requireSuperadmin",
-      "controller.listAdminPublications"
+      "requireRecentMfaForMutations",
+      "controller.createAdminInvitation"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "post",
-    "path": "/admin/client-portal/publications",
+    "method": "patch",
+    "path": "/admin/client-portal/accounts/{accountId}/status",
     "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:14",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "requireSuperadmin",
-      "controller.createAdminPublication"
+      "requireRecentMfaForMutations",
+      "controller.patchAdminAccountStatus"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "post",
-    "path": "/admin/client-portal/publications/{publicationId}/revoke",
+    "method": "get",
+    "path": "/admin/client-portal/publications",
     "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:15",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "controller.listAdminPublications"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/admin/client-portal/publications",
+    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:16",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "controller.createAdminPublication"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/admin/client-portal/publications/{publicationId}/revoke",
+    "source": "src/module/client-portal/routes/client-portal-admin.routes.ts:17",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "controller.revokeAdminPublication"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "get",
     "path": "/admin/login-logs",
-    "source": "src/module/admin/routes/admin.routes.ts:34",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "authenticateToken",
-      "requireSuperadmin",
-      "listLoginLogsAdmin"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/admin/operations",
     "source": "src/module/admin/routes/admin.routes.ts:36",
     "middleware": [
       "anonymous",
@@ -543,53 +563,39 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "listLoginLogsAdmin"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/admin/operations",
+    "source": "src/module/admin/routes/admin.routes.ts:38",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "getOperationsConsole"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "get",
     "path": "/admin/roles",
-    "source": "src/module/admin/routes/admin.routes.ts:28",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "authenticateToken",
-      "requireSuperadmin",
-      "listRolesAdmin"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/admin/users",
-    "source": "src/module/admin/routes/admin.routes.ts:27",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "authenticateToken",
-      "requireSuperadmin",
-      "listUsersAdmin"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/admin/users",
     "source": "src/module/admin/routes/admin.routes.ts:30",
     "middleware": [
       "anonymous",
@@ -597,17 +603,19 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "createUserAdmin"
+      "requireRecentMfaForMutations",
+      "listRolesAdmin"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "get",
-    "path": "/admin/users/{id}",
+    "path": "/admin/users",
     "source": "src/module/admin/routes/admin.routes.ts:29",
     "middleware": [
       "anonymous",
@@ -615,16 +623,38 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "getUserAdmin"
+      "requireRecentMfaForMutations",
+      "listUsersAdmin"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "patch",
+    "method": "post",
+    "path": "/admin/users",
+    "source": "src/module/admin/routes/admin.routes.ts:32",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "createUserAdmin"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/admin/users/{id}",
     "source": "src/module/admin/routes/admin.routes.ts:31",
     "middleware": [
@@ -633,143 +663,159 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "getUserAdmin"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "patch",
+    "path": "/admin/users/{id}",
+    "source": "src/module/admin/routes/admin.routes.ts:33",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "patchUserAdmin"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "post",
     "path": "/admin/users/{id}/invitations",
-    "source": "src/module/admin/routes/admin.routes.ts:32",
+    "source": "src/module/admin/routes/admin.routes.ts:34",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "createAccountInvitationAdmin"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "patch",
     "path": "/admin/users/{id}/password",
-    "source": "src/module/admin/routes/admin.routes.ts:39",
+    "source": "src/module/admin/routes/admin.routes.ts:41",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "resetUserPasswordAdmin"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "post",
     "path": "/admin/users/{id}/password-reset-token",
-    "source": "src/module/admin/routes/admin.routes.ts:38",
+    "source": "src/module/admin/routes/admin.routes.ts:40",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "createPasswordResetTokenAdmin"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "get",
     "path": "/admin/webhooks/deliveries",
-    "source": "src/module/integrations/webhooks/webhook.routes.ts:31",
+    "source": "src/module/integrations/webhooks/webhook.routes.ts:33",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "getWebhookDeliveries"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "post",
     "path": "/admin/webhooks/deliveries/{id}/replay",
-    "source": "src/module/integrations/webhooks/webhook.routes.ts:32",
+    "source": "src/module/integrations/webhooks/webhook.routes.ts:34",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "postWebhookReplay"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "get",
     "path": "/admin/webhooks/events",
-    "source": "src/module/integrations/webhooks/webhook.routes.ts:24",
+    "source": "src/module/integrations/webhooks/webhook.routes.ts:26",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "getWebhookEvents"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
     "method": "get",
     "path": "/admin/webhooks/readiness",
-    "source": "src/module/integrations/webhooks/webhook.routes.ts:23",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "authenticateToken",
-      "requireSuperadmin",
-      "getWebhookReadiness"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "get",
-    "path": "/admin/webhooks/subscriptions",
     "source": "src/module/integrations/webhooks/webhook.routes.ts:25",
     "middleware": [
       "anonymous",
@@ -777,16 +823,18 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "getWebhookSubscriptions"
+      "requireRecentMfaForMutations",
+      "getWebhookReadiness"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "post",
+    "method": "get",
     "path": "/admin/webhooks/subscriptions",
     "source": "src/module/integrations/webhooks/webhook.routes.ts:27",
     "middleware": [
@@ -795,34 +843,38 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "postWebhookSubscription"
+      "requireRecentMfaForMutations",
+      "getWebhookSubscriptions"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "get",
-    "path": "/admin/webhooks/subscriptions/{id}",
-    "source": "src/module/integrations/webhooks/webhook.routes.ts:26",
+    "method": "post",
+    "path": "/admin/webhooks/subscriptions",
+    "source": "src/module/integrations/webhooks/webhook.routes.ts:29",
     "middleware": [
       "anonymous",
       "authenticateToken",
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "getWebhookSubscriptionById"
+      "requireRecentMfaForMutations",
+      "postWebhookSubscription"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "patch",
+    "method": "get",
     "path": "/admin/webhooks/subscriptions/{id}",
     "source": "src/module/integrations/webhooks/webhook.routes.ts:28",
     "middleware": [
@@ -831,35 +883,19 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
-      "patchWebhookSubscriptionController"
+      "requireRecentMfaForMutations",
+      "getWebhookSubscriptionById"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
-    ]
-  },
-  {
-    "method": "post",
-    "path": "/admin/webhooks/subscriptions/{id}/rotate-secret",
-    "source": "src/module/integrations/webhooks/webhook.routes.ts:29",
-    "middleware": [
-      "anonymous",
-      "authenticateToken",
-      "moduleAccessGate",
-      "authenticateToken",
       "requireSuperadmin",
-      "postWebhookSecretRotation"
-    ],
-    "authenticated": true,
-    "rbac": [
-      "moduleAccessGate",
-      "requireSuperadmin"
+      "requireRecentMfaForMutations"
     ]
   },
   {
-    "method": "post",
-    "path": "/admin/webhooks/subscriptions/{id}/test",
+    "method": "patch",
+    "path": "/admin/webhooks/subscriptions/{id}",
     "source": "src/module/integrations/webhooks/webhook.routes.ts:30",
     "middleware": [
       "anonymous",
@@ -867,12 +903,54 @@ export const GENERATED_ROUTE_INVENTORY = [
       "moduleAccessGate",
       "authenticateToken",
       "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "patchWebhookSubscriptionController"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/admin/webhooks/subscriptions/{id}/rotate-secret",
+    "source": "src/module/integrations/webhooks/webhook.routes.ts:31",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
+      "postWebhookSecretRotation"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/admin/webhooks/subscriptions/{id}/test",
+    "source": "src/module/integrations/webhooks/webhook.routes.ts:32",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireSuperadmin",
+      "requireRecentMfaForMutations",
       "postWebhookTest"
     ],
     "authenticated": true,
     "rbac": [
       "moduleAccessGate",
-      "requireSuperadmin"
+      "requireSuperadmin",
+      "requireRecentMfaForMutations"
     ]
   },
   {
@@ -1381,7 +1459,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/auth/access-profile",
-    "source": "src/module/auth/routes/auth.routes.ts:28",
+    "source": "src/module/auth/routes/auth.routes.ts:38",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1393,7 +1471,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/auth/activate",
-    "source": "src/module/auth/routes/auth.routes.ts:19",
+    "source": "src/module/auth/routes/auth.routes.ts:29",
     "middleware": [
       "anonymous",
       "resetPasswordRateLimit",
@@ -1405,7 +1483,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/auth/forgot-password",
-    "source": "src/module/auth/routes/auth.routes.ts:17",
+    "source": "src/module/auth/routes/auth.routes.ts:27",
     "middleware": [
       "anonymous",
       "forgotPasswordRateLimit",
@@ -1417,7 +1495,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/auth/login",
-    "source": "src/module/auth/routes/auth.routes.ts:16",
+    "source": "src/module/auth/routes/auth.routes.ts:25",
     "middleware": [
       "anonymous",
       "loginRateLimit",
@@ -1429,7 +1507,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/auth/me",
-    "source": "src/module/auth/routes/auth.routes.ts:20",
+    "source": "src/module/auth/routes/auth.routes.ts:30",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1440,8 +1518,84 @@ export const GENERATED_ROUTE_INVENTORY = [
   },
   {
     "method": "post",
+    "path": "/auth/mfa/recovery-codes",
+    "source": "src/module/auth/routes/auth.routes.ts:42",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "mfaRateLimit",
+      "recoveryCodes"
+    ],
+    "authenticated": true,
+    "rbac": []
+  },
+  {
+    "method": "post",
+    "path": "/auth/mfa/replacement",
+    "source": "src/module/auth/routes/auth.routes.ts:41",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "mfaRateLimit",
+      "startReplacement"
+    ],
+    "authenticated": true,
+    "rbac": []
+  },
+  {
+    "method": "post",
+    "path": "/auth/mfa/revoke",
+    "source": "src/module/auth/routes/auth.routes.ts:43",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "mfaRateLimit",
+      "revoke"
+    ],
+    "authenticated": true,
+    "rbac": []
+  },
+  {
+    "method": "get",
+    "path": "/auth/mfa/status",
+    "source": "src/module/auth/routes/auth.routes.ts:39",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "status"
+    ],
+    "authenticated": true,
+    "rbac": []
+  },
+  {
+    "method": "post",
+    "path": "/auth/mfa/step-up",
+    "source": "src/module/auth/routes/auth.routes.ts:40",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "mfaRateLimit",
+      "stepUp"
+    ],
+    "authenticated": true,
+    "rbac": []
+  },
+  {
+    "method": "post",
+    "path": "/auth/mfa/verify",
+    "source": "src/module/auth/routes/auth.routes.ts:26",
+    "middleware": [
+      "anonymous",
+      "mfaRateLimit",
+      "verifyChallenge"
+    ],
+    "authenticated": false,
+    "rbac": []
+  },
+  {
+    "method": "post",
     "path": "/auth/reset-password",
-    "source": "src/module/auth/routes/auth.routes.ts:18",
+    "source": "src/module/auth/routes/auth.routes.ts:28",
     "middleware": [
       "anonymous",
       "resetPasswordRateLimit",

--- a/src/swagger/openapi-contract.ts
+++ b/src/swagger/openapi-contract.ts
@@ -14,6 +14,7 @@ const PUBLIC_ROUTE_POLICIES: Readonly<Record<string, string>> = {
   "post /auth/activate": "Activation par jeton administratif à usage unique avec limitation de débit.",
   "post /auth/forgot-password": "Demande de récupération non révélatrice avec limitation de débit.",
   "post /auth/login": "Échange d’identifiants contre une session avec limitation de débit distribuée.",
+  "post /auth/mfa/verify": "Vérification d’un challenge MFA signé, court, à usage unique et limité en débit avant émission de session.",
   "post /auth/reset-password": "Réinitialisation par jeton à usage unique avec limitation de débit.",
   "post /electronic-invoicing/webhooks/{providerCode}": "Webhook prestataire authentifié par signature sur le corps brut et limité en débit.",
   "get /environment": "Signal public minimal de routage de base, sans secret ni donnée métier.",


### PR DESCRIPTION
Promotion contrôlée de SOL-32 après suites complètes, E2E réel et répétition de migration/restauration. Contenu dev→main limité au commit MFA validé.

## Summary by Sourcery

Introduce privileged-account MFA flow with TOTP-based challenges, enforcing MFA assurance on admin and access-control mutations and wiring it into the authentication lifecycle.

New Features:
- Add full MFA domain, services, controllers and routes for TOTP enrollment, verification, step-up, replacement, recovery codes and self-revocation.
- Expose MFA status and management endpoints in the auth API, with rate limiting and OpenAPI policy coverage.
- Provide a CLI runbook-backed recovery path for privileged MFA, plus E2E seeding support for fixtures.

Enhancements:
- Refactor session token issuance into a dedicated module that can embed MFA assurance claims in JWTs.
- Tighten active-account checks to require valid, non-stale MFA assurance for privileged users before allowing access.
- Add middleware enforcing recent MFA for sensitive administrative and access-control mutations across admin, client-portal and webhook routes.
- Add startup assertions for MFA key material configuration and database-side guards, including preflight, verify and rollback scripts for the SOL-32 migration.

Build:
- Add an npm script to run the privileged MFA recovery CLI for out-of-band administrator factor recovery.

Documentation:
- Document the SOL-32 privileged MFA boundary with an ADR, operator runbook and updated migration rehearsal notes including new patch and timing metrics.

Tests:
- Add unit and integration tests covering MFA cryptography, assurance middleware behaviour, migration guards and active-account MFA enforcement.
- Update auth middleware tests to validate rejection of legacy or stale-factor privileged sessions and acceptance of live MFA tokens.

Chores:
- Extend auth rate limiting configuration to cover MFA endpoints with IP and token-based quotas, and update swagger route inventory hashes to reflect new routes.