### PR TITLE
docs(forecast): gate SOL-39 on representative history

### DIFF
--- a/docs/adr/ADR-0084-demand-forecast-data-readiness.md
+++ b/docs/adr/ADR-0084-demand-forecast-data-readiness.md
@@ -1,0 +1,87 @@
+# ADR-0084 — Préparation des données pour la prévision de demande
+
+- Statut : accepté ; prévision statistique non activée
+- Date : 2026-08-15
+- Décideur produit : Keenan Martin
+- Périmètre : demande, prévision et consommation MRP
+
+## Contexte
+
+SOL-39 exige un historique propre, stable et représentatif. `cerp_prod` ne contient
+encore aucun article, devis, commande client ou fournisseur, facture, OF, pointage
+ou mouvement de stock. Il n'existe donc aucune observation de demande, aucun mois
+actif et aucun résultat permettant un backtest.
+
+La projection à treize semaines de SOL-19 n'est pas une prévision statistique : elle
+propage les commandes, besoins d'OF, réservations, réceptions attendues, délais et
+politiques explicitement enregistrés. Elle reste utile et ne doit pas être renommée
+« prévision IA ».
+
+## Décision immédiate
+
+Aucun modèle, dataset de démonstration dans le produit, suggestion automatique ou
+KPI de précision n'est ajouté. Toute prévision reste `UNAVAILABLE` tant que le gate
+ci-dessous n'est pas satisfait sur le segment calculé.
+
+## Gate de qualité par article ou famille
+
+Un segment devient candidat seulement si le rapport daté prouve :
+
+1. au moins 52 semaines consécutives observées ; deux cycles complets sont requis
+   avant de tester une saisonnalité annuelle ;
+2. une date et une quantité fiables pour commandes, annulations, retours et
+   substitutions, avec unités convertibles ;
+3. la continuité des références ou un crosswalk versionné pour renommages,
+   remplacements et changements de famille ;
+4. les périodes de rupture identifiées, afin de ne pas prendre une demande censurée
+   pour une absence de besoin ;
+5. les changements de prix, client, marché, capacité ou politique marqués comme
+   ruptures de régime ;
+6. une couverture temporelle, un taux de valeurs manquantes, de doublons et
+   d'événements tardifs publiés avec un seuil approuvé ;
+7. suffisamment de périodes non nulles pour distinguer demande régulière et
+   intermittente ; le minimum dépend du segment et reste visible.
+
+Le nombre de semaines ne suffit jamais seul : une série complète mais non
+représentative reste refusée.
+
+## Baselines et backtesting futur
+
+La première version compare, par validation chronologique à origine glissante :
+
+- naïf dernière période ;
+- naïf saisonnier uniquement avec deux cycles qualifiés ;
+- moyenne mobile simple ;
+- méthode intermittente de type Croston seulement pour le segment correspondant.
+
+Une méthode plus complexe n'est admise que si elle améliore durablement une baseline
+sur plusieurs fenêtres. Le rapport expose MAE, WAPE, MASE et biais, plus un coût
+métier paramétré des surstocks et ruptures. Les intervalles d'incertitude proviennent
+des erreurs hors échantillon, pas d'un pourcentage arbitraire.
+
+## Frontière MRP et validation humaine
+
+Une prévision approuvée porte version, période d'apprentissage, date de calcul,
+méthode, segment, unité, source, fraîcheur, intervalle et fiabilité. MRP la consomme
+comme une source séparée des commandes fermes et des OF ; il ne double compte jamais
+les deux. Une proposition automatique est interdite si le gate, les unités, délais,
+lots, stock de sécurité ou capacités sont incomplets.
+
+L'utilisateur valide ou refuse chaque version avec motif. Le rejeu conserve les
+entrées et l'empreinte. Un suivi mesure dérive de distribution, biais, couverture des
+intervalles et coût d'erreur ; un seuil franchi désactive la proposition automatique
+mais ne réécrit pas les décisions historiques.
+
+## Tests futurs
+
+Les données synthétiques seront réservées aux tests et marquées comme telles. Elles
+couvriront saisonnalité, intermittence, rupture de stock, référence remplacée,
+retour, annulation et changement de régime. Elles ne seront jamais importables ni
+affichées par le build de production.
+
+## Compatibilité et rollback
+
+Cette décision ne modifie ni runtime ni schéma. SOL-19 continue de calculer sa
+projection explicable à partir des besoins enregistrés. Le rollback documentaire
+retire l'ADR ; une future version de prévision devra être désactivable sans supprimer
+ses preuves et sans interrompre le MRP déterministe.

