### PR TITLE
docs(product): gate SOL-40 internationalization and mobile

### DIFF
--- a/docs/adr/ADR-0085-internationalization-currency-mobile-gate.md
+++ b/docs/adr/ADR-0085-internationalization-currency-mobile-gate.md
@@ -1,0 +1,86 @@
+# ADR-0085 — Gate internationalisation, devises et mobile
+
+- Statut : accepté ; extension non activée
+- Date : 2026-08-15
+- Décideur produit : Keenan Martin
+- Périmètre : locales, change et parcours mobiles
+
+## Contexte
+
+SOL-40 exige un besoin commercial confirmé. CERP+ sert actuellement un pilote
+français : les 191 clients de `cerp_prod` portent `langue=fr` et `devise=EUR`. Aucune
+commande, facture ou commande fournisseur ne permet de prouver un usage d'une autre
+devise. Le référentiel connaît CHF, EUR, GBP et USD, mais il n'existe aucune table de
+taux de change datés ; cette liste ne constitue donc pas une capacité de conversion.
+
+Le frontend est francophone et utilise de nombreux formats `fr-FR`. Il n'a ni moteur
+i18n ni PWA/service worker. Des parcours web ciblés sont déjà optimisés tablette ou
+mobile : atelier, scan QR/code-barres, réception et stock. La file hors ligne atelier
+est bornée, chiffrée et rapprochée côté serveur ; elle n'est pas une base locale.
+
+## Décision immédiate
+
+Aucune extraction massive de textes, traduction, table de change, PWA ou application
+native n'est ajoutée sans marché cible. Le français, `Europe/Paris` et l'EUR restent
+les valeurs produit actuelles, explicitement limitées. Les champs de devise existants
+n'autorisent aucun total inter-devises et aucun écran ne doit convertir implicitement.
+
+## Gate commercial
+
+L'extension exige avant développement :
+
+1. pays, langue, utilisateurs et parcours contractuels identifiés ;
+2. exigences légales des documents, taxes, numérotations et archivage ;
+3. devises nécessaires, fournisseur de taux, type de taux, fréquence et règle
+   d'arrondi validés par Finance ;
+4. appareils, OS, scanners, connectivité, durée hors ligne et politique MDM réels ;
+5. valeur mesurable et support financé pour trois à cinq parcours maximum.
+
+## Architecture conditionnelle
+
+### Textes, formats et documents
+
+- Les messages adoptent des clés stables et des catalogues versionnés. Le fallback
+  contrôlé est `fr`, avec journal d'une clé manquante ; la clé brute n'est jamais
+  affichée.
+- La locale de session vient d'une préférence serveur autorisée, avec fallback de
+  l'instance. Le navigateur ne change pas les règles métier ni le fuseau contractuel.
+- Nombres, dates, unités et pluriels utilisent une couche unique. Les données API
+  restent canoniques : ISO 8601, codes ISO, décimaux sous forme non ambiguë.
+- Chaque document généré fige langue, modèle, mentions et version ; changer la langue
+  d'un utilisateur ne régénère jamais silencieusement un document émis.
+
+### Devises
+
+- Un montant conserve valeur décimale et devise d'origine. Une conversion ajoute
+  montant cible, taux décimal, paire, source, date/heure, type et empreinte de la
+  version utilisée.
+- Le taux est figé au moment de la décision comptable. L'historique n'est jamais
+  recalculé avec le taux courant.
+- En l'absence de taux applicable, le calcul et le total inter-devises sont
+  indisponibles ; aucun taux 1 ou zéro n'est injecté.
+
+### Mobile
+
+Les parcours candidats restent : scan/identification, réception, atelier, inventaire
+stock et approbation. La PWA est préférée seulement si le matériel réel fonctionne
+avec les API web et la politique hors ligne ; une application native n'est retenue
+que pour une contrainte prouvée (scanner/MDM/périphérique). Dans les deux cas, les API,
+RBAC, idempotences et audits existants sont réutilisés.
+
+Les secrets ne sont pas persistés côté client. Les intentions hors ligne sont
+minimales, chiffrées, expirables et visibles ; le serveur décide du résultat et des
+conflits. Aucun cache générique ne rend les données ERP consultables après révocation.
+
+## Compatibilité et rollback
+
+Cette décision ne change ni runtime ni schéma. Les parcours responsive et Electron
+restent inchangés. Une future activation sera feature-flaggée par locale/parcours et
+réversible vers `fr`/web ; les montants originaux et preuves de taux resteront
+conservés lors d'un rollback.
+
+## Conséquences
+
+CERP+ n'engage pas une traduction coûteuse ni un second frontend sans client. Le
+produit dispose cependant d'une frontière claire pour internationaliser sans fausser
+les montants ou dupliquer les règles métier.

