### PR TITLE
test(migrations): supporter les schemas historiques

### DIFF
--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -88,10 +88,17 @@ async function main() {
   try {
     await client.query("BEGIN");
     // The access-review browser proof must always start from the same state.
-    // This seed is hard-gated to loopback cerp_test above, so no operational
-    // review can be removed by this deterministic fixture reset.
-    await client.query("DELETE FROM public.app_access_review_items");
-    await client.query("DELETE FROM public.app_access_reviews");
+    // The migration rehearsal also runs this seed against historical schemas,
+    // before SOL-25 created these tables, so the reset is capability-based.
+    const accessReviewTables = await client.query(
+      `SELECT
+         to_regclass('public.app_access_review_items') IS NOT NULL AS items,
+         to_regclass('public.app_access_reviews') IS NOT NULL AS reviews`
+    );
+    if (accessReviewTables.rows[0]?.items && accessReviewTables.rows[0]?.reviews) {
+      await client.query("DELETE FROM public.app_access_review_items");
+      await client.query("DELETE FROM public.app_access_reviews");
+    }
     for (const [username, name, surname, email, role, superadmin, assignedRole] of USERS) {
       const result = await client.query(
         `INSERT INTO public.users (username,password,name,surname,email,role,status,is_superadmin)

--- a/src/__tests__/e2e-isolated-seed-contract.test.ts
+++ b/src/__tests__/e2e-isolated-seed-contract.test.ts
@@ -6,12 +6,16 @@ import { describe, expect, it } from "vitest";
 describe("isolated deterministic seed contract", () => {
   it("resets access reviews only after the loopback cerp_test guard", () => {
     const source = readFileSync(path.resolve("scripts/e2e/seed-isolated.js"), "utf8");
-    const guard = source.indexOf("assertIsolated();")
-    const deleteItems = source.indexOf("DELETE FROM public.app_access_review_items")
-    const deleteReviews = source.indexOf("DELETE FROM public.app_access_reviews")
+    const guard = source.indexOf("assertIsolated();");
+    const capabilityCheck = source.indexOf("to_regclass('public.app_access_review_items')");
+    const guardedReset = source.indexOf("if (accessReviewTables.rows[0]?.items && accessReviewTables.rows[0]?.reviews)");
+    const deleteItems = source.indexOf("DELETE FROM public.app_access_review_items");
+    const deleteReviews = source.indexOf("DELETE FROM public.app_access_reviews");
 
     expect(guard).toBeGreaterThanOrEqual(0);
-    expect(deleteItems).toBeGreaterThan(guard);
+    expect(capabilityCheck).toBeGreaterThan(guard);
+    expect(guardedReset).toBeGreaterThan(capabilityCheck);
+    expect(deleteItems).toBeGreaterThan(guardedReset);
     expect(deleteReviews).toBeGreaterThan(deleteItems);
   });
 });


### PR DESCRIPTION
Closes #561. Le reset SOL-25 est conditionné à la présence des tables pendant les répétitions de rollback. Preuves: contrat 1/1, build, répétition SOL-06 restore=passed replay=true.

## Summary by Sourcery

Make the isolated E2E seed compatible with historical database schemas while preserving the access-review reset contract.

Bug Fixes:
- Guard the access-review tables reset in the isolated E2E seed so it only runs when the relevant tables exist, supporting migration rehearsals on older schemas.

Tests:
- Extend the isolated deterministic seed contract test to assert the presence and ordering of the new capability check and guarded reset logic.