### PR TITLE
release: promouvoir le gate backend SOL-35

### DIFF
--- a/docs/adr/ADR-0080-supplier-portal-product-gate.md
+++ b/docs/adr/ADR-0080-supplier-portal-product-gate.md
@@ -1,0 +1,43 @@
+# ADR-0080 — Gate produit du portail fournisseur
+
+- Statut : accepté
+- Date : 2026-08-15
+- Décisionnaire : Keenan Martin
+- Portée : SOL-35 et CLAUDE-16
+
+## Contexte
+
+Un portail fournisseur crée une nouvelle frontière Internet, des identités externes, des données contractuelles, des dépôts documentaires et des actions qui peuvent modifier une promesse d'achat. Il ne doit pas être construit sur la seule hypothèse qu'il pourrait être utile.
+
+SOL-35 impose donc un besoin fournisseur réel et répété. La mesure effectuée le 15 août 2026 dans une transaction PostgreSQL `READ ONLY` donne pour `cerp_prod` : un fournisseur actif, aucune commande fournisseur et aucun fournisseur ayant reçu au moins deux commandes non annulées. Les 60 commandes de `cerp_test` appartiennent au jeu déterministe de validation et ne constituent pas une preuve métier.
+
+## Décision
+
+Le portail fournisseur est placé en **No-Go produit**. Aucun compte externe, endpoint public, table, projection, document publié, notification ou écran de portail n'est ajouté tant que la précondition n'est pas démontrée.
+
+Le gate peut être rouvert uniquement lorsque les preuves suivantes existent ensemble :
+
+1. au moins deux commandes d'achat réelles non annulées adressées au même fournisseur sur une période de douze mois ;
+2. une confirmation écrite du besoin répété portant sur au moins une action précise : accusé de commande, proposition de date, dépôt d'un document ou réponse à une non-conformité ;
+3. un fournisseur pilote nommé et consentant, un propriétaire métier Achats et un responsable de support ;
+4. la liste des champs exposables, des validations internes obligatoires et des délais de conservation approuvés ;
+5. un environnement de pilote, un canal d'invitation et de récupération, et les secrets dédiés provisionnés hors dépôt.
+
+Ces critères sont des conditions minimales, pas une autorisation automatique de développement. Le périmètre reste limité au besoin financé et ne doit pas reproduire le module Achats.
+
+## Architecture réservée après réouverture
+
+Une future implémentation devra reprendre les contrôles éprouvés du portail client sans réutiliser ses identités ni son audience : identité fournisseur distincte de `users`, rattachement à un seul `fournisseur_id`, JWT/session dédiés, projections SQL en liste blanche, filtrage dérivé exclusivement de l'identité vérifiée, invitations à usage unique, idempotence persistante, audit append-only et tests de non-fuite entre fournisseurs.
+
+Une proposition de date ou une réponse contractuelle restera une proposition externe. Son application à la commande interne exigera une validation Achats explicite, idempotente et auditée.
+
+## Conséquences
+
+- CERP+ n'expose pas aujourd'hui de nouvelle surface d'attaque ni de faux parcours fournisseur.
+- Aucune migration, variable d'environnement, sauvegarde spéciale ou opération de rollback n'est nécessaire.
+- CLAUDE-16 est non applicable : il n'existe aucun portail fournisseur fonctionnel à retoucher et il est interdit d'en inventer un à des fins visuelles.
+- La requête de preuve et ses résultats sont consignés dans `docs/execution-reports/SOL-35.md`.
+
+## Retour arrière
+
+Cette décision ne modifie aucun runtime ni aucune donnée. Son retour arrière consiste à remplacer cette ADR par une nouvelle ADR citant les preuves du gate, le fournisseur pilote, le besoin financé et l'architecture approuvée. L'historique de la présente décision doit être conservé.

