### PR TITLE
docs(maintenance): gate SOL-38 OEE on measured data

### DIFF
--- a/docs/adr/ADR-0083-maintenance-oee-machine-data-gate.md
+++ b/docs/adr/ADR-0083-maintenance-oee-machine-data-gate.md
@@ -1,0 +1,76 @@
+# ADR-0083 — Gate maintenance, données machine et OEE
+
+- Statut : accepté
+- Date : 2026-08-15
+- Décideur produit : Keenan Martin
+- Périmètre : GMAO ciblée, télémétrie et TRS/OEE
+
+## Contexte
+
+Le parc CERP+ possède déjà la GMAO minimale adaptée à l'atelier : machines,
+spécifications, plans datés ou à compteur, échéances, checklists, responsables,
+indisponibilités reliées au Planning et événements append-only. Les routes appliquent
+RBAC, contrôle horizontal, concurrence et audit. Ajouter un second module de
+maintenance dupliquerait cette source de vérité.
+
+La donnée réelle n'est toutefois pas encore alimentée. `cerp_prod` contient douze
+machines actives, mais zéro plan de maintenance, événement, indisponibilité et
+pointage de production. Aucune table de télémétrie, observation machine, compteur
+machine ou OEE n'existe. ADR-0031 confirme qu'aucune machine n'est connectée.
+
+## Décision
+
+### Maintenance
+
+La GMAO ciblée existante est conservée et constitue la seule frontière de
+maintenance CERP+. Son activation opérationnelle exige un inventaire terrain validé,
+pas une nouvelle implémentation : plan, périodicité ou compteur, unité, prochaine
+échéance, checklist, responsable, pièces/document et règle d'indisponibilité pour
+chaque équipement concerné.
+
+Une maintenance bloquante reste un événement Planning explicite. Aucun conflit ne
+peut être masqué et aucune échéance n'est fabriquée à partir du modèle commercial de
+la machine.
+
+### OEE/TRS
+
+Le TRS reste `computable=false`, `value=null`. Il ne devient calculable que si une
+période prouve simultanément :
+
+1. le temps d'ouverture planifié versionné ;
+2. les arrêts planifiés et non planifiés, avec cause et horodatages fiables ;
+3. le temps de marche mesuré ;
+4. une cadence nominale versionnée pour l'opération et la machine ;
+5. le nombre total produit et le nombre bon après décision Qualité ;
+6. une liaison non ambiguë machine → opération → OF ;
+7. une couverture, une fraîcheur et une horloge synchronisée suffisantes.
+
+Disponibilité, performance et qualité sont publiées séparément avec source,
+fraîcheur, couverture et éléments manquants. Une composante absente rend l'OEE non
+calculable ; elle n'est jamais remplacée par zéro ou une estimation.
+
+### Connectivité machine
+
+Aucun adaptateur n'est implémenté sans machine et client financés. Le premier pilote
+portera sur un seul type de machine réel. Il suivra ADR-0031 : passerelle locale en
+pull, réseau OT non exposé, allowlist, observations horodatées et dédoublonnées,
+aucune commande de machine, aucune fermeture automatique d'OF et réconciliation
+humaine des compteurs.
+
+Avant activation, le rapport qualité doit mesurer au minimum couverture temporelle,
+trous, doublons, événements hors ordre, dérive d'horloge, valeurs impossibles,
+déconnexions et part d'observations rapprochées à un OF. Le seuil d'acceptation est
+contractuel et documenté pour la machine pilote.
+
+## Compatibilité et rollback
+
+Cette décision ne change ni runtime ni schéma. Les écrans existants continuent
+d'afficher les manques et l'OEE indisponible. Le rollback documentaire consiste à
+révoquer l'ADR après preuve d'un pilote financé ; toute future passerelle devra être
+désactivable indépendamment et la production manuelle restera le fallback sûr.
+
+## Conséquences
+
+CERP+ conserve une maintenance utile sans devenir une plateforme IoT universelle.
+Les douze machines ne sont pas déclarées « connectées » et aucun taux OEE n'est
+affiché avant données mesurées fiables.

