### PR TITLE
release: promote SOL-32 migration selector

### DIFF
--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -67,6 +67,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "d5c203c1c44f61b2b296d8fd08a5a35eb8b65060200119cbf7fe873f215d0f5c",
   "20260814_identification_labels_sol30.sql":
     "e9a2a116945105fbcce2a4ecc7246b3c9708a9d64920ed5f7a8ef94dc3740a7d",
+  "20260815_privileged_mfa_sol32.sql":
+    "1050fe92489eed4e25a75b7810b37545c702bfbb8baa860c46396b9a748545f4",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -112,6 +112,10 @@ const recentSolPatchChecksums = new Map([
     "20260814_identification_labels_sol30.sql",
     "e9a2a116945105fbcce2a4ecc7246b3c9708a9d64920ed5f7a8ef94dc3740a7d",
   ],
+  [
+    "20260815_privileged_mfa_sol32.sql",
+    "1050fe92489eed4e25a75b7810b37545c702bfbb8baa860c46396b9a748545f4",
+  ],
 ]);
 const wave9PatchChecksums = new Map([
   [


### PR DESCRIPTION
Promotes the isolated privileged MFA migration selector fix after targeted tests, typecheck and production build.

## Summary by Sourcery

Promote the SOL-32 privileged MFA database patch to the immutable patch set.

Build:
- Register the SOL-32 privileged MFA migration script and checksum in the db-patches immutable patch configuration.

Tests:
- Extend db patch runner tests to include the SOL-32 privileged MFA migration checksum.