--- a/docs/execution-reports/SOL-39.md
+++ b/docs/execution-reports/SOL-39.md
@@ -1,0 +1,89 @@
+# Rapport d'exécution — SOL-39
+
+- Date : 2026-08-15
+- Issue : https://github.com/BigFootLime/erp-crp-backend/issues/546
+- Branche : `docs/546-sol39-forecast-data-gate`
+- Base : `origin/main` `03570c5918edd8d0506413931ea3e8722c9ca89e`
+- Verdict : **NO-GO prévision — historique inexistant**
+
+## Diagnostic et cause racine
+
+La précondition SOL-39 n'est pas partiellement faible : elle est absente. La base de
+production n'a aucune transaction sur les sept séries nécessaires et aucun article.
+Il est donc impossible de mesurer saisonnalité, biais, intermittence, référence
+remplacée, surstock, rupture ou qualité hors échantillon.
+
+Créer une moyenne ou un modèle sur des fixtures donnerait un résultat techniquement
+testable mais commercialement faux. La projection SOL-19 reste autoritaire pour les
+besoins fermes et explicitement paramétrés ; elle n'est pas une prévision de demande.
+
+## Preuves mesurées
+
+Transaction PostgreSQL `BEGIN READ ONLY` sur `cerp_prod` :
+
+| Dataset | Lignes | Premier/dernier | Mois actifs |
+|---|---:|---|---:|
+| devis | 0 | indisponible | 0 |
+| commandes clients | 0 | indisponible | 0 |
+| commandes fournisseurs | 0 | indisponible | 0 |
+| factures | 0 | indisponible | 0 |
+| ordres de fabrication | 0 | indisponible | 0 |
+| pointages | 0 | indisponible | 0 |
+| mouvements de stock | 0 | indisponible | 0 |
+
+Le même contrôle compte 0 article et 0 ligne de devis, vente, achat ou stock. Les
+issues des deux dépôts ne contiennent aucune demande financée de prévision/MRP
+statistique.
+
+## Choix d'architecture
+
+`ADR-0084` définit un gate par article/famille, au moins 52 semaines consécutives et
+deux cycles avant saisonnalité annuelle, mais exige aussi continuité des références,
+ruptures identifiées, unités, changements de régime et couverture mesurée. Il décrit
+des baselines simples, un backtesting chronologique, les métriques et la séparation
+stricte entre prévisions approuvées et besoins fermes MRP.
+
+## Fichiers, migrations et données
+
+- `docs/adr/ADR-0084-demand-forecast-data-readiness.md` ;
+- `docs/execution-reports/SOL-39.md`.
+
+Aucun modèle, endpoint, écran, migration, fixture de production ou donnée n'est
+ajouté. Aucune proposition automatique n'est activée.
+
+## Tests et vérifications
+
+| Contrôle | Résultat |
+|---|---|
+| audit temporel `cerp_prod` read-only | PASS — 7 datasets à 0 ligne |
+| audit lignes/articles | PASS — tous à 0 |
+| tests ciblés projection/réapprovisionnement SOL-19 | PASS — 6 fichiers, 31 tests |
+| validation UTF-8 des Markdown | PASS — 2/2 |
+| `git diff --check` | PASS |
+
+Le navigateur et un backtest sont non applicables : aucune prévision n'est exposée
+et aucune fenêtre historique réelle ne peut être testée.
+
+## Risques et compatibilité
+
+- Une année seule peut rester non représentative ; les ruptures de régime doivent
+  être examinées humainement.
+- La demande observée pendant une rupture est censurée et ne doit pas être traitée
+  comme zéro.
+- Les séries de test synthétiques futures resteront hors du bundle et de la base de
+  production.
+- SOL-19 reste inchangé et compatible.
+
+## Rollback
+
+Revenir sur le commit documentaire retire l'ADR et le rapport. Aucun rollback SQL,
+applicatif ou de données n'est requis.
+
+## Reste réellement à faire
+
+1. Utiliser CERP+ en production et accumuler des transactions propres et datées.
+2. Produire périodiquement le rapport de readiness ADR-0084 par segment.
+3. Une fois le gate franchi, implémenter les baselines et le backtesting avant toute
+   méthode complexe.
+4. N'autoriser la consommation MRP qu'après validation humaine et surveillance de
+   dérive.


### PR DESCRIPTION
## Verdict\n- historique production inexistant : aucun modèle ni prédiction activé\n- projection déterministe SOL-19 conservée\n- contrat de readiness, baselines et backtesting futur documenté\n\n## Preuves\n- 7 datasets et tous les articles/lignes à 0 en lecture seule\n- 6 fichiers / 31 tests SOL-19 PASS\n- UTF-8 et diff-check PASS\n\nCloses #546

## Summary by Sourcery

Document the decision to keep SOL-39 demand forecasting inactive until representative production history is available, and record the current NO-GO execution verdict.

Documentation:
- Add execution report SOL-39 describing data absence, architectural choices, tests performed, risks, and remaining work before enabling demand forecasting.
- Introduce ADR-0084 defining data readiness gate, baseline forecasting approach, backtesting requirements, and MRP/forecast separation for future demand prediction features.