--- a/docs/execution-reports/SOL-38.md
+++ b/docs/execution-reports/SOL-38.md
@@ -1,0 +1,86 @@
+# Rapport d'exécution — SOL-38
+
+- Date : 2026-08-15
+- Issue : https://github.com/BigFootLime/erp-crp-backend/issues/543
+- Branche : `docs/543-sol38-maintenance-oee-gate`
+- Base : `origin/main` `a4842b7272900854a3ed80dc7ec6d81389b8c7d7`
+- Verdict : **GMAO ciblée déjà présente ; NO-GO télémétrie/OEE**
+
+## Diagnostic et cause racine
+
+Le besoin de maintenance n'exige pas un nouveau module : le parc machines gère déjà
+plans, compteurs, échéances, checklists, événements, indisponibilités Planning, RBAC,
+audit et concurrence. Le blocage est l'absence de données terrain et de besoin
+financé pour une machine connectée.
+
+La production possède 12 machines actives mais aucune ligne opérationnelle dans ce
+socle. Aucun pointage n'est disponible pour estimer honnêtement marche, arrêts,
+cadence ou qualité. Le calcul existant renvoie donc volontairement un OEE nul au sens
+de disponibilité de donnée (`value=null`), jamais un taux de 0 %.
+
+## Preuves examinées
+
+- `20260722_machine_park_165.sql`, routes et repository : plans de maintenance,
+  événements append-only, indisponibilités reliées au Planning, RBAC et audit ;
+- `production-execution.repository.ts` et ses tests : OEE non calculable quand
+  calendrier ou cadence nominale manque ;
+- ADR-0031 : aucune machine CERP+ connectée, aucune passerelle ou simulation ;
+- transaction PostgreSQL `BEGIN READ ONLY` sur `cerp_prod` : 12 machines actives,
+  0 plan, 0 événement maintenance, 0 indisponibilité, 0 pointage total ou machine ;
+- catalogue PostgreSQL : aucune table machine de télémétrie, observation, compteur
+  ou OEE (`article_observations` est hors périmètre machine).
+
+## Choix d'architecture
+
+`ADR-0083` conserve le module ciblé existant et définit les données minimales du
+TRS : ouverture planifiée, arrêts, marche, cadence, total, bon Qualité et lien OF.
+Il impose source, fraîcheur, couverture et qualité par composante. L'absence d'une
+preuve rend le taux non calculable.
+
+La future connectivité reste limitée à une machine et un client financés, via la
+passerelle locale en pull d'ADR-0031, sans commande machine depuis l'ERP.
+
+## Fichiers, migrations et données
+
+- `docs/adr/ADR-0083-maintenance-oee-machine-data-gate.md` ;
+- `docs/execution-reports/SOL-38.md`.
+
+Aucun code, endpoint, adaptateur, migration, fixture ou donnée n'est ajouté. Aucun
+plan de maintenance réel n'est inventé pour les douze machines.
+
+## Tests et vérifications
+
+| Contrôle | Résultat |
+|---|---|
+| inventaire code/ADR/issues | PASS |
+| introspection production read-only | PASS — `12 / 0 / 0 / 0 / 0` |
+| tests ciblés parc/exécution/OEE | PASS — 5 fichiers, 252 tests |
+| validation UTF-8 des Markdown | PASS — 2/2 |
+| `git diff --check` | PASS |
+
+Aucun test navigateur n'est applicable au diff documentaire. Les tests actuels de
+l'écran et de l'API vérifient déjà que l'OEE indisponible reste visible et n'est pas
+converti en zéro. Le premier lancement a détecté un `node_modules` local incomplet ;
+`pnpm install --frozen-lockfile` l'a reconstruit sans modifier le lockfile avant le
+rejeu réussi.
+
+## Risques et compatibilité
+
+- Le parc décrit ne prouve pas les durées de fonctionnement ou les alarmes.
+- Un compteur de cycles ne prouve pas la conformité ; Qualité reste autoritaire.
+- Les valeurs issues d'un futur pilote ne pourront pas être extrapolées aux onze
+  autres machines sans qualification séparée.
+- Le comportement actuel et le planning restent inchangés.
+
+## Rollback
+
+Revenir sur le commit documentaire retire seulement l'ADR et ce rapport. Aucun
+rollback applicatif ou SQL n'est requis.
+
+## Reste réellement à faire
+
+1. Faire valider et saisir les plans réels, compteurs, échéances et responsables.
+2. Obtenir le financement et choisir une machine/protocole pilote réels.
+3. Collecter puis qualifier les événements avec le rapport ADR-0083.
+4. Activer le calcul OEE seulement lorsque chaque composante atteint le seuil
+   contractuel ; sinon conserver `non calculable`.


### PR DESCRIPTION
## Verdict\n- GMAO ciblée existante conservée\n- OEE et connectivité machine restent bloqués faute de données mesurées et de pilote financé\n- aucun simulateur, adaptateur ou taux inventé\n\n## Preuves\n- cerp_prod read-only : 12 machines, 0 plan, 0 événement, 0 indisponibilité, 0 pointage\n- aucune table machine de télémétrie/OEE\n- 5 fichiers / 252 tests ciblés PASS\n- UTF-8 et diff-check PASS\n\nCloses #543

## Summary by Sourcery

Document the decision to keep existing targeted maintenance while gating machine connectivity and OEE/TRS calculations on real measured data, with no runtime or schema changes.

Documentation:
- Add execution report SOL-38 capturing the diagnosis, evidences, test checks, risks, and remaining work for maintenance and OEE gating.
- Add ADR-0083 describing the architectural decision to rely on existing GMAO, require proven machine data for OEE/TRS, and constrain future machine connectivity to funded pilots.