### PR TITLE
release: promote SOL-41 product scope guardrails

### DIFF
--- a/docs/adr/ADR-0086-product-scope-governance.md
+++ b/docs/adr/ADR-0086-product-scope-governance.md
@@ -1,0 +1,104 @@
+# ADR-0086 — Gouvernance du périmètre produit
+
+- Statut : accepté
+- Date : 2026-08-15
+- Propriétaire : direction produit CERP+
+- Portée : frontend, backend, données, intégrations et exploitation
+
+## Contexte
+
+CERP+ doit servir les flux industriels récurrents sans devenir une juxtaposition de
+variantes clients. Une fonction peu utilisée peut coûter durablement en sécurité,
+support, migrations, documentation et tests. À l'inverse, une demande spécifique
+peut devenir un bon composant produit si son besoin, sa frontière et son financement
+sont explicites.
+
+## Décision
+
+Toute évolution passe par la grille `docs/product/FEATURE_ACCEPTANCE_GRID.md` avant
+développement. Une fonction est soit :
+
+1. **produit commun**, lorsque le besoin est réutilisable, fréquent et soutenable ;
+2. **extension client financée**, isolée par configuration ou contrat stable, sans
+   fork de code ni affaiblissement de la sécurité ;
+3. **expérience bornée**, désactivée par défaut, avec date et critères de sortie ;
+4. **refusée ou différée**, lorsque les preuves ou la capacité de maintenance
+   manquent.
+
+Les exigences de sécurité, isolation, qualité de données, observabilité, sauvegarde,
+rollback et tests sont des gates : un score commercial ne peut pas les compenser.
+Une feature ne peut pas être activée en production par une valeur par défaut ambiguë.
+
+## Non-priorités explicites
+
+Tant qu'un contrat et une preuve d'usage ne les financent pas, CERP+ ne construit
+pas :
+
+- une comptabilité générale complète ;
+- une paie complète ;
+- un multitenant complexe prématuré ;
+- une IA prédictive sur des historiques insuffisants ou non qualifiés ;
+- des connecteurs IoT/CNC universels ;
+- des scènes 3D ou dashboards décoratifs supplémentaires.
+
+Ces sujets peuvent être réévalués par la grille ; ils ne sont ni promis ni activés
+par opportunité technique.
+
+## Passage de 3 à 10 puis 20 clients
+
+### Jusqu'à 3 clients pilotes
+
+- une instance dédiée par société reste acceptable ;
+- chaque flux vendu a un propriétaire, une preuve E2E, un runbook et un rollback ;
+- sauvegarde/restauration, RBAC, audit et prérequis métier sont démontrés ;
+- aucune divergence client ne nécessite un fork.
+
+### De 3 à 10 clients
+
+- deux usages indépendants au moins confirment chaque fonction promue au noyau ;
+- provisioning, configuration, migration et contrôle de release sont automatisés ;
+- coût de support par module, fréquence d'incident et délai de résolution sont mesurés ;
+- les extensions restent versionnées, documentées et testées dans la matrice commune ;
+- les engagements de disponibilité et de récupération sont contractualisés.
+
+### De 10 à 20 clients
+
+- la frontière organisation/site est réévaluée à partir des contrats réels ;
+- capacité, isolation, rotation des secrets, observabilité et reprise sont testées en
+  charge représentative ;
+- les modules au coût de support disproportionné sont corrigés, tarifés, dépréciés
+  ou retirés ;
+- le support et les opérations disposent d'une astreinte, d'indicateurs et d'un
+  budget compatibles avec le nombre d'instances.
+
+Le franchissement d'un palier est une décision écrite. Le nombre de clients seul ne
+constitue pas une preuve de maturité.
+
+## Revue trimestrielle
+
+La direction produit réunit produit, support, sécurité et exploitation. Pour chaque
+module elle examine : clients actifs, fréquence d'usage, tickets et temps passé,
+incidents, dette de sécurité, coût d'infrastructure, couverture de tests, revenu ou
+engagement associé et prochaine décision. Le relevé indique une source, une période,
+un propriétaire et une fiabilité ; une absence de mesure reste « indisponible », pas
+zéro.
+
+Les décisions possibles sont : maintenir, investir, reconfigurer, tarifer,
+déprécier ou retirer. Le cycle de dépréciation est défini dans
+`docs/product/EXTENSION_LIFECYCLE.md`.
+
+## Conséquences
+
+- Les demandes sont arbitrées avant de créer du code ou un schéma.
+- Les variantes maintenables utilisent des capacités communes et des configurations
+  explicites.
+- Les fonctions sans usage prouvé peuvent être retirées de façon annoncée et
+  réversible.
+- La grille et le relevé trimestriel deviennent des preuves attendues dans les PR
+  fonctionnelles significatives.
+
+## Rollback
+
+Cette décision ne modifie aucun runtime. La retirer exige un nouvel ADR expliquant
+la gouvernance de remplacement ; supprimer seulement les documents recréerait une
+zone de décision implicite.

