### PR TITLE
release: promote SOL-43 migration convergence

### DIFF
--- a/db/patches/20260815_historical_test_guard_convergence_sol43.sql
+++ b/db/patches/20260815_historical_test_guard_convergence_sol43.sql
@@ -1,0 +1,211 @@
+-- SOL-43 — converge four historical migrations that were intentionally guarded
+-- to cerp_test. The final state is applied atomically and the legacy ledger
+-- entries are recorded only after all preconditions have been verified.
+
+BEGIN;
+
+DO $$
+DECLARE
+  current_scale integer;
+  mismatch_count integer;
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'SOL-43 convergence refused on database %', current_database();
+  END IF;
+
+  IF to_regclass('public.contacts') IS NULL
+     OR to_regclass('public.data_import_batches') IS NULL
+     OR to_regclass('public.stock_movement_lines') IS NULL
+     OR to_regclass('public.stock_movements') IS NULL
+     OR to_regclass('public.stock_movement_event_log') IS NULL
+     OR to_regclass('public.cerp_schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'SOL-43 convergence refused: required tables are missing';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.contacts
+     WHERE client_id IS NOT NULL
+       AND email IS NOT NULL
+       AND btrim(email) <> ''
+       AND archived_at IS NULL
+     GROUP BY
+       client_id,
+       lower(btrim(email)),
+       lower(btrim(coalesce(first_name, ''))),
+       lower(btrim(coalesce(last_name, '')))
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'SOL-43 convergence refused: duplicate active contact identities exist';
+  END IF;
+
+  SELECT numeric_scale
+    INTO current_scale
+    FROM information_schema.columns
+   WHERE table_schema = 'public'
+     AND table_name = 'stock_movement_lines'
+     AND column_name = 'qty';
+
+  IF current_scale NOT IN (3, 6) THEN
+    RAISE EXCEPTION 'SOL-43 convergence refused: unexpected stock quantity scale %', current_scale;
+  END IF;
+
+  SELECT count(*)::integer
+    INTO mismatch_count
+    FROM public.cerp_schema_migrations AS applied
+    JOIN (VALUES
+      ('20260727_contacts_email_scope_187.sql', '4d43141bc2e6b803f4b37d1dff146c9950e64c75f0b317194ebf03dacbddbf1a'),
+      ('20260727_contacts_shared_email_identity_190.sql', 'b3b030cefbbf16ceca44481d74380de71803d72320c19b4da9cc62eee37aaf89'),
+      ('20260727_import_supplier_orders_312.sql', '5988f518ebfe8160372ec833fb14fba636a54638f367a637703162032d7193a0'),
+      ('20260727_stock_import_precision_198.sql', '0a348b7d6b723ba2d38b4927a5eed9a3999e3dfa82f56940f1f3a4d5b2da5a6a')
+    ) AS expected(filename, sha256)
+      ON expected.filename = applied.filename
+   WHERE applied.sha256 <> expected.sha256;
+
+  IF mismatch_count <> 0 THEN
+    RAISE EXCEPTION 'SOL-43 convergence refused: historical migration checksum mismatch';
+  END IF;
+END
+$$;
+
+ALTER TABLE public.contacts
+  DROP CONSTRAINT IF EXISTS contacts_email_key;
+
+DROP INDEX IF EXISTS public.contacts_client_email_active_key;
+DROP INDEX IF EXISTS public.contacts_client_email_identity_active_key;
+
+CREATE UNIQUE INDEX contacts_client_email_identity_active_key
+  ON public.contacts (
+    client_id,
+    lower(btrim(email)),
+    lower(btrim(coalesce(first_name, ''))),
+    lower(btrim(coalesce(last_name, '')))
+  )
+  WHERE client_id IS NOT NULL
+    AND email IS NOT NULL
+    AND btrim(email) <> ''
+    AND archived_at IS NULL;
+
+ALTER TABLE public.data_import_batches
+  DROP CONSTRAINT IF EXISTS data_import_batches_entity_ck;
+
+ALTER TABLE public.data_import_batches
+  ADD CONSTRAINT data_import_batches_entity_ck CHECK (
+    entity_type IN (
+      'CLIENT',
+      'CLIENT_ENRICHISSEMENT',
+      'CLIENT_CONTACT',
+      'FOURNISSEUR',
+      'FOURNISSEUR_COMMANDE',
+      'ARTICLE',
+      'PIECE_TECHNIQUE',
+      'MACHINE',
+      'STOCK_INITIAL',
+      'BL_HISTORIQUE',
+      'EMPLOYE'
+    )
+  );
+
+ALTER TABLE public.stock_movement_lines
+  ALTER COLUMN qty TYPE numeric(18,6)
+  USING qty::numeric(18,6);
+
+ALTER TABLE public.stock_movement_lines
+  DISABLE TRIGGER trg_protect_posted_stock_movement_line;
+
+WITH opening_lines AS (
+  SELECT
+    line.id AS line_id,
+    line.movement_id,
+    line.qty AS old_line_qty,
+    movement.qty AS posted_qty,
+    COALESCE(movement.posted_by, movement.updated_by, movement.created_by, movement.user_id) AS actor_user_id,
+    count(*) OVER (PARTITION BY line.movement_id) AS lines_count
+  FROM public.stock_movement_lines AS line
+  JOIN public.stock_movements AS movement ON movement.id = line.movement_id
+  WHERE movement.status = 'POSTED'
+    AND movement.source_document_type = 'CLIPPER_STOCK_OPENING'
+), repaired AS (
+  UPDATE public.stock_movement_lines AS line
+     SET qty = opening_lines.posted_qty,
+         updated_at = now(),
+         updated_by = opening_lines.actor_user_id
+    FROM opening_lines
+   WHERE line.id = opening_lines.line_id
+     AND opening_lines.lines_count = 1
+     AND opening_lines.old_line_qty IS DISTINCT FROM opening_lines.posted_qty
+     AND abs(opening_lines.old_line_qty - opening_lines.posted_qty) < 0.0005
+  RETURNING
+    opening_lines.movement_id,
+    opening_lines.old_line_qty,
+    opening_lines.posted_qty,
+    opening_lines.actor_user_id
+)
+INSERT INTO public.stock_movement_event_log (
+  id,
+  stock_movement_id,
+  event_type,
+  old_values,
+  new_values,
+  user_id,
+  created_by,
+  updated_by
+)
+SELECT
+  gen_random_uuid(),
+  movement_id,
+  'PRECISION_RECONCILED_198',
+  jsonb_build_object('line_qty', old_line_qty),
+  jsonb_build_object(
+    'line_qty', posted_qty,
+    'reason', 'SOL-43 production-safe convergence to NUMERIC(18,6)'
+  ),
+  actor_user_id,
+  actor_user_id,
+  actor_user_id
+FROM repaired;
+
+ALTER TABLE public.stock_movement_lines
+  ENABLE TRIGGER trg_protect_posted_stock_movement_line;
+
+CREATE TABLE IF NOT EXISTS public.cerp_migration_supersessions (
+  legacy_filename text PRIMARY KEY,
+  legacy_sha256 text NOT NULL CHECK (legacy_sha256 ~ '^[0-9a-f]{64}$'),
+  replacement_filename text NOT NULL,
+  database_name text NOT NULL,
+  applied_by text NOT NULL,
+  applied_at timestamptz NOT NULL DEFAULT now(),
+  reason text NOT NULL
+);
+
+INSERT INTO public.cerp_migration_supersessions (
+  legacy_filename,
+  legacy_sha256,
+  replacement_filename,
+  database_name,
+  applied_by,
+  reason
+)
+VALUES
+  ('20260727_contacts_email_scope_187.sql', '4d43141bc2e6b803f4b37d1dff146c9950e64c75f0b317194ebf03dacbddbf1a', '20260815_historical_test_guard_convergence_sol43.sql', current_database(), current_user, 'Legacy patch was restricted to cerp_test; final contact identity rule applied by SOL-43'),
+  ('20260727_contacts_shared_email_identity_190.sql', 'b3b030cefbbf16ceca44481d74380de71803d72320c19b4da9cc62eee37aaf89', '20260815_historical_test_guard_convergence_sol43.sql', current_database(), current_user, 'Legacy patch was restricted to cerp_test; final contact identity rule applied by SOL-43'),
+  ('20260727_import_supplier_orders_312.sql', '5988f518ebfe8160372ec833fb14fba636a54638f367a637703162032d7193a0', '20260815_historical_test_guard_convergence_sol43.sql', current_database(), current_user, 'Legacy patch was restricted to cerp_test; supplier-order import constraint applied by SOL-43'),
+  ('20260727_stock_import_precision_198.sql', '0a348b7d6b723ba2d38b4927a5eed9a3999e3dfa82f56940f1f3a4d5b2da5a6a', '20260815_historical_test_guard_convergence_sol43.sql', current_database(), current_user, 'Legacy patch was restricted to cerp_test; stock precision and bounded repair applied by SOL-43')
+ON CONFLICT (legacy_filename) DO UPDATE
+SET legacy_sha256 = EXCLUDED.legacy_sha256,
+    replacement_filename = EXCLUDED.replacement_filename,
+    database_name = EXCLUDED.database_name,
+    applied_by = EXCLUDED.applied_by,
+    applied_at = now(),
+    reason = EXCLUDED.reason;
+
+INSERT INTO public.cerp_schema_migrations (filename, sha256)
+VALUES
+  ('20260727_contacts_email_scope_187.sql', '4d43141bc2e6b803f4b37d1dff146c9950e64c75f0b317194ebf03dacbddbf1a'),
+  ('20260727_contacts_shared_email_identity_190.sql', 'b3b030cefbbf16ceca44481d74380de71803d72320c19b4da9cc62eee37aaf89'),
+  ('20260727_import_supplier_orders_312.sql', '5988f518ebfe8160372ec833fb14fba636a54638f367a637703162032d7193a0'),
+  ('20260727_stock_import_precision_198.sql', '0a348b7d6b723ba2d38b4927a5eed9a3999e3dfa82f56940f1f3a4d5b2da5a6a')
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/db/patches/support/20260815_historical_test_guard_convergence_sol43.preflight.sql
+++ b/db/patches/support/20260815_historical_test_guard_convergence_sol43.preflight.sql
@@ -1,0 +1,64 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+DECLARE
+  current_scale integer;
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'SOL-43 convergence preflight refused on database %', current_database();
+  END IF;
+
+  IF to_regclass('public.contacts') IS NULL
+     OR to_regclass('public.data_import_batches') IS NULL
+     OR to_regclass('public.stock_movement_lines') IS NULL
+     OR to_regclass('public.stock_movements') IS NULL
+     OR to_regclass('public.stock_movement_event_log') IS NULL
+     OR to_regclass('public.cerp_schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'SOL-43 convergence preflight refused: required tables are missing';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.contacts
+     WHERE client_id IS NOT NULL
+       AND email IS NOT NULL
+       AND btrim(email) <> ''
+       AND archived_at IS NULL
+     GROUP BY client_id, lower(btrim(email)), lower(btrim(coalesce(first_name, ''))), lower(btrim(coalesce(last_name, '')))
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'SOL-43 convergence preflight refused: duplicate active contact identities exist';
+  END IF;
+
+  SELECT numeric_scale
+    INTO current_scale
+    FROM information_schema.columns
+   WHERE table_schema = 'public'
+     AND table_name = 'stock_movement_lines'
+     AND column_name = 'qty';
+
+  IF current_scale NOT IN (3, 6) THEN
+    RAISE EXCEPTION 'SOL-43 convergence preflight refused: unexpected stock quantity scale %', current_scale;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.cerp_schema_migrations AS applied
+      JOIN (VALUES
+        ('20260727_contacts_email_scope_187.sql', '4d43141bc2e6b803f4b37d1dff146c9950e64c75f0b317194ebf03dacbddbf1a'),
+        ('20260727_contacts_shared_email_identity_190.sql', 'b3b030cefbbf16ceca44481d74380de71803d72320c19b4da9cc62eee37aaf89'),
+        ('20260727_import_supplier_orders_312.sql', '5988f518ebfe8160372ec833fb14fba636a54638f367a637703162032d7193a0'),
+        ('20260727_stock_import_precision_198.sql', '0a348b7d6b723ba2d38b4927a5eed9a3999e3dfa82f56940f1f3a4d5b2da5a6a')
+      ) AS expected(filename, sha256)
+        ON expected.filename = applied.filename
+     WHERE applied.sha256 <> expected.sha256
+  ) THEN
+    RAISE EXCEPTION 'SOL-43 convergence preflight refused: historical migration checksum mismatch';
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/db/patches/support/20260815_historical_test_guard_convergence_sol43.rollback.sql
+++ b/db/patches/support/20260815_historical_test_guard_convergence_sol43.rollback.sql
@@ -1,0 +1,9 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  RAISE EXCEPTION USING
+    MESSAGE = 'SOL-43 convergence rollback requires restoring the verified pre-migration custom-format backup into a new database',
+    HINT = 'Do not delete supersession evidence or downcast stock quantities in place; validate the restored database, then repoint the previous application release.';
+END
+$$;

--- a/db/patches/support/20260815_historical_test_guard_convergence_sol43.verify.sql
+++ b/db/patches/support/20260815_historical_test_guard_convergence_sol43.verify.sql
@@ -1,0 +1,60 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+DECLARE
+  current_scale integer;
+  proven_count integer;
+BEGIN
+  IF to_regclass('public.cerp_migration_supersessions') IS NULL THEN
+    RAISE EXCEPTION 'SOL-43 convergence verification failed: supersession audit table is missing';
+  END IF;
+
+  IF to_regclass('public.contacts_client_email_identity_active_key') IS NULL
+     OR to_regclass('public.contacts_email_key') IS NOT NULL
+     OR to_regclass('public.contacts_client_email_active_key') IS NOT NULL THEN
+    RAISE EXCEPTION 'SOL-43 convergence verification failed: contact identity indexes are not final';
+  END IF;
+
+  SELECT numeric_scale
+    INTO current_scale
+    FROM information_schema.columns
+   WHERE table_schema = 'public'
+     AND table_name = 'stock_movement_lines'
+     AND column_name = 'qty';
+
+  IF current_scale <> 6 THEN
+    RAISE EXCEPTION 'SOL-43 convergence verification failed: stock quantity scale is %', current_scale;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conrelid = 'public.data_import_batches'::regclass
+       AND conname = 'data_import_batches_entity_ck'
+       AND pg_get_constraintdef(oid) LIKE '%FOURNISSEUR_COMMANDE%'
+  ) THEN
+    RAISE EXCEPTION 'SOL-43 convergence verification failed: supplier-order import is not allowed';
+  END IF;
+
+  SELECT count(*)::integer
+    INTO proven_count
+    FROM public.cerp_schema_migrations AS applied
+    JOIN public.cerp_migration_supersessions AS supersession
+      ON supersession.legacy_filename = applied.filename
+     AND supersession.legacy_sha256 = applied.sha256
+   WHERE applied.filename IN (
+     '20260727_contacts_email_scope_187.sql',
+     '20260727_contacts_shared_email_identity_190.sql',
+     '20260727_import_supplier_orders_312.sql',
+     '20260727_stock_import_precision_198.sql'
+   );
+
+  IF proven_count <> 4 THEN
+    RAISE EXCEPTION 'SOL-43 convergence verification failed: expected 4 provenance records, found %', proven_count;
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/docs/release/MIGRATION_INVENTORY_SOL_06.json
+++ b/docs/release/MIGRATION_INVENTORY_SOL_06.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-08-14T14:13:24.602Z",
+  "generated_at": "2026-08-15T10:58:45.419Z",
   "source": "filesystem scan of db/patches and db/patches/support",
