### PR TITLE
test(e2e): promouvoir la fixture de revue déterministe

### DIFF
--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -87,6 +87,11 @@ async function main() {
   await client.connect();
   try {
     await client.query("BEGIN");
+    // The access-review browser proof must always start from the same state.
+    // This seed is hard-gated to loopback cerp_test above, so no operational
+    // review can be removed by this deterministic fixture reset.
+    await client.query("DELETE FROM public.app_access_review_items");
+    await client.query("DELETE FROM public.app_access_reviews");
     for (const [username, name, surname, email, role, superadmin, assignedRole] of USERS) {
       const result = await client.query(
         `INSERT INTO public.users (username,password,name,surname,email,role,status,is_superadmin)

--- a/src/__tests__/e2e-isolated-seed-contract.test.ts
+++ b/src/__tests__/e2e-isolated-seed-contract.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("isolated deterministic seed contract", () => {
+  it("resets access reviews only after the loopback cerp_test guard", () => {
+    const source = readFileSync(path.resolve("scripts/e2e/seed-isolated.js"), "utf8");
+    const guard = source.indexOf("assertIsolated();")
+    const deleteItems = source.indexOf("DELETE FROM public.app_access_review_items")
+    const deleteReviews = source.indexOf("DELETE FROM public.app_access_reviews")
+
+    expect(guard).toBeGreaterThanOrEqual(0);
+    expect(deleteItems).toBeGreaterThan(guard);
+    expect(deleteReviews).toBeGreaterThan(deleteItems);
+  });
+});


### PR DESCRIPTION
Promotion contrôlée de #559. Preuves: contrats 2/2, build backend et pile isolée 11/11.

## Summary by Sourcery

Ensure isolated e2e seeds reset access review data deterministically while preserving the loopback cerp_test isolation guard.

Bug Fixes:
- Clear access review and review item tables in the isolated e2e seed to enforce a consistent initial state for browser-based access-review proofs.

Tests:
- Add a contract test that verifies access review resets happen only after the isolated environment guard and in the correct order.