### PR TITLE
docs(architecture): define SOL-37 dedicated-instance boundary

### DIFF
--- a/docs/adr/ADR-0082-dedicated-instance-organization-boundary.md
+++ b/docs/adr/ADR-0082-dedicated-instance-organization-boundary.md
@@ -1,0 +1,84 @@
+# ADR-0082 — Frontière société/site et identité d'entreprise
+
+- Statut : accepté pour le modèle actuel ; extension conditionnelle
+- Date : 2026-08-15
+- Décideur produit : Keenan Martin
+- Périmètre : sociétés, sites, SSO et SCIM
+
+## Contexte et preuve
+
+SOL-37 autorise cette évolution seulement pour plusieurs clients ou un client
+multi-site avec un besoin contractuel. Aucun contrat de ce type, fournisseur
+d'identité, protocole OIDC/SAML, domaine, groupe ou endpoint SCIM n'est déclaré.
+
+La production est une instance dédiée. Elle contient quatre `warehouses` et cinq
+`magasins`, qui sont des périmètres logistiques. L'inventaire du catalogue PostgreSQL
+ne trouve aucune table `tenant`, `company`, `organization`, `societe` ou `site`, ni
+aucune colonne `tenant_id`, `company_id`, `organization_id`, `societe_id` ou
+`site_id`. Un filtre `site_id` utilisé par un indicateur de Direction désigne un
+entrepôt source ; il ne constitue pas une frontière d'autorisation.
+
+## Cartographie de propriété actuelle
+
+| Domaine | Propriété autoritaire actuelle | Limite |
+|---|---|---|
+| société légale | instance et configuration de déploiement | aucune entité société en base |
+| utilisateurs, rôles et numérotations | instance entière | aucune partition société/site |
+| stocks et emplacements | `warehouse → magasin → emplacement` | logistique, pas identité juridique |
+| calendriers, centres de coûts et taux | référentiels versionnés de l'instance | pas de rattachement universel à un site |
+| ventes, achats, production et qualité | instance entière, liens métier explicites | aucune clé société/site commune |
+| GED | entité métier et politique documentaire | aucune partition société/site générale |
+| reporting | données de l'instance, filtres métier ponctuels | pas de consolidation multi-société |
+
+## Décision immédiate
+
+CERP+ conserve **une instance dédiée par société cliente**. Les magasins et entrepôts
+ne deviennent pas artificiellement des sociétés ou des sites de sécurité. Aucun
+champ envoyé par le navigateur ne peut choisir une société implicite. Aucun SSO ou
+SCIM générique n'est ajouté sans fournisseur d'identité et contrat réels.
+
+Cette option est la plus sûre pour le premier pilote : les frontières réseau, base,
+stockage, secrets et sauvegardes restent celles de l'instance. Le reporting entre
+instances n'est pas présenté comme disponible.
+
+## Plan conditionnel si le gate est satisfait
+
+1. **Contrat et modèle** : identifier sociétés légales, sites, partages autorisés,
+   IdP, groupes, SLA et responsabilité des données.
+2. **Spine additive** : créer `organizations` et `sites`, amorcer une organisation et
+   un site legacy par instance, puis rattacher côté serveur les écritures nouvelles.
+3. **Migration contrôlée** : backfill par domaine avec preflight, sauvegarde, rapports
+   d'orphelins et doubles lectures temporaires ; rendre chaque clé obligatoire
+   seulement après couverture complète.
+4. **Isolation** : dériver le contexte d'un droit serveur, imposer clés étrangères,
+   uniques composites et tests de non-fuite. Le changement de contexte est explicite,
+   audité et interdit au milieu d'une transaction métier.
+5. **Partage/consolidation** : ajouter des tables d'autorisation explicites et des
+   read models agrégés ; jamais de fallback vers « toutes les sociétés ».
+6. **Identité** : implémenter OIDC ou SAML selon l'IdP contractualisé, valider issuer,
+   audience, signature, nonce et claims, puis mapper les groupes vers des rôles
+   internes versionnés.
+7. **SCIM** : `/Users` et `/Groups` idempotents, désactivation plutôt que suppression,
+   rapprochement par identifiant externe immuable, audit et protection anti-rejeu.
+8. **Compatibilité** : qualifier une instance dédiée existante, le changement de
+   contexte, le reporting consolidé et chaque route sensible avant activation.
+
+## Invariant principal
+
+Toute écriture métier future doit recevoir son `organization_id` et son `site_id`
+depuis le contexte d'autorisation serveur. Une valeur absente, ambiguë ou hors droit
+échoue avant mutation. Aucun payload client ne peut élargir ce contexte.
+
+## Compatibilité et rollback
+
+La décision actuelle ne change ni runtime ni schéma. Si le plan futur démarre, ses
+migrations seront additives et activées par domaine. Avant contrainte obligatoire,
+le rollback consiste à désactiver le nouveau contexte et redéployer le binaire
+précédent ; après données multi-société réelles, le retour exige restauration dans
+une base neuve et réconciliation, jamais suppression de colonnes en place.
+
+## Conséquences
+
+Le produit évite une multi-tenance prématurée tout en fixant l'invariant à respecter
+si un contrat la finance. Le prochain jalon est un dossier client/IdP validé, pas une
+migration universelle.

