### PR TITLE
release: promote SOL-43 MFA seed role fix

### DIFF
--- a/scripts/e2e/seed-mfa-sol32.js
+++ b/scripts/e2e/seed-mfa-sol32.js
@@ -24,11 +24,18 @@ async function main() {
     );
 
     const passwordHash = await bcrypt.hash(password, 10);
-    await client.query(
+    const adminResult = await client.query(
       `INSERT INTO public.users(username,password,name,surname,email,role,status,is_superadmin)
        VALUES ('SOL32ADMIN',$1,'SOL32','Admin','sol32-admin@invalid.example','Administrateur Systeme et Reseau','Active',true)
-       ON CONFLICT (username) DO UPDATE SET password=EXCLUDED.password,status='Active',is_superadmin=true`,
+       ON CONFLICT (username) DO UPDATE SET password=EXCLUDED.password,status='Active',is_superadmin=true
+       RETURNING id`,
       [passwordHash],
+    );
+    await client.query(
+      `INSERT INTO public.user_role_assignments(user_id,role_key,assigned_by)
+       VALUES ($1,'Administrateur Systeme et Reseau',$2)
+       ON CONFLICT (user_id,role_key) DO NOTHING`,
+      [adminResult.rows[0].id, keenan.id],
     );
     await client.query("COMMIT");
     process.stdout.write(JSON.stringify({ seeded: true, activeFactorUser: "KEENAN", enrollmentUser: "SOL32ADMIN" }) + "\n");

--- a/src/__tests__/e2e-mfa-seed-contract.test.ts
+++ b/src/__tests__/e2e-mfa-seed-contract.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("isolated MFA seed contract", () => {
+  it("never creates an active SOL32ADMIN account without its primary role assignment", () => {
+    const source = readFileSync(path.resolve("scripts/e2e/seed-mfa-sol32.js"), "utf8");
+
+    expect(source).toContain("RETURNING id");
+    expect(source).toContain("INSERT INTO public.user_role_assignments");
+    expect(source).toContain("'Administrateur Systeme et Reseau'");
+    expect(source).toContain("ON CONFLICT (user_id,role_key) DO NOTHING");
+  });
+});


### PR DESCRIPTION
Promotes the tested isolated MFA role invariant fix from dev to main.

## Summary by Sourcery

Ensure SOL32 MFA seeding always assigns the primary system administrator role to the seeded admin user and add a test to enforce this invariant.

New Features:
- Add explicit creation of the SOL32 admin user's primary role assignment during MFA seed script execution.

Tests:
- Introduce an end-to-end contract test that verifies the MFA seed script never activates the SOL32 admin user without its primary role assignment.