--- a/docs/execution-reports/SOL-35.md
+++ b/docs/execution-reports/SOL-35.md
@@ -1,0 +1,64 @@
+# SOL-35 — Portail fournisseur minimal — contrôle de précondition
+
+- Date : 2026-08-15
+- Propriétaire : Keenan Martin
+- Issue : [#534](https://github.com/BigFootLime/erp-crp-backend/issues/534)
+- Décision : **No-Go produit — précondition non satisfaite**
+
+## Diagnostic et cause racine
+
+Le dépôt contient déjà le domaine Fournisseurs, les commandes d'achat, les réceptions et les contrôles qualité. Il ne contient volontairement aucun portail fournisseur. La précondition de SOL-35 n'est pas satisfaite dans la source de vérité : `cerp_prod` contient un fournisseur actif mais aucune commande d'achat réelle. Il n'existe donc ni besoin répété démontré, ni fournisseur pilote, ni action externe à financer.
+
+Les 60 commandes et 12 fournisseurs répétés trouvés dans `cerp_test` viennent des fixtures SOL-05. Les utiliser comme justification produit présenterait une donnée synthétique comme réelle.
+
+## Preuve reproductible
+
+La requête a été exécutée sur HYPERBOX2 via `sudo -u postgres psql`, avec `ON_ERROR_STOP` et une transaction `BEGIN READ ONLY`. Elle compte les fournisseurs actifs, les commandes, les fournisseurs ayant au moins deux commandes non annulées et les commandes qui attendraient une réponse.
+
+| Base | Fournisseurs actifs | Commandes | Commandes sur 365 jours | Fournisseurs avec besoin répété | En attente de réponse | Actives sans date promise |
+|---|---:|---:|---:|---:|---:|---:|
+| `cerp_prod` | 1 | 0 | 0 | 0 | 0 | 0 |
+| `cerp_test` | 46 | 60 | 60 | 12 | 0 | 0 |
+
+La seconde ligne est explicitement une fixture de test et ne satisfait pas le gate métier.
+
+## Choix d'architecture
+
+L'ADR [ADR-0080](../adr/ADR-0080-supplier-portal-product-gate.md) interdit toute création anticipée de routes, tables, identités ou documents portail. Elle définit les cinq preuves nécessaires à une réouverture et réserve une architecture isolée inspirée du portail client, sans partage d'identité ou d'audience.
+
+## Fichiers modifiés
+
+- `docs/adr/ADR-0080-supplier-portal-product-gate.md`
+- `docs/execution-reports/SOL-35.md`
+
+Aucun fichier runtime, contrat OpenAPI, route, service, repository, validateur ou test produit n'est modifié.
+
+## Migrations et données
+
+Aucune migration ni patch SQL. Les deux requêtes ont été exécutées en lecture seule. Aucune sauvegarde, restauration ou écriture sur `cerp_test` ou `cerp_prod` n'est nécessaire pour cette décision.
+
+## Tests et vérifications
+
+- accès HYPERBOX2 par clé dédiée : réussi ;
+- requête `cerp_prod` dans une transaction `READ ONLY` : réussie ;
+- même requête sur `cerp_test` : réussie et correctement classée comme fixture ;
+- `git diff --check` : réussi ;
+- suite runtime : non applicable, aucun code ni schéma n'est modifié.
+
+## Navigateur / E2E
+
+Non applicable. Aucun écran fournisseur externe n'est créé. Lancer un E2E ou une retouche CLAUDE-16 sur une interface fictive contredirait le gate et les règles anti-mock.
+
+## Risques et compatibilité
+
+Le risque évité est élevé : exposition inter-fournisseurs, ambiguïté contractuelle sur les dates proposées, stockage documentaire externe et charge de support sans utilisateur réel. La compatibilité des modules Achats, Fournisseurs, Réceptions et Qualité est totale, puisqu'ils ne changent pas.
+
+Le risque résiduel est l'absence d'autonomie fournisseur. Il est acceptable tant qu'aucune commande réelle répétée ne le justifie ; les échanges restent dans le processus Achats existant.
+
+## Rollback
+
+Rollback runtime et SQL : aucun. Pour révoquer la décision documentaire, créer une ADR de remplacement avec les preuves de réouverture ; ne pas supprimer l'historique.
+
+## Éléments restant réellement à faire
+
+Attendre un besoin réel répondant aux cinq critères de l'ADR-0080. À ce moment seulement : créer une nouvelle issue financée, refaire la mesure production, concevoir l'isolation, puis implémenter SOL-35 avant toute invocation de CLAUDE-16.


### PR DESCRIPTION
Promotion de l'ADR-0080 et du rapport SOL-35. Aucun runtime, endpoint, migration ou donnée modifié.

## Summary by Sourcery

Document the product gate decision for the supplier portal and record the SOL-35 execution report without changing runtime code or data.

Documentation:
- Add ADR-0080 to formalize the supplier portal product gate, its preconditions, and reserved architecture after reactivation.
- Add SOL-35 execution report documenting the measurement in production/test and the resulting No-Go decision for the supplier portal.

Chores:
- Clarify that no runtime, schema, migrations, data, endpoints, or tests are modified by this decision.