### PR TITLE
docs(sol33): promouvoir les preuves de release

### DIFF
--- a/docs/execution-reports/SOL-33.md
+++ b/docs/execution-reports/SOL-33.md
@@ -71,8 +71,63 @@ même titre dans la carte et le panneau ; la capture montrait l'écran correct.
 Le sélecteur a été resserré sur le rôle de titre, puis le scénario a réussi sur
 une base jetable neuve. Aucun timeout ni assertion métier n'a été assoupli.
 
-Les promotions et déploiements réels seront ajoutés au même rapport après leur
-exécution ; ils ne sont pas déclarés réussis par anticipation.
+## Promotion Git
+
+- commit fonctionnel backend :
+  `1e26f9bf27c47239aae911b2d7c21906a5e31b1f` ;
+- PR backend feature vers `dev` : `#530`, fusionnée ;
+- PR backend `dev` vers `main` : `#531`, SHA
+  `3dc4471abdfe100d9221a9f112c52cf103d1dab0` ;
+- commit fonctionnel frontend :
+  `c0e1f8fe7665073913e4f76b9bffe7a05512772b` ;
+- PR frontend feature vers `dev` : `#738`, fusionnée ;
+- PR frontend `dev` vers `main` : `#739`, SHA
+  `000f6edad3af970d016a6fb7961c5123cfc72d6f`.
+
+Les branches officielles locales `dev` et `main` des deux dépôts ont été
+avancées en fast-forward jusqu'aux références distantes et vérifiées propres.
+Les arbres locaux historiques non liés à SOL-33 n'ont pas été modifiés.
+
+## Sauvegarde, migration et restauration réelles
+
+Le preflight a été exécuté sur `cerp_test` et `cerp_prod` : PostgreSQL 17.10,
+espace disponible, rôle `cerp_app`, tables prérequises et données invalides
+contrôlés. Tous les prérequis SOL-33 étaient verts et les trois tables cibles
+étaient absentes.
+
+Sauvegardes pré-migration conservées hors du répertoire applicatif :
+
+- `cerp_test_pre_sol33_20260815-081709.dump`, 73 136 508 octets, SHA-256
+  `e4a81d043a47866c9a051fcd4e723bbee247367169482fae8a4f2c353e6a8e1a` ;
+- `cerp_prod_pre_sol33_20260815-081709.dump`, 49 665 530 octets, SHA-256
+  `773f8ccf38f71aa3faa9b288fa3edaf9545140b0cccd26edd1d0a05fc5e00765`.
+
+Les deux archives sont en mode `0600`, leur inventaire `pg_restore` est valide.
+La sauvegarde de test a été restaurée dans la base jetable
+`cerp_sol33_restore_20260815`, puis le preflight complet y a réussi ; la base et
+la copie temporaire ont ensuite été supprimées.
+
+Le runner immuable a appliqué uniquement
+`20260815_reference_data_center_sol33.sql`, d'abord sur `cerp_test`, puis sur
+`cerp_prod`. Les deux vérifications post-migration confirment tables, triggers,
+droits et zéro chevauchement. Aucun paramètre métier n'a été créé. Le rejeu sur
+chaque base a appliqué zéro patch.
+
+## Déploiements et preuves live
+
+- HYPERBOX2 : archive Git SHA-256
+  `ed9918695b174e45b6f7b4962ebebe3fc998b38a5e23ec1764f106709b7bdd6c`,
+  release immuable `/srv/cerp/releases/20260815-3dc4471` ; services
+  `cerp-api-test` et `cerp-api` actifs et prêts sur les ports 8082 et 8080 ;
+- les deux readiness HYPERBOX2 publient le SHA backend complet et mesurent DB,
+  GED, antivirus et realtime `up` ; la route anonyme du centre répond `401` ;
+- Coolify backend : déploiement webhook `p13kmu34ypqstvvwn1754voi`, réussi de
+  06:14:24 à 06:20:26 UTC, application `healthy` au SHA `3dc4471…` ;
+- Coolify frontend : déploiement webhook `x32agxx267sbxli3qne5itke`, réussi de
+  06:14:23 à 06:16:32 UTC, application `healthy` au SHA `000f6eda…` ;
+- smoke public : readiness backend `200`, route anonyme `401`, page
+  `/administration/reference-data` `200`, et bundle frontend contenant le SHA
+  complet `000f6edad3af970d016a6fb7961c5123cfc72d6f`.
 
 ## Risques, compatibilité et rollback
 
@@ -88,8 +143,7 @@ peut redéployer le SHA précédent tout en conservant les tables additives.
 
 ## Reste réellement à faire
 
-- promouvoir les deux dépôts vers `dev` puis `main` ;
-- sauvegarder, appliquer avec `--only` et vérifier le patch sur `cerp_test` puis
-  `cerp_prod` ;
-- redéployer et vérifier Coolify et HYPERBOX2 ;
-- compléter ce rapport avec les SHA, sauvegardes et preuves live exactes.
+Aucun reliquat fonctionnel SOL-33 connu. Les valeurs réelles restent à saisir
+par leurs propriétaires via le workflow gouverné ; les inventer ou les charger
+automatiquement aurait contredit le contrôle métier. Ce complément documentaire
+est promu séparément et ne modifie ni runtime ni schéma.


### PR DESCRIPTION
Promotion documentaire SOL-33 : preuves de migration, restauration et déploiement déjà exécutés. Aucun changement runtime supplémentaire.

## Summary by Sourcery

Document completed release evidence for SOL-33, covering Git promotion, database backup/migration/restoration, and live deployment proofs without changing runtime behavior.

Documentation:
- Extend SOL-33 execution report with detailed Git promotion steps and resulting SHAs.
- Add documented evidence of production/test database preflight checks, backups, migrations, and restorations for SOL-33.
- Record live deployment proofs for HYPERBOX2 and Coolify, including readiness checks, routes, and frontend bundle verification.
- Update remaining-work section to reflect that SOL-33 functional tasks are complete and only governed data entry remains.