### PR TITLE
release: promote SOL-36 connector commercial gate

### DIFF
--- a/docs/adr/ADR-0081-connectors-commercial-gate.md
+++ b/docs/adr/ADR-0081-connectors-commercial-gate.md
@@ -1,0 +1,58 @@
+# ADR-0081 — Gate commercial des connecteurs comptables et EDI
+
+- Statut : accepté
+- Date : 2026-08-15
+- Décideur produit : Keenan Martin
+- Périmètre : premier adaptateur comptable ou EDI spécifique à un tiers
+
+## Contexte
+
+SOL-36 exige qu'un premier connecteur soit choisi à partir du besoin d'un client
+payant. Aucun client, logiciel, protocole, contrat d'import, bac à sable ou jeu de
+secrets n'est actuellement déclaré. La base `cerp_prod` contient zéro connexion de
+Plateforme Agréée, zéro version de mapping comptable et zéro lot d'export. Les
+issues GitHub ne portent aucune demande client pour Sage, Cegid, EBP, Pennylane,
+EDIFACT ou un autre tiers.
+
+Le socle livré par SOL-26 et SOL-27 fournit déjà les frontières sûres utiles :
+adaptateurs indépendants du fournisseur, données canoniques, mappings versionnés,
+validation, empreintes, idempotence, reprise, rapprochement, audit, RBAC et
+références de secrets. `GENERIC_DELIMITED_V1` reste un export générique contrôlé ;
+il ne constitue pas un connecteur fournisseur réel.
+
+## Décision
+
+Le développement d'un adaptateur réel est **refusé tant que le gate commercial
+n'est pas satisfait**. Il est également interdit d'ajouter maintenant une nouvelle
+couche générique de transport, une dead-letter queue ou une sandbox factice : ces
+choix dépendent du contrat et du comportement du tiers réellement sélectionné.
+
+Une demande devient éligible seulement si son dossier contient simultanément :
+
+1. le client payant et le propriétaire métier identifiés ;
+2. le flux prioritaire, sa fréquence, ses volumes et son impact mesurable ;
+3. le produit, fournisseur, version et protocole exacts ;
+4. une spécification contractuelle versionnée et des exemples acceptés ;
+5. un environnement de test réel, ses limites et ses scénarios de rejet ;
+6. le modèle d'authentification, la rotation et l'isolation des secrets ;
+7. les SLA, limites de débit, règles de retry, idempotence, rejeu et réconciliation ;
+8. les responsabilités de support, le prix et la date de dépréciation éventuelle.
+
+À satisfaction du gate, l'équipe implémentera le chemin vertical minimal dans les
+frontières SOL-26/SOL-27 : transport, transformation, orchestration et audit seront
+séparés seulement aux points imposés par le tiers. Les tests contractuels utiliseront
+le véritable bac à sable. L'effort du deuxième adaptateur sera mesuré après le
+premier, à partir du diff réel, et non estimé par une abstraction spéculative.
+
+## Compatibilité et rollback
+
+Cette décision ne modifie ni le runtime, ni le schéma, ni les données. Elle conserve
+l'export générique et l'état explicite `NO_QUALIFIED_PROVIDER`. Le rollback consiste
+à révoquer cet ADR si un dossier client complet satisfait les huit critères ; aucune
+restauration de base n'est nécessaire.
+
+## Conséquences
+
+CERP+ ne prétend pas être connecté à un système externe et n'engage aucun coût de
+support sans financement. Le prochain travail est une qualification commerciale,
+pas une implémentation technique.