--- a/docs/execution-reports/SOL-40.md
+++ b/docs/execution-reports/SOL-40.md
@@ -1,0 +1,70 @@
+# Rapport d'exécution — SOL-40 (backend)
+
+- Date : 2026-08-15
+- Issue : https://github.com/BigFootLime/erp-crp-backend/issues/549
+- Branche : `docs/549-sol40-i18n-mobile-gate`
+- Base : `origin/main` `2465761b99ff5e511fa004b09ecb50da36bd6e64`
+- Verdict : **NO-GO extension internationale/mobile sans besoin commercial**
+
+## Diagnostic et cause racine
+
+Le modèle sait stocker une langue et une devise sur certains objets, mais aucun
+usage réel ne prouve une conversion ou une autre locale. Une liste de quatre devises
+sans taux datés ne permet pas de calculer. Le besoin mobile est déjà couvert par des
+surfaces web ciblées ; aucune contrainte matérielle ne justifie une application
+séparée.
+
+## Preuves mesurées
+
+- `cerp_prod` en `BEGIN READ ONLY` : 191 clients `fr`, 191 clients `EUR` ;
+- référentiel devises : CHF, EUR, GBP et USD, sans table de taux datés ;
+- 0 facture, 0 commande client, 0 commande fournisseur et 0 devise transactionnelle ;
+- aucun besoin commercial i18n/PWA/mobile dans les issues ;
+- le backend conserve déjà les montants par devise et refuse les agrégats
+  inter-devises sans source de change.
+
+Une première requête d'introspection a référencé à tort `currencies.is_active` ; la
+transaction read-only a été annulée automatiquement. La requête corrigée a lu le
+schéma réel (`code`, `name`) et s'est terminée par `COMMIT`, sans écriture.
+
+## Architecture
+
+`ADR-0085` définit le gate commercial, les clés/locales futures, le gel de langue des
+documents, la preuve complète d'un taux et le choix PWA/native fondé sur le matériel.
+Les API et permissions existantes restent l'unique source métier.
+
+## Fichiers, migrations et données
+
+- `docs/adr/ADR-0085-internationalization-currency-mobile-gate.md` ;
+- `docs/execution-reports/SOL-40.md`.
+
+Aucun endpoint, devise, taux, traduction, migration, secret ou donnée n'est ajouté.
+
+## Tests et vérifications
+
+| Contrôle | Résultat |
+|---|---|
+| audit production read-only | PASS après correction d'introspection |
+| recherche schéma/taux/issues | PASS |
+| validation UTF-8 des Markdown | PASS — 2 fichiers sur 2 |
+| `git diff --check` | PASS |
+
+Les tests runtime et E2E backend sont non applicables à ce diff documentaire. Le
+frontend exécute séparément les tests des parcours ciblés existants.
+
+## Risques, compatibilité et rollback
+
+- Toute conversion sans taux daté serait fausse ; elle reste interdite.
+- Les documents émis ne pourront jamais changer de langue ou de taux rétroactivement.
+- Une PWA ne doit pas mettre en cache génériquement les données authentifiées.
+- Le modèle actuel `fr`/EUR et les parcours web restent inchangés.
+
+Revenir sur le commit retire seulement l'ADR et le rapport ; aucun rollback SQL ou
+applicatif n'est requis.
+
+## Reste réellement à faire
+
+1. Confirmer marché, locales, règles légales, devises et appareils.
+2. Choisir et contractualiser la source de taux Finance.
+3. Prioriser trois à cinq parcours mobiles et qualifier le matériel.
+4. Implémenter alors par lots, avec locale/taux figés et tests de sécurité/hors ligne.


### PR DESCRIPTION
## Résumé
- établit la frontière i18n, change et mobile
- documente les preuves production read-only
- interdit les conversions sans taux daté

Closes #549

## Summary by Sourcery

Document the decision to gate internationalization, multi-currency support, and mobile extensions behind confirmed commercial needs, without changing runtime or schema.

Documentation:
- Add ADR-0085 describing the commercial gate and architectural constraints for internationalization, currency handling, and mobile workflows.
- Add SOL-40 backend execution report documenting production read-only findings and the decision to block international/mobile extension without a proven business case.

Tests:
- Record that existing runtime and E2E tests are not applicable to this documentation-only change, and that basic documentation validations have been performed.

Chores:
- Clarify that no endpoints, migrations, currencies, exchange rates, translations, secrets, or data changes are introduced by this PR.