### PR TITLE
test(migrations): promouvoir la compatibilite rollback SOL-43

### DIFF
--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -88,10 +88,17 @@ async function main() {
   try {
     await client.query("BEGIN");
     // The access-review browser proof must always start from the same state.
-    // This seed is hard-gated to loopback cerp_test above, so no operational
-    // review can be removed by this deterministic fixture reset.
-    await client.query("DELETE FROM public.app_access_review_items");
-    await client.query("DELETE FROM public.app_access_reviews");
+    // The migration rehearsal also runs this seed against historical schemas,
+    // before SOL-25 created these tables, so the reset is capability-based.
+    const accessReviewTables = await client.query(
+      `SELECT
+         to_regclass('public.app_access_review_items') IS NOT NULL AS items,
+         to_regclass('public.app_access_reviews') IS NOT NULL AS reviews`
+    );
+    if (accessReviewTables.rows[0]?.items && accessReviewTables.rows[0]?.reviews) {
+      await client.query("DELETE FROM public.app_access_review_items");
+      await client.query("DELETE FROM public.app_access_reviews");
+    }
     for (const [username, name, surname, email, role, superadmin, assignedRole] of USERS) {
       const result = await client.query(
         `INSERT INTO public.users (username,password,name,surname,email,role,status,is_superadmin)

--- a/src/__tests__/e2e-isolated-seed-contract.test.ts
+++ b/src/__tests__/e2e-isolated-seed-contract.test.ts
@@ -6,12 +6,16 @@ import { describe, expect, it } from "vitest";
 describe("isolated deterministic seed contract", () => {
   it("resets access reviews only after the loopback cerp_test guard", () => {
     const source = readFileSync(path.resolve("scripts/e2e/seed-isolated.js"), "utf8");
-    const guard = source.indexOf("assertIsolated();")
-    const deleteItems = source.indexOf("DELETE FROM public.app_access_review_items")
-    const deleteReviews = source.indexOf("DELETE FROM public.app_access_reviews")
+    const guard = source.indexOf("assertIsolated();");
+    const capabilityCheck = source.indexOf("to_regclass('public.app_access_review_items')");
+    const guardedReset = source.indexOf("if (accessReviewTables.rows[0]?.items && accessReviewTables.rows[0]?.reviews)");
+    const deleteItems = source.indexOf("DELETE FROM public.app_access_review_items");
+    const deleteReviews = source.indexOf("DELETE FROM public.app_access_reviews");
 
     expect(guard).toBeGreaterThanOrEqual(0);
-    expect(deleteItems).toBeGreaterThan(guard);
+    expect(capabilityCheck).toBeGreaterThan(guard);
+    expect(guardedReset).toBeGreaterThan(capabilityCheck);
+    expect(deleteItems).toBeGreaterThan(guardedReset);
     expect(deleteReviews).toBeGreaterThan(deleteItems);
   });
 });


### PR DESCRIPTION
Promotion contrôlée de #562. La répétition isolée SOL-06 passe avec restauration et replay.

## Summary by Sourcery

Make the isolated seed script compatible with historical schemas while preserving its deterministic access-review reset guard.

Enhancements:
- Gate the access-review table reset in the isolated seed script on the presence of the relevant tables to support running against pre-SOL-25 schemas.

Tests:
- Adjust the isolated seed contract E2E test to assert the new capability-based reset ordering around the access-review tables.