--- a/docs/execution-reports/SOL-36.md
+++ b/docs/execution-reports/SOL-36.md
@@ -1,0 +1,82 @@
+# Rapport d'exécution — SOL-36
+
+- Date : 2026-08-15
+- Issue : https://github.com/BigFootLime/erp-crp-backend/issues/537
+- Branche : `docs/537-sol36-connector-gate`
+- Base : `origin/main` `d00dd77265465917b3c13acb5a1e603c999440b9`
+- Verdict : **NO-GO adaptateur réel — précondition client non satisfaite**
+
+## Diagnostic et cause racine
+
+Le premier connecteur doit répondre à un besoin financé. L'inventaire des dépôts,
+des issues et de la configuration réelle ne trouve ni client payant associé, ni
+logiciel/protocole choisi, ni spécification, ni bac à sable, ni secrets qualifiés.
+Une implémentation Sage/EDI dans cet état serait une donnée et une compatibilité
+inventées.
+
+Le noyau existant n'est pas manquant : SOL-26 fournit la frontière de facturation
+électronique et SOL-27 un moteur d'export canonique, versionné, idempotent, audité et
+protégé par RBAC. La cause du blocage est exclusivement commerciale et contractuelle.
+
+## Preuves examinées
+
+- recherche ciblée dans `docs`, `src`, `scripts` et les issues des deux dépôts :
+  aucune demande client nominative pour un fournisseur comptable ou EDI ;
+- `ADR-0072` : aucun prestataire, contrat, certificat ou sandbox de Plateforme
+  Agréée ;
+- `ADR-0073` et rapport SOL-27 : aucun logiciel comptable prioritaire ni contrat
+  d'import, l'adaptateur générique n'est pas déclaré compatible avec un tiers ;
+- lecture PostgreSQL `BEGIN READ ONLY` sur `cerp_prod` :
+  `einvoice_provider_connections=0`, `accounting_export_mapping_versions=0`,
+  `accounting_export_batches=0` ; aucun statut de lot n'existe.
+
+## Choix d'architecture
+
+`ADR-0081` bloque tout adaptateur spécifique jusqu'à un dossier commercial complet.
+Il réutilise les frontières SOL-26/SOL-27 et interdit une nouvelle architecture
+générique prématurée. Le premier adaptateur sera un chemin vertical minimal contre
+un bac à sable réel ; le coût d'un second sera mesuré ensuite sur le diff observé.
+
+## Fichiers, migrations et données
+
+- `docs/adr/ADR-0081-connectors-commercial-gate.md` ;
+- `docs/execution-reports/SOL-36.md`.
+
+Aucun fichier runtime, endpoint, secret, migration ou donnée n'est modifié. Le
+frontend reste inchangé car aucun écran fonctionnel n'est autorisé sans connecteur.
+
+## Vérifications exécutées
+
+| Contrôle | Résultat |
+|---|---|
+| état Git de la base `origin/main` | propre, SHA `d00dd772…` |
+| inventaire dépôts/issues | PASS — aucun besoin client ou fournisseur choisi |
+| lecture production en transaction read-only | PASS — compteurs `0 / 0 / 0` |
+| lecture des deux Markdown et contrôle des liens relatifs | PASS |
+| `git diff --check` | PASS |
+
+Les suites runtime et Playwright sont non applicables : aucune logique, API,
+interface ou configuration exécutable n'est changée. Aucun accès navigateur ne peut
+qualifier un tiers absent.
+
+## Risques et compatibilité
+
+- Le besoin futur peut imposer SFTP, API, AS2, EDIFACT ou un format propriétaire ;
+  le choisir aujourd'hui créerait une dette sans preuve.
+- L'export `GENERIC_DELIMITED_V1` reste disponible, mais son import dans un logiciel
+  externe doit toujours être qualifié par le comptable.
+- L'absence de connecteur reste visible et fermée ; aucun succès externe n'est
+  simulé.
+
+## Rollback
+
+Revenir sur le commit documentaire retire seulement l'ADR et ce rapport. Aucun
+rollback applicatif, SQL ou secret n'est requis.
+
+## Reste réellement à faire
+
+1. Obtenir un engagement client payant et désigner le propriétaire métier.
+2. Fournir produit/version/protocole, spécification, exemples, sandbox et secrets.
+3. Définir volumes, SLA, rejets, retry, réconciliation, support et prix.
+4. Implémenter et qualifier alors le premier adaptateur réel, puis mesurer le coût
+   d'un deuxième adaptateur à partir du travail observé.


### PR DESCRIPTION
Promotes the reviewed SOL-36 decision from dev to main. Documentation-only: no runtime, schema, secret, API, or production data change.\n\nEvidence: PR #538, read-only production counts 0/0/0, UTF-8 and diff checks passed.

## Summary by Sourcery

Document the SOL-36 execution decision and formalize a commercial gate for future accounting/EDI connectors without changing runtime behavior or data.

Documentation:
- Add SOL-36 execution report describing the NO-GO decision for a real connector due to unmet commercial preconditions.
- Introduce ADR-0081 to define the commercial eligibility criteria and gate for implementing specific accounting/EDI connectors.

Chores:
- Record that no runtime, schema, secrets, endpoints, migrations, or production data are modified by this decision.