### PR TITLE
test(e2e): reinitialiser les revues d acces isolees

### DIFF
--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -87,6 +87,11 @@ async function main() {
   await client.connect();
   try {
     await client.query("BEGIN");
+    // The access-review browser proof must always start from the same state.
+    // This seed is hard-gated to loopback cerp_test above, so no operational
+    // review can be removed by this deterministic fixture reset.
+    await client.query("DELETE FROM public.app_access_review_items");
+    await client.query("DELETE FROM public.app_access_reviews");
     for (const [username, name, surname, email, role, superadmin, assignedRole] of USERS) {
       const result = await client.query(
         `INSERT INTO public.users (username,password,name,surname,email,role,status,is_superadmin)

--- a/src/__tests__/e2e-isolated-seed-contract.test.ts
+++ b/src/__tests__/e2e-isolated-seed-contract.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("isolated deterministic seed contract", () => {
+  it("resets access reviews only after the loopback cerp_test guard", () => {
+    const source = readFileSync(path.resolve("scripts/e2e/seed-isolated.js"), "utf8");
+    const guard = source.indexOf("assertIsolated();")
+    const deleteItems = source.indexOf("DELETE FROM public.app_access_review_items")
+    const deleteReviews = source.indexOf("DELETE FROM public.app_access_reviews")
+
+    expect(guard).toBeGreaterThanOrEqual(0);
+    expect(deleteItems).toBeGreaterThan(guard);
+    expect(deleteReviews).toBeGreaterThan(deleteItems);
+  });
+});


### PR DESCRIPTION
Closes #558. Réinitialise les seules tables de revue d’accès après garde stricte loopback/cerp_test afin que la preuve de création soit rejouable. Preuves: tests contrats 2/2, build backend, pile isolée frontend 11/11.

## Summary by Sourcery

Reset isolated access-review tables in the e2e seed to ensure a deterministic initial state for browser proofs, and add a contract test to guard the reset ordering and isolation assumptions.

Bug Fixes:
- Ensure isolated e2e access-review proofs always start from a clean, deterministic database state by clearing access-review tables in the seed script.

Tests:
- Add an e2e contract test that verifies access-review table resets occur only after the isolated loopback cerp_test guard and in the expected order.