--- a/docs/execution-reports/SOL-41.md
+++ b/docs/execution-reports/SOL-41.md
@@ -1,0 +1,69 @@
+# Rapport d'exécution — SOL-41
+
+- Date : 2026-08-15
+- Issue : https://github.com/BigFootLime/erp-crp-backend/issues/552
+- Branche : `docs/552-sol41-product-scope`
+- Base : `origin/main` `3a4566816ccb08b9870837fa1162b2dfb0449e8a`
+- Verdict : **garde-fous adoptés, aucun runtime ajouté**
+
+## Diagnostic et cause racine
+
+Les ADR récents bornaient plusieurs capacités risquées, mais la règle transversale
+d'acceptation, de financement, de mesure du support et de retrait n'était pas
+regroupée. Le risque était de réouvrir séparément les mêmes décisions et de créer des
+variantes durables sans propriétaire.
+
+## Choix d'architecture et produit
+
+`ADR-0086` impose quatre issues explicites : noyau commun, extension financée sans
+fork, expérience bornée ou non-intégration. La grille ne produit pas de score
+magique : sécurité, exploitation, données, tests et sortie restent bloquants.
+
+Le cycle de vie décrit la transformation d'une demande spécifique, la revue
+trimestrielle du coût de support et une dépréciation réversible. Les paliers 3, 10 et
+20 clients sont conditionnés par des preuves d'exploitation, pas par le volume seul.
+
+Les variables du helper Project Office ne sont pas configurées dans ce checkout ;
+aucun secret n'a été lu et aucune écriture implicite n'a été tentée. L'issue GitHub
+#552, la branche et la PR constituent la trace de travail disponible pour ce lot.
+
+## Fichiers modifiés
+
+- `docs/adr/ADR-0086-product-scope-governance.md` ;
+- `docs/product/FEATURE_ACCEPTANCE_GRID.md` ;
+- `docs/product/EXTENSION_LIFECYCLE.md` ;
+- `docs/execution-reports/SOL-41.md`.
+
+## Données, migrations et compatibilité
+
+Aucune migration, configuration, feature flag runtime, dépendance ou donnée n'est
+modifiée. La règle s'applique aux nouvelles décisions ; elle ne requalifie pas
+silencieusement les engagements existants.
+
+## Tests et preuves
+
+| Contrôle | Résultat |
+|---|---|
+| couverture des neuf axes demandés | PASS — 9 gates sur 9 |
+| non-priorités explicites | PASS — 6 catégories sur 6 |
+| paliers 3 → 10 → 20 clients | PASS — 3 gates documentés |
+| validation UTF-8 et liens relatifs | PASS — 4 fichiers sur 4 |
+| `git diff --check` | PASS |
+
+Les tests runtime, SQL, navigateur et E2E sont non applicables à ce diff purement
+documentaire. SOL-43 exécutera séparément le contrôle de release sur le commit propre.
+
+## Risques et rollback
+
+Le principal risque est organisationnel : une grille non liée aux décisions n'a pas
+d'effet. L'issue, la PR et les revues trimestrielles fournissent la trace minimale ;
+les prochaines évolutions significatives devront joindre leur décision.
+
+Le rollback technique consiste à revenir sur le commit. Un remplacement de la règle
+requiert cependant un nouvel ADR afin de ne pas recréer une gouvernance implicite.
+
+## Reste réellement à faire
+
+1. Appliquer la grille à la prochaine demande fonctionnelle significative.
+2. Mesurer le premier trimestre complet par module avant d'arbitrer une suppression.
+3. Revoir formellement les gates avant le passage de 3 à 10 clients.

--- a/docs/product/EXTENSION_LIFECYCLE.md
+++ b/docs/product/EXTENSION_LIFECYCLE.md
@@ -1,0 +1,62 @@
+# Cycle de vie des extensions et dépréciations
+
+## Transformer une demande spécifique
+
+1. **Observer** : décrire le travail, la fréquence, l'acteur et la preuve sans
+   promettre d'implémentation.
+2. **Classer** : appliquer `FEATURE_ACCEPTANCE_GRID.md` et choisir noyau, extension,
+   expérience, report ou refus.
+3. **Définir la frontière** : conserver une API et un modèle communs ; isoler les
+   écarts par configuration validée ou adaptateur versionné. Aucun fork client.
+4. **Contractualiser** : fixer prix, données, SLO, support, propriétaire et sortie.
+5. **Construire petit** : livrer le flux minimal, flag faux par défaut si
+   expérimental, audit et tests négatifs compris.
+6. **Promouvoir** : test puis production seulement après release gate, migration
+   réversible et runbook.
+7. **Mesurer** : usage et coût à 30/90 jours puis dans la revue trimestrielle.
+
+Les flags servent à contrôler un rollout temporaire, pas à maintenir indéfiniment
+plusieurs produits. Chaque flag a un propriétaire, une valeur production explicite,
+une date de retrait et des tests dans les deux états.
+
+## Revue trimestrielle du coût de support
+
+Pour chaque module, le propriétaire consigne sur le trimestre :
+
+- clients et utilisateurs actifs, opérations métier et dernière utilisation ;
+- tickets, incidents, gravité, temps de diagnostic et de résolution ;
+- temps d'assistance, formation et corrections manuelles ;
+- coût d'infrastructure et dépendances externes ;
+- dette de sécurité, migrations en attente et couverture de tests ;
+- revenu, contrat ou risque évité associé.
+
+Chaque mesure porte unité, période, source, fraîcheur et fiabilité. Les données
+incomplètes sont marquées `PARTIELLE` ou `INDISPONIBLE`. La revue produit un
+propriétaire et une décision datée.
+
+## Déprécier puis retirer
+
+1. ouvrir une décision avec usage mesuré, motif, propriétaire et alternative ;
+2. vérifier obligations contractuelles, conservation, export et dépendances ;
+3. annoncer une échéance proportionnée aux contrats et identifier les utilisateurs
+   concernés ;
+4. bloquer les nouvelles activations avant de retirer l'existant ;
+5. fournir export, migration, rollback et support de transition ;
+6. instrumenter l'usage résiduel sans PII et tester l'absence de consommateurs ;
+7. retirer code, routes, permissions, jobs, données de référence et documentation
+   morte dans une PR dédiée ;
+8. conserver les données requises ou les supprimer selon la politique approuvée ;
+9. valider release, sauvegarde/restauration, comportement métier et communication ;
+10. clore seulement après une période d'observation sans appel résiduel.
+
+## Actions interdites
+
+- supprimer une donnée ou une API sans inventaire des consommateurs et sauvegarde ;
+- laisser un endpoint déprécié non surveillé sans date de fin ;
+- facturer une extension que l'exploitation ne sait ni diagnostiquer ni restaurer ;
+- contourner RBAC, audit ou validation pour isoler une variante client ;
+- présenter un usage manquant comme nul.
+
+Le rollback d'un retrait restaure une version applicative compatible et, si le
+schéma a changé, la sauvegarde ou migration inverse testée. Un flag ne remplace pas
+la compatibilité des données.