-  "patch_count": 157,
-  "support_file_count": 263,
-  "recent_patch_count": 99,
+  "patch_count": 164,
+  "support_file_count": 284,
+  "recent_patch_count": 106,
   "recent_support_gaps": [
     {
       "filename": "20260706_affaire_allow_projet.sql",
@@ -209,9 +209,9 @@
   "risk_totals": {
     "destructive_ddl": 2,
     "destructive_dml": 8,
-    "data_rewrite": 93,
-    "table_lock": 126,
-    "blocking_index": 118,
+    "data_rewrite": 100,
+    "table_lock": 128,
+    "blocking_index": 125,
     "enum_change": 1
   },
   "patches": [
@@ -2812,6 +2812,23 @@
     },
     {
       "order": 152,
+      "filename": "20260814_accounting_export_sol27.sql",
+      "sha256": "7daeedd829315f64e5bd5752a15047a45c80b0836093d135815305623b61e309",
+      "bytes": 12912,
+      "transaction_wrapped": true,
+      "replay_markers": true,
+      "support": {
+        "preflight": true,
+        "verify": true,
+        "rollback": true
+      },
+      "risks": [
+        "data-rewrite",
+        "blocking-index"
+      ]
+    },
+    {
+      "order": 153,
       "filename": "20260814_admin_operations_sol25.sql",
       "sha256": "741a16b710835f4bc05dcac52c7ba5ceb74504c962bfe4307805d2071142d3f3",
       "bytes": 8264,
@@ -2829,7 +2846,7 @@
       ]
     },
     {
-      "order": 153,
+      "order": 154,
       "filename": "20260814_adv_reliability_sol23.sql",
       "sha256": "f14a8d356312133841168e681f4266142ff95f7e4a07dc6c2a18dd50b9a4f52e",
       "bytes": 13216,
@@ -2847,7 +2864,41 @@
       ]
     },
     {
-      "order": 154,
+      "order": 155,
+      "filename": "20260814_api_contract_webhooks_sol28.sql",
+      "sha256": "42d9f33de100499836e7c1d58ef49e91daffa4af3861c59536bc2d0ab0f87f1f",
+      "bytes": 11363,
+      "transaction_wrapped": true,
+      "replay_markers": true,
+      "support": {
+        "preflight": true,
+        "verify": true,
+        "rollback": true
+      },
+      "risks": [
+        "data-rewrite",
+        "blocking-index"
+      ]
+    },
+    {
+      "order": 156,
+      "filename": "20260814_client_portal_sol29.sql",
+      "sha256": "d5c203c1c44f61b2b296d8fd08a5a35eb8b65060200119cbf7fe873f215d0f5c",
+      "bytes": 15120,
+      "transaction_wrapped": true,
+      "replay_markers": true,
+      "support": {
+        "preflight": true,
+        "verify": true,
+        "rollback": true
+      },
+      "risks": [
+        "data-rewrite",
+        "blocking-index"
+      ]
+    },
+    {
+      "order": 157,
       "filename": "20260814_electronic_invoicing_sol26.sql",
       "sha256": "03da2f92e7c99e1ffe437fb5443517585a9c20765322d85ab0cb83e378f7968e",
       "bytes": 9660,
@@ -2864,7 +2915,24 @@
       ]
     },
     {
-      "order": 155,
+      "order": 158,
+      "filename": "20260814_identification_labels_sol30.sql",
+      "sha256": "e9a2a116945105fbcce2a4ecc7246b3c9708a9d64920ed5f7a8ef94dc3740a7d",
+      "bytes": 11072,
+      "transaction_wrapped": true,
+      "replay_markers": true,
+      "support": {
+        "preflight": true,
+        "verify": true,
+        "rollback": true
+      },
+      "risks": [
+        "data-rewrite",
+        "blocking-index"
+      ]
+    },
+    {
+      "order": 159,
       "filename": "20260814_planning_execution_intelligence_0021.sql",
       "sha256": "ca667814cae65e695ec45dccf407752432aa9e6f7e61b4d9a38ae6fcfd339107",
       "bytes": 5133,
@@ -2881,7 +2949,7 @@
       ]
     },
     {
-      "order": 156,
+      "order": 160,
       "filename": "20260814_project_operations_sol24.sql",
       "sha256": "e978abeb2b6758744d3824540b2552ef6b6ca90f0c634bc49dd7af403d4e8cd9",
       "bytes": 7897,
@@ -2898,10 +2966,63 @@
       ]
     },
     {
-      "order": 157,
+      "order": 161,
       "filename": "20260814_sol22_quality_intelligence.sql",
       "sha256": "adf2b97867ef23f9c40ecd5df7c271cd40cc4d4d67c04cc60e7444f2cf367264",
       "bytes": 10194,
+      "transaction_wrapped": true,
+      "replay_markers": true,
+      "support": {
+        "preflight": true,
+        "verify": true,
+        "rollback": true
+      },
+      "risks": [
+        "data-rewrite",
+        "table-lock",
+        "blocking-index"
+      ]
+    },
+    {
+      "order": 162,
+      "filename": "20260815_historical_test_guard_convergence_sol43.sql",
+      "sha256": "4ab8dc57c44b3baaa77314e7ef7725df28ac5afacdc66f189d1935bd4bffd828",
+      "bytes": 8087,
+      "transaction_wrapped": true,
+      "replay_markers": true,
+      "support": {
+        "preflight": true,
+        "verify": true,
+        "rollback": true
+      },
+      "risks": [
+        "data-rewrite",
+        "table-lock",
+        "blocking-index"
+      ]
+    },
+    {
+      "order": 163,
+      "filename": "20260815_privileged_mfa_sol32.sql",
+      "sha256": "1050fe92489eed4e25a75b7810b37545c702bfbb8baa860c46396b9a748545f4",
+      "bytes": 4629,
+      "transaction_wrapped": true,
+      "replay_markers": true,
+      "support": {
+        "preflight": true,
+        "verify": true,
+        "rollback": true
+      },
+      "risks": [
+        "data-rewrite",
+        "blocking-index"
+      ]
+    },
+    {
+      "order": 164,
+      "filename": "20260815_reference_data_center_sol33.sql",
+      "sha256": "a40f4948dfbcee7de8eb00d9077f499a2b92bdda863b6728f29d8e62751a899f",
+      "bytes": 10231,
       "transaction_wrapped": true,
       "replay_markers": true,
       "support": {

--- a/docs/release/MIGRATION_INVENTORY_SOL_06.md
+++ b/docs/release/MIGRATION_INVENTORY_SOL_06.md
@@ -1,10 +1,10 @@
 # Inventaire des migrations — SOL-06
 
-- Généré : 2026-08-14T14:13:24.602Z
+- Généré : 2026-08-15T10:58:45.419Z
 - Source : filesystem scan of db/patches and db/patches/support
-- Patches exécutables : 157
-- Scripts auxiliaires : 263
-- Patches depuis 2026-07-01 : 99
+- Patches exécutables : 164
+- Scripts auxiliaires : 284
+- Patches depuis 2026-07-01 : 106
 
 ## Risques statiques à examiner
 
@@ -12,9 +12,9 @@
 |---|---:|
 | DDL destructif | 2 |
 | DML destructif | 8 |
-| Réécriture de données | 93 |
-| Verrou de table possible | 126 |
-| Index non concurrent | 118 |
+| Réécriture de données | 100 |
+| Verrou de table possible | 128 |
+| Index non concurrent | 125 |
 | Évolution d'enum | 1 |
 
 Ces détections sont volontairement conservatrices : elles servent de file de revue, pas de preuve de danger. Les durées réelles sont capturées par la répétition isolée.

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-15T04:38:46.103Z",
+  "started_at": "2026-08-15T10:59:43.794Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 18133,
-    "source_seed": 207,
-    "backup": 797,
-    "preflight": 159,
-    "integrity_before": 589,
-    "migration": 771,
-    "verify": 254,
-    "replay": 129,
-    "integrity_after": 1527,
+    "source_migration": 18897,
+    "source_seed": 222,
+    "backup": 764,
+    "preflight": 183,
+    "integrity_before": 636,
+    "migration": 892,
+    "verify": 299,
+    "replay": 166,
+    "integrity_after": 1600,
     "negative_gate": 40,
-    "rollback": 434,
-    "restore": 3935
+    "rollback": 479,
+    "restore": 4076
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-15T04:39:07.937Z",
-    "duration_ms": 108,
+    "checked_at": "2026-08-15T11:00:06.301Z",
+    "duration_ms": 136,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36355095"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-VbkOWG\\cerp-test-before-sol06.dump",
-      "bytes": 1968432,
-      "sha256": "1715b92f0dbdcade9019bf3523018d9893a3927dfaaac7a1f1aa352835d8f1ce",
-      "free_bytes": 406424678400
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-ZPkZeh\\cerp-test-before-sol06.dump",
+      "bytes": 1968403,
+      "sha256": "f188eb6ccce1b4bf73d68338140f7f8f6035d50c35bb7600f73c0e9b1c82f405",
+      "free_bytes": 400919621632
     },
     "ledger": {
       "applied": 140,
@@ -62,7 +62,9 @@
         "20260814_planning_execution_intelligence_0021.sql",
         "20260814_project_operations_sol24.sql",
         "20260814_sol22_quality_intelligence.sql",
-        "20260815_privileged_mfa_sol32.sql"
+        "20260815_historical_test_guard_convergence_sol43.sql",
+        "20260815_privileged_mfa_sol32.sql",
+        "20260815_reference_data_center_sol33.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
@@ -466,13 +468,15 @@
         "20260814_planning_execution_intelligence_0021.sql",
         "20260814_project_operations_sol24.sql",
         "20260814_sol22_quality_intelligence.sql",
-        "20260815_privileged_mfa_sol32.sql"
+        "20260815_historical_test_guard_convergence_sol43.sql",
+        "20260815_privileged_mfa_sol32.sql",
+        "20260815_reference_data_center_sol33.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "ca12781f9d6271d3cd9c95ac408d7f83c2d96b765aae62fbefaa3a4a636a9b71"
+    "fingerprint": "36318e3291be6dfdcbad2cdeb6c5fca43dc6b3c8312741ea6bd43ed96e9eaa54"
   },
   "replay": {
     "applied_zero": true,
@@ -480,8 +484,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-15T04:39:11.212Z",
-    "duration_ms": 1513,
+    "checked_at": "2026-08-15T11:00:09.898Z",
+    "duration_ms": 1586,
     "table_counts": {
       "accounting_export_batch_sources": "0",
       "accounting_export_batches": "0",
@@ -558,9 +562,10 @@
       "bon_livraison_pack_quality_documents": "0",
       "bon_livraison_pack_versions": "0",
       "centres_frais": "1",
+      "cerp_migration_supersessions": "4",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "162",
+      "cerp_schema_migrations": "164",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -871,6 +876,9 @@
       "reception_incoming_inspections": "0",
       "reception_incoming_measurements": "0",
       "receptions_fournisseurs": "0",
+      "reference_data_change_sets": "0",
+      "reference_data_decisions": "0",
+      "reference_data_versions": "0",
       "replenishment_budgets": "0",
       "replenishment_proposal_events": "0",
       "replenishment_proposal_idempotence": "0",
@@ -919,7 +927,7 @@
       "users": "8",
       "warehouses": "4"
     },
-    "table_count": 435,
+    "table_count": 439,
     "unvalidated_constraints": [
       {
         "table_name": "avoir",
@@ -996,7 +1004,7 @@
         "groups": 0
       }
     ],
-    "foreign_key_count": 1216,
+    "foreign_key_count": 1225,
     "orphans": [],
     "readiness": [
       {
@@ -1008,7 +1016,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1025,7 +1033,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1043,7 +1051,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1069,7 +1077,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1086,7 +1094,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1104,7 +1112,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1124,7 +1132,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1142,7 +1150,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1168,7 +1176,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1186,7 +1194,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1205,7 +1213,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1243,7 +1251,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-15T04:39:09.702Z",
+        "freshness_at": "2026-08-15T11:00:08.314Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1262,13 +1270,13 @@
       }
     ],
     "ledger": {
-      "applied": 162,
+      "applied": 164,
       "pending": [],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "9fa0976a5861bceb28157c3a019c0d6d0c4389d83607f70b211c3e1dad25dd7c"
+    "fingerprint": "cf934d390a5308950eba6d17e7b57909745455c066bd0ccbdd7e7c1608a6a033"
   },
   "negative_gate": {
     "status": "passed",
@@ -1311,7 +1319,7 @@
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "ca12781f9d6271d3cd9c95ac408d7f83c2d96b765aae62fbefaa3a4a636a9b71",
+    "fingerprint": "36318e3291be6dfdcbad2cdeb6c5fca43dc6b3c8312741ea6bd43ed96e9eaa54",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1337,12 +1345,14 @@
         "20260814_planning_execution_intelligence_0021.sql",
         "20260814_project_operations_sol24.sql",
         "20260814_sol22_quality_intelligence.sql",
-        "20260815_privileged_mfa_sol32.sql"
+        "20260815_historical_test_guard_convergence_sol43.sql",
+        "20260815_privileged_mfa_sol32.sql",
+        "20260815_reference_data_center_sol33.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-15T04:39:15.783Z"
+  "completed_at": "2026-08-15T11:00:14.666Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-15T04:39:15.783Z
+- Exécutée : 2026-08-15T11:00:14.666Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36355095 octets
-- Sauvegarde : 1968432 octets, SHA-256 `1715b92f0dbdcade9019bf3523018d9893a3927dfaaac7a1f1aa352835d8f1ce`
-- Patches avant/après : 140 / 162
+- Sauvegarde : 1968403 octets, SHA-256 `f188eb6ccce1b4bf73d68338140f7f8f6035d50c35bb7600f73c0e9b1c82f405`
+- Patches avant/après : 140 / 164
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `ca12781f9d6271d3cd9c95ac408d7f83c2d96b765aae62fbefaa3a4a636a9b71` / `ca12781f9d6271d3cd9c95ac408d7f83c2d96b765aae62fbefaa3a4a636a9b71`
+- Empreinte source/restaurée : `36318e3291be6dfdcbad2cdeb6c5fca43dc6b3c8312741ea6bd43ed96e9eaa54` / `36318e3291be6dfdcbad2cdeb6c5fca43dc6b3c8312741ea6bd43ed96e9eaa54`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 18133 |
-| source_seed | 207 |
-| backup | 797 |
-| preflight | 159 |
-| integrity_before | 589 |
-| migration | 771 |
-| verify | 254 |
-| replay | 129 |
-| integrity_after | 1527 |
+| source_migration | 18897 |
+| source_seed | 222 |
+| backup | 764 |
+| preflight | 183 |
+| integrity_before | 636 |
+| migration | 892 |
+| verify | 299 |
+| replay | 166 |
+| integrity_after | 1600 |
 | negative_gate | 40 |
-| rollback | 434 |
-| restore | 3935 |
+| rollback | 479 |
+| restore | 4076 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -71,6 +71,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "1050fe92489eed4e25a75b7810b37545c702bfbb8baa860c46396b9a748545f4",
   "20260815_reference_data_center_sol33.sql":
     "a40f4948dfbcee7de8eb00d9077f499a2b92bdda863b6728f29d8e62751a899f",
+  "20260815_historical_test_guard_convergence_sol43.sql":
+    "4ab8dc57c44b3baaa77314e7ef7725df28ac5afacdc66f189d1935bd4bffd828",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/historical-test-guard-convergence-sol43.migration.test.ts
+++ b/src/__tests__/historical-test-guard-convergence-sol43.migration.test.ts
@@ -1,0 +1,61 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(__dirname, "../..");
+const migrationName = "20260815_historical_test_guard_convergence_sol43";
+const read = (relativePath: string) => readFileSync(resolve(root, relativePath), "utf8");
+const migration = read(`db/patches/${migrationName}.sql`);
+const preflight = read(`db/patches/support/${migrationName}.preflight.sql`);
+const verify = read(`db/patches/support/${migrationName}.verify.sql`);
+const rollback = read(`db/patches/support/${migrationName}.rollback.sql`);
+const runner = read("scripts/db-patches.js");
+
+const legacy = new Map([
+  ["20260727_contacts_email_scope_187.sql", "4d43141bc2e6b803f4b37d1dff146c9950e64c75f0b317194ebf03dacbddbf1a"],
+  ["20260727_contacts_shared_email_identity_190.sql", "b3b030cefbbf16ceca44481d74380de71803d72320c19b4da9cc62eee37aaf89"],
+  ["20260727_import_supplier_orders_312.sql", "5988f518ebfe8160372ec833fb14fba636a54638f367a637703162032d7193a0"],
+  ["20260727_stock_import_precision_198.sql", "0a348b7d6b723ba2d38b4927a5eed9a3999e3dfa82f56940f1f3a4d5b2da5a6a"],
+]);
+
+describe("SOL-43 historical test-guard convergence migration", () => {
+  it("keeps the immutable legacy hashes and records explicit supersession provenance", () => {
+    for (const [filename, sha256] of legacy) {
+      expect(migration).toContain(filename);
+      expect(migration).toContain(sha256);
+      expect(preflight).toContain(filename);
+      expect(preflight).toContain(sha256);
+    }
+    expect(migration).toContain("cerp_migration_supersessions");
+    expect(migration).toContain("ON CONFLICT (filename) DO NOTHING");
+    expect(verify).toContain("expected 4 provenance records");
+  });
+
+  it("applies only the final contact, supplier-import and stock-precision states", () => {
+    expect(migration).toContain("contacts_client_email_identity_active_key");
+    expect(migration).toContain("FOURNISSEUR_COMMANDE");
+    expect(migration).toContain("ALTER COLUMN qty TYPE numeric(18,6)");
+    expect(migration).toContain("PRECISION_RECONCILED_198");
+    expect(migration).toContain("abs(opening_lines.old_line_qty - opening_lines.posted_qty) < 0.0005");
+    expect(migration).toContain("DISABLE TRIGGER trg_protect_posted_stock_movement_line");
+    expect(migration).toContain("ENABLE TRIGGER trg_protect_posted_stock_movement_line");
+  });
+
+  it("restricts execution, keeps preflight and verify read-only, and requires backup restore for rollback", () => {
+    expect(migration).toContain("current_database() NOT IN ('cerp_test', 'cerp_prod')");
+    expect(preflight).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(preflight).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/im);
+    expect(verify).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(verify).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/im);
+    expect(rollback).toContain("restoring the verified pre-migration custom-format backup");
+    expect(rollback).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/im);
+  });
+
+  it("registers the exact migration checksum for safe one-patch convergence", () => {
+    const sha256 = createHash("sha256").update(migration.replace(/\r\n?/g, "\n"), "utf8").digest("hex");
+    expect(sha256).toBe("4ab8dc57c44b3baaa77314e7ef7725df28ac5afacdc66f189d1935bd4bffd828");
+    expect(runner).toContain(`"${migrationName}.sql":`);
+    expect(runner).toContain(sha256);
+  });
+});


### PR DESCRIPTION
Promotes the audited SOL-43 historical migration convergence from dev to main. The patch has preflight, immutable provenance, verification, restore-only rollback, focused tests and a successful full migration rehearsal.

## Summary by Sourcery

Promote the SOL-43 historical migration convergence patch, including its preflight, verification, rollback strategy and tests, into the main migration pipeline.

New Features:
- Add a SOL-43 convergence migration that safely applies final contact identity, supplier-import and stock-precision states across guarded historical patches.
- Introduce a supersession audit table to record immutable provenance for converged legacy migrations.

Enhancements:
- Wire the SOL-43 convergence migration into the immutable-only patch runner with its verified checksum.
- Update migration inventory and rehearsal artefacts for SOL-06 to reflect the latest patch set, backup fingerprint and execution timings.

Documentation:
- Refresh SOL-06 migration rehearsal and inventory documentation to capture the latest rehearsal run and risk counts.

Tests:
- Add a focused migration test suite that asserts SOL-43 preflight, verification, rollback constraints and the registered checksum for one-patch convergence.