### PR TITLE
test(e2e): assign the isolated MFA admin role

### DIFF
--- a/scripts/e2e/seed-mfa-sol32.js
+++ b/scripts/e2e/seed-mfa-sol32.js
@@ -24,11 +24,18 @@ async function main() {
     );
 
     const passwordHash = await bcrypt.hash(password, 10);
-    await client.query(
+    const adminResult = await client.query(
       `INSERT INTO public.users(username,password,name,surname,email,role,status,is_superadmin)
        VALUES ('SOL32ADMIN',$1,'SOL32','Admin','sol32-admin@invalid.example','Administrateur Systeme et Reseau','Active',true)
-       ON CONFLICT (username) DO UPDATE SET password=EXCLUDED.password,status='Active',is_superadmin=true`,
+       ON CONFLICT (username) DO UPDATE SET password=EXCLUDED.password,status='Active',is_superadmin=true
+       RETURNING id`,
       [passwordHash],
+    );
+    await client.query(
+      `INSERT INTO public.user_role_assignments(user_id,role_key,assigned_by)
+       VALUES ($1,'Administrateur Systeme et Reseau',$2)
+       ON CONFLICT (user_id,role_key) DO NOTHING`,
+      [adminResult.rows[0].id, keenan.id],
     );
     await client.query("COMMIT");
     process.stdout.write(JSON.stringify({ seeded: true, activeFactorUser: "KEENAN", enrollmentUser: "SOL32ADMIN" }) + "\n");

--- a/src/__tests__/e2e-mfa-seed-contract.test.ts
+++ b/src/__tests__/e2e-mfa-seed-contract.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("isolated MFA seed contract", () => {
+  it("never creates an active SOL32ADMIN account without its primary role assignment", () => {
+    const source = readFileSync(path.resolve("scripts/e2e/seed-mfa-sol32.js"), "utf8");
+
+    expect(source).toContain("RETURNING id");
+    expect(source).toContain("INSERT INTO public.user_role_assignments");
+    expect(source).toContain("'Administrateur Systeme et Reseau'");
+    expect(source).toContain("ON CONFLICT (user_id,role_key) DO NOTHING");
+  });
+});


### PR DESCRIPTION
## Fix
Assign the active SOL32ADMIN fixture its primary catalog role in the same seed transaction.

## Proof
- targeted backend: 2 files / 11 tests PASS
- strict backend build: PASS
- isolated business/UI subset with corrected backend: 11/11 Playwright PASS

Closes #555

## Summary by Sourcery

Tests:
- Add an e2e contract test verifying the seed script always assigns SOL32ADMIN its primary role when the account is active.