--- a/docs/execution-reports/SOL-37.md
+++ b/docs/execution-reports/SOL-37.md
@@ -1,0 +1,79 @@
+# Rapport d'exécution — SOL-37
+
+- Date : 2026-08-15
+- Issue : https://github.com/BigFootLime/erp-crp-backend/issues/540
+- Branche : `docs/540-sol37-organization-identity-gate`
+- Base : `origin/main` `132b0f7c0f611bab095c6503dde64a6789ea8ac9`
+- Verdict : **instances dédiées ; NO-GO multi-société/SSO/SCIM sans contrat**
+
+## Diagnostic et cause racine
+
+Le modèle courant isole l'entreprise par instance de déploiement. Les entrepôts et
+magasins sont des objets logistiques, pas des tenants. Aucune preuve ne montre
+plusieurs clients CERP+ ni un client multi-site avec besoin contractuel, et aucun IdP
+n'est choisi. Introduire aujourd'hui des clés de tenant ou un SSO générique créerait
+des ambiguïtés d'écriture et une surface de fuite sans utilisateur réel.
+
+## Preuves
+
+- recherche des deux dépôts et des issues : aucune demande multi-site, SSO, SCIM,
+  OIDC ou SAML contractualisée ;
+- code et ADR-0076 : aucun contexte société/site universel, et un `site_id` de filtre
+  Direction correspond à un entrepôt métier ;
+- transaction PostgreSQL `BEGIN READ ONLY` sur `cerp_prod` : 4 entrepôts, 5 magasins,
+  18 utilisateurs ; zéro colonne de tenant/société/organisation/site et zéro table
+  `tenants`, `companies`, `organizations`, `societes`, `sites`, `sso_connections` ou
+  `scim_connections`.
+
+## Architecture retenue
+
+`ADR-0082` maintient une instance dédiée par société et interdit d'utiliser les
+magasins comme frontière de sécurité. Il cartographie les propriétaires actuels et
+définit un plan additif en huit étapes si un besoin réel apparaît : spine
+organisation/site, backfill, contexte serveur, isolation, consolidation, IdP, SCIM
+idempotent et qualification de compatibilité.
+
+L'invariant futur est explicite : toute écriture reçoit société/site du serveur et
+échoue en cas d'ambiguïté. Une valeur venant du navigateur ne peut jamais élargir le
+périmètre autorisé.
+
+## Fichiers, migrations et données
+
+- `docs/adr/ADR-0082-dedicated-instance-organization-boundary.md` ;
+- `docs/execution-reports/SOL-37.md`.
+
+Aucun code, endpoint, claim, secret, migration ou donnée n'est ajouté. Le frontend
+reste inchangé. Les 4 entrepôts et 5 magasins existants ne sont pas réinterprétés.
+
+## Tests et vérifications
+
+| Contrôle | Résultat |
+|---|---|
+| inventaire Git/dépôts/issues | PASS |
+| introspection `cerp_prod` en lecture seule | PASS |
+| validation UTF-8 des Markdown | PASS — 2/2 |
+| `git diff --check` | PASS |
+
+Typecheck, build et E2E sont non applicables à ce diff documentaire. Aucun navigateur
+ne peut prouver un SSO ou un changement de contexte qui n'existe pas.
+
+## Risques et compatibilité
+
+- Plusieurs entrepôts ne prouvent ni plusieurs sites juridiques ni des droits
+  inter-sites ; les confondre provoquerait des fuites ou des blocages.
+- Une future consolidation doit gérer numérotations, devises, calendriers, coûts,
+  documents et sauvegardes ; elle ne peut être activée domaine par domaine sans
+  rapport de couverture.
+- Le modèle dédié reste compatible avec toutes les fonctions actuelles.
+
+## Rollback
+
+Revenir sur le commit documentaire retire seulement la décision et le rapport. Il
+n'existe aucun changement SQL ou de secrets à restaurer.
+
+## Reste réellement à faire
+
+1. Obtenir un contrat multi-société/multi-site ou SSO et identifier l'IdP réel.
+2. Valider propriété, partage, numérotations, stocks, calendriers, coûts et GED.
+3. Exécuter alors le plan ADR-0082 avec sauvegarde, migration par domaine, tests de
+   non-fuite et rollback démontré.


### PR DESCRIPTION
## Décision\n- conserver une instance dédiée par société\n- ne pas confondre warehouses/magasins avec une frontière juridique\n- plan conditionnel organisation/site + OIDC/SAML + SCIM seulement après contrat\n\n## Preuves\n- cerp_prod en lecture seule : 4 warehouses, 5 magasins, 18 utilisateurs\n- aucune table/colonne tenant, société, organisation ou site\n- aucun IdP ou besoin contractuel dans les dépôts/issues\n- UTF-8 et diff-check réussis\n\nCloses #540

## Summary by Sourcery

Document the decision to keep one dedicated deployment instance per customer company and to defer multi-tenant organization/site boundaries and enterprise identity until there is a contractual need.

Documentation:
- Add ADR-0082 describing the current dedicated-instance per company boundary, the absence of legal-entity modeling in the schema, and a conditional plan for introducing organizations, sites, SSO, and SCIM in the future.
- Add an execution report for SOL-37 capturing the investigation, evidence, decision rationale, and next steps related to organization boundaries and enterprise identity.

Chores:
- Record that no runtime code, schema, or data changes are introduced by this documentation-only change.