--- a/docs/product/FEATURE_ACCEPTANCE_GRID.md
+++ b/docs/product/FEATURE_ACCEPTANCE_GRID.md
@@ -1,0 +1,70 @@
+# Grille d'acceptation d'une fonctionnalité CERP+
+
+À remplir avant estimation puis à relire avant promotion en production. Les sources
+doivent être liées ; « inconnu » n'est jamais remplacé par une hypothèse favorable.
+
+## Identité de la décision
+
+| Champ | Valeur attendue |
+|---|---|
+| Identifiant / titre | issue ou work package unique |
+| Demandeur et décideur | personnes responsables |
+| Clients concernés | noms internes ou segment, sans PII |
+| Problème observé | preuve du flux ou incident, pas une solution proposée |
+| Résultat attendu | indicateur, unité, période et seuil |
+| Échéance / contrat | date et engagement source |
+| Propriétaire après livraison | produit et exploitation |
+
+## Gates obligatoires
+
+Une réponse `NON` bloque l'acceptation. `N/A` exige une justification vérifiable.
+
+| Gate | Question | Preuve minimale |
+|---|---|---|
+| besoin client | le problème réel et son propriétaire sont-ils confirmés ? | entretien, contrat, incident ou données |
+| fréquence | connaît-on la fréquence et le nombre d'utilisateurs ? | période mesurée et source |
+| réutilisabilité | le cœur sert-il plusieurs clients sans fork ? | frontière commune / configuration |
+| coût complet | build, migration, support et retrait sont-ils chiffrés ? | estimation avec hypothèses |
+| sécurité | auth, RBAC, isolation, audit et secrets sont-ils couverts ? | revue et tests négatifs |
+| exploitation | health, logs, alertes, backup et runbook sont-ils prévus ? | plan opérable et propriétaire |
+| données | source, unité, période, fraîcheur et fiabilité sont-elles définies ? | contrat de données |
+| tests | unitaires, intégration, migration et E2E sont-ils proportionnés ? | scénarios et fixtures isolées |
+| prix | le coût récurrent est-il couvert par le produit ou le client ? | règle tarifaire / contrat |
+| sortie | rollback, feature flag éventuel et retrait sont-ils définis ? | plan daté |
+
+## Classement
+
+Après les gates, qualifier chaque axe `FAIBLE`, `MOYEN` ou `FORT` avec une phrase de
+preuve. Il n'existe pas de total automatique : un chiffre unique masquerait les
+risques asymétriques.
+
+| Axe | Questions d'arbitrage |
+|---|---|
+| valeur | fréquence, temps gagné, risque évité, engagement commercial |
+| portée | nombre de clients, rôles, sites, transactions et documents |
+| complexité | états, intégrations, concurrence, migrations et reprise |
+| charge récurrente | support, supervision, données de référence, formation |
+| réversibilité | capacité de désactivation, export et retour arrière |
+
+## Décision
+
+Cocher une seule issue :
+
+- [ ] **Noyau produit** — besoin réutilisable, coût mutualisé et maintenance produit.
+- [ ] **Extension client financée** — contrat stable, configuration isolée, support
+  et retrait financés ; aucun fork.
+- [ ] **Expérience bornée** — flag faux par défaut, population, métrique, propriétaire
+  et date de fin explicites.
+- [ ] **Différée** — preuve ou capacité manquante, prochaine action et date.
+- [ ] **Refusée** — conflit produit, risque ou coût disproportionné documenté.
+
+La décision mentionne décideur, date, durée de validité et conditions de réexamen.
+Une PR fonctionnelle significative lie cette grille ou justifie pourquoi le
+changement est purement correctif.
+
+## Revue après livraison
+
+À 30 et 90 jours, relever usage réel, incidents, temps de support, coût
+d'infrastructure, résultat métier et écarts aux hypothèses. La promotion d'une
+extension vers le noyau exige au moins deux usages clients indépendants et le
+respect des gates ; elle n'est jamais automatique.


### PR DESCRIPTION
Promotes the accepted SOL-41 product-scope ADR, decision grid and lifecycle guidance from dev to main.

## Summary by Sourcery

Introduce governance guardrails for CERP+ product scope, formalizing how new features and client-specific demands are evaluated, classified, and reviewed over time.

Documentation:
- Add ADR documenting product scope governance rules, non-priorities, growth milestones, and quarterly review expectations.
- Document a feature acceptance grid that standardizes decision inputs, mandatory gates, and classification outcomes for new functional changes.
- Add extension lifecycle guidance covering transformation of specific requests, support cost review, and deprecation/removal procedures.
- Record an execution report for SOL-41 capturing the rationale, scope, and non-runtime impact of adopting these governance guardrails.

Chores:
- Clarify that the new governance applies prospectively to future decisions without silently requalifying existing commitments.