### PR TITLE
release: promote SOL-43 client convergence follow-up

### DIFF
--- a/db/patches/20260815_historical_test_guard_convergence_sol43.sql
+++ b/db/patches/20260815_historical_test_guard_convergence_sol43.sql
@@ -57,6 +57,7 @@ BEGIN
     JOIN (VALUES
       ('20260727_contacts_email_scope_187.sql', '4d43141bc2e6b803f4b37d1dff146c9950e64c75f0b317194ebf03dacbddbf1a'),
       ('20260727_contacts_shared_email_identity_190.sql', 'b3b030cefbbf16ceca44481d74380de71803d72320c19b4da9cc62eee37aaf89'),
+      ('20260727_import_clients_enrichment_306.sql', '3b0987397ad79f1fe8580c19a7cd2153c3ed5fb3617d357b2dfa452684b93181'),
       ('20260727_import_supplier_orders_312.sql', '5988f518ebfe8160372ec833fb14fba636a54638f367a637703162032d7193a0'),
       ('20260727_stock_import_precision_198.sql', '0a348b7d6b723ba2d38b4927a5eed9a3999e3dfa82f56940f1f3a4d5b2da5a6a')
     ) AS expected(filename, sha256)
@@ -106,6 +107,15 @@ ALTER TABLE public.data_import_batches
       'EMPLOYE'
     )
   );
+
+CREATE TABLE IF NOT EXISTS public.client_contact_create_idempotency (
+  idempotency_key text PRIMARY KEY,
+  contact_id uuid NOT NULL REFERENCES public.contacts(contact_id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS client_contact_create_idempotency_contact_idx
+  ON public.client_contact_create_idempotency (contact_id);
 
 ALTER TABLE public.stock_movement_lines
   ALTER COLUMN qty TYPE numeric(18,6)
@@ -190,6 +200,7 @@ INSERT INTO public.cerp_migration_supersessions (
 VALUES
   ('20260727_contacts_email_scope_187.sql', '4d43141bc2e6b803f4b37d1dff146c9950e64c75f0b317194ebf03dacbddbf1a', '20260815_historical_test_guard_convergence_sol43.sql', current_database(), current_user, 'Legacy patch was restricted to cerp_test; final contact identity rule applied by SOL-43'),
   ('20260727_contacts_shared_email_identity_190.sql', 'b3b030cefbbf16ceca44481d74380de71803d72320c19b4da9cc62eee37aaf89', '20260815_historical_test_guard_convergence_sol43.sql', current_database(), current_user, 'Legacy patch was restricted to cerp_test; final contact identity rule applied by SOL-43'),
+  ('20260727_import_clients_enrichment_306.sql', '3b0987397ad79f1fe8580c19a7cd2153c3ed5fb3617d357b2dfa452684b93181', '20260815_historical_test_guard_convergence_sol43.sql', current_database(), current_user, 'Legacy patch was restricted to cerp_test; client enrichment and idempotency state applied by SOL-43'),
   ('20260727_import_supplier_orders_312.sql', '5988f518ebfe8160372ec833fb14fba636a54638f367a637703162032d7193a0', '20260815_historical_test_guard_convergence_sol43.sql', current_database(), current_user, 'Legacy patch was restricted to cerp_test; supplier-order import constraint applied by SOL-43'),
   ('20260727_stock_import_precision_198.sql', '0a348b7d6b723ba2d38b4927a5eed9a3999e3dfa82f56940f1f3a4d5b2da5a6a', '20260815_historical_test_guard_convergence_sol43.sql', current_database(), current_user, 'Legacy patch was restricted to cerp_test; stock precision and bounded repair applied by SOL-43')
 ON CONFLICT (legacy_filename) DO UPDATE
@@ -204,6 +215,7 @@ INSERT INTO public.cerp_schema_migrations (filename, sha256)
 VALUES
   ('20260727_contacts_email_scope_187.sql', '4d43141bc2e6b803f4b37d1dff146c9950e64c75f0b317194ebf03dacbddbf1a'),
   ('20260727_contacts_shared_email_identity_190.sql', 'b3b030cefbbf16ceca44481d74380de71803d72320c19b4da9cc62eee37aaf89'),
+  ('20260727_import_clients_enrichment_306.sql', '3b0987397ad79f1fe8580c19a7cd2153c3ed5fb3617d357b2dfa452684b93181'),
   ('20260727_import_supplier_orders_312.sql', '5988f518ebfe8160372ec833fb14fba636a54638f367a637703162032d7193a0'),
   ('20260727_stock_import_precision_198.sql', '0a348b7d6b723ba2d38b4927a5eed9a3999e3dfa82f56940f1f3a4d5b2da5a6a')
 ON CONFLICT (filename) DO NOTHING;

--- a/db/patches/support/20260815_historical_test_guard_convergence_sol43.preflight.sql
+++ b/db/patches/support/20260815_historical_test_guard_convergence_sol43.preflight.sql
@@ -50,6 +50,7 @@ BEGIN
       JOIN (VALUES
         ('20260727_contacts_email_scope_187.sql', '4d43141bc2e6b803f4b37d1dff146c9950e64c75f0b317194ebf03dacbddbf1a'),
         ('20260727_contacts_shared_email_identity_190.sql', 'b3b030cefbbf16ceca44481d74380de71803d72320c19b4da9cc62eee37aaf89'),
+        ('20260727_import_clients_enrichment_306.sql', '3b0987397ad79f1fe8580c19a7cd2153c3ed5fb3617d357b2dfa452684b93181'),
         ('20260727_import_supplier_orders_312.sql', '5988f518ebfe8160372ec833fb14fba636a54638f367a637703162032d7193a0'),
         ('20260727_stock_import_precision_198.sql', '0a348b7d6b723ba2d38b4927a5eed9a3999e3dfa82f56940f1f3a4d5b2da5a6a')
       ) AS expected(filename, sha256)

--- a/db/patches/support/20260815_historical_test_guard_convergence_sol43.verify.sql
+++ b/db/patches/support/20260815_historical_test_guard_convergence_sol43.verify.sql
@@ -38,6 +38,11 @@ BEGIN
     RAISE EXCEPTION 'SOL-43 convergence verification failed: supplier-order import is not allowed';
   END IF;
 
+  IF to_regclass('public.client_contact_create_idempotency') IS NULL
+     OR to_regclass('public.client_contact_create_idempotency_contact_idx') IS NULL THEN
+    RAISE EXCEPTION 'SOL-43 convergence verification failed: contact idempotency state is missing';
+  END IF;
+
   SELECT count(*)::integer
     INTO proven_count
     FROM public.cerp_schema_migrations AS applied
@@ -47,12 +52,13 @@ BEGIN
    WHERE applied.filename IN (
      '20260727_contacts_email_scope_187.sql',
      '20260727_contacts_shared_email_identity_190.sql',
+     '20260727_import_clients_enrichment_306.sql',
      '20260727_import_supplier_orders_312.sql',
      '20260727_stock_import_precision_198.sql'
    );
 
-  IF proven_count <> 4 THEN
-    RAISE EXCEPTION 'SOL-43 convergence verification failed: expected 4 provenance records, found %', proven_count;
+  IF proven_count <> 5 THEN
+    RAISE EXCEPTION 'SOL-43 convergence verification failed: expected 5 provenance records, found %', proven_count;
   END IF;
 END
 $$;

--- a/docs/release/MIGRATION_INVENTORY_SOL_06.json
+++ b/docs/release/MIGRATION_INVENTORY_SOL_06.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-15T10:58:45.419Z",
+  "generated_at": "2026-08-15T11:03:39.109Z",
   "source": "filesystem scan of db/patches and db/patches/support",
   "patch_count": 164,
   "support_file_count": 284,
@@ -2986,8 +2986,8 @@
     {
       "order": 162,
       "filename": "20260815_historical_test_guard_convergence_sol43.sql",
-      "sha256": "4ab8dc57c44b3baaa77314e7ef7725df28ac5afacdc66f189d1935bd4bffd828",
-      "bytes": 8087,
+      "sha256": "f3ccb16d3f85e03f1b00f710a9d28eda70dc6818b26353d081ac17fa41dce119",
+      "bytes": 9016,
       "transaction_wrapped": true,
       "replay_markers": true,
       "support": {

--- a/docs/release/MIGRATION_INVENTORY_SOL_06.md
+++ b/docs/release/MIGRATION_INVENTORY_SOL_06.md
@@ -1,6 +1,6 @@
 # Inventaire des migrations — SOL-06
 
-- Généré : 2026-08-15T10:58:45.419Z
+- Généré : 2026-08-15T11:03:39.109Z
 - Source : filesystem scan of db/patches and db/patches/support
 - Patches exécutables : 164
 - Scripts auxiliaires : 284

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-15T10:59:43.794Z",
+  "started_at": "2026-08-15T11:04:03.217Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 18897,
-    "source_seed": 222,
-    "backup": 764,
-    "preflight": 183,
-    "integrity_before": 636,
-    "migration": 892,
-    "verify": 299,
-    "replay": 166,
-    "integrity_after": 1600,
-    "negative_gate": 40,
-    "rollback": 479,
-    "restore": 4076
+    "source_migration": 18720,
+    "source_seed": 197,
+    "backup": 785,
+    "preflight": 192,
+    "integrity_before": 623,
+    "migration": 906,
+    "verify": 280,
+    "replay": 169,
+    "integrity_after": 1570,
+    "negative_gate": 41,
+    "rollback": 465,
+    "restore": 4118
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-15T11:00:06.301Z",
-    "duration_ms": 136,
+    "checked_at": "2026-08-15T11:04:25.628Z",
+    "duration_ms": 143,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36355095"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-ZPkZeh\\cerp-test-before-sol06.dump",
-      "bytes": 1968403,
-      "sha256": "f188eb6ccce1b4bf73d68338140f7f8f6035d50c35bb7600f73c0e9b1c82f405",
-      "free_bytes": 400919621632
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-15H0NS\\cerp-test-before-sol06.dump",
+      "bytes": 1968430,
+      "sha256": "1270b357fc646deadc7246bb9276d52415ca60d9d125efe9e14dbff229af0e12",
+      "free_bytes": 400905625600
     },
     "ledger": {
       "applied": 140,
@@ -484,8 +484,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-15T11:00:09.898Z",
-    "duration_ms": 1586,
+    "checked_at": "2026-08-15T11:04:29.181Z",
+    "duration_ms": 1555,
     "table_counts": {
       "accounting_export_batch_sources": "0",
       "accounting_export_batches": "0",
@@ -562,7 +562,7 @@
       "bon_livraison_pack_quality_documents": "0",
       "bon_livraison_pack_versions": "0",
       "centres_frais": "1",
-      "cerp_migration_supersessions": "4",
+      "cerp_migration_supersessions": "5",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
       "cerp_schema_migrations": "164",
@@ -1016,7 +1016,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1033,7 +1033,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1051,7 +1051,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1077,7 +1077,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1094,7 +1094,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1112,7 +1112,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1132,7 +1132,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1150,7 +1150,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1176,7 +1176,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1194,7 +1194,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1213,7 +1213,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1251,7 +1251,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-15T11:00:08.314Z",
+        "freshness_at": "2026-08-15T11:04:27.627Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1276,7 +1276,7 @@
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "cf934d390a5308950eba6d17e7b57909745455c066bd0ccbdd7e7c1608a6a033"
+    "fingerprint": "95a160e7a44b6b8468f54c7cc5029f713006b8ba1c0f39902c71bd83d1798bb0"
   },
   "negative_gate": {
     "status": "passed",
@@ -1354,5 +1354,5 @@
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-15T11:00:14.666Z"
+  "completed_at": "2026-08-15T11:04:33.978Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,10 +1,10 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-15T11:00:14.666Z
+- Exécutée : 2026-08-15T11:04:33.978Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36355095 octets
-- Sauvegarde : 1968403 octets, SHA-256 `f188eb6ccce1b4bf73d68338140f7f8f6035d50c35bb7600f73c0e9b1c82f405`
+- Sauvegarde : 1968430 octets, SHA-256 `1270b357fc646deadc7246bb9276d52415ca60d9d125efe9e14dbff229af0e12`
 - Patches avant/après : 140 / 164
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
@@ -17,17 +17,17 @@
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 18897 |
-| source_seed | 222 |
-| backup | 764 |
-| preflight | 183 |
-| integrity_before | 636 |
-| migration | 892 |
-| verify | 299 |
-| replay | 166 |
-| integrity_after | 1600 |
-| negative_gate | 40 |
-| rollback | 479 |
-| restore | 4076 |
+| source_migration | 18720 |
+| source_seed | 197 |
+| backup | 785 |
+| preflight | 192 |
+| integrity_before | 623 |
+| migration | 906 |
+| verify | 280 |
+| replay | 169 |
+| integrity_after | 1570 |
+| negative_gate | 41 |
+| rollback | 465 |
+| restore | 4118 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -72,7 +72,7 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
   "20260815_reference_data_center_sol33.sql":
     "a40f4948dfbcee7de8eb00d9077f499a2b92bdda863b6728f29d8e62751a899f",
   "20260815_historical_test_guard_convergence_sol43.sql":
-    "4ab8dc57c44b3baaa77314e7ef7725df28ac5afacdc66f189d1935bd4bffd828",
+    "f3ccb16d3f85e03f1b00f710a9d28eda70dc6818b26353d081ac17fa41dce119",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/historical-test-guard-convergence-sol43.migration.test.ts
+++ b/src/__tests__/historical-test-guard-convergence-sol43.migration.test.ts
@@ -15,6 +15,7 @@ const runner = read("scripts/db-patches.js");
 const legacy = new Map([
   ["20260727_contacts_email_scope_187.sql", "4d43141bc2e6b803f4b37d1dff146c9950e64c75f0b317194ebf03dacbddbf1a"],
   ["20260727_contacts_shared_email_identity_190.sql", "b3b030cefbbf16ceca44481d74380de71803d72320c19b4da9cc62eee37aaf89"],
+  ["20260727_import_clients_enrichment_306.sql", "3b0987397ad79f1fe8580c19a7cd2153c3ed5fb3617d357b2dfa452684b93181"],
   ["20260727_import_supplier_orders_312.sql", "5988f518ebfe8160372ec833fb14fba636a54638f367a637703162032d7193a0"],
   ["20260727_stock_import_precision_198.sql", "0a348b7d6b723ba2d38b4927a5eed9a3999e3dfa82f56940f1f3a4d5b2da5a6a"],
 ]);
@@ -29,12 +30,13 @@ describe("SOL-43 historical test-guard convergence migration", () => {
     }
     expect(migration).toContain("cerp_migration_supersessions");
     expect(migration).toContain("ON CONFLICT (filename) DO NOTHING");
-    expect(verify).toContain("expected 4 provenance records");
+    expect(verify).toContain("expected 5 provenance records");
   });
 
   it("applies only the final contact, supplier-import and stock-precision states", () => {
     expect(migration).toContain("contacts_client_email_identity_active_key");
     expect(migration).toContain("FOURNISSEUR_COMMANDE");
+    expect(migration).toContain("client_contact_create_idempotency");
     expect(migration).toContain("ALTER COLUMN qty TYPE numeric(18,6)");
     expect(migration).toContain("PRECISION_RECONCILED_198");
     expect(migration).toContain("abs(opening_lines.old_line_qty - opening_lines.posted_qty) < 0.0005");
@@ -54,7 +56,7 @@ describe("SOL-43 historical test-guard convergence migration", () => {
 
   it("registers the exact migration checksum for safe one-patch convergence", () => {
     const sha256 = createHash("sha256").update(migration.replace(/\r\n?/g, "\n"), "utf8").digest("hex");
-    expect(sha256).toBe("4ab8dc57c44b3baaa77314e7ef7725df28ac5afacdc66f189d1935bd4bffd828");
+    expect(sha256).toBe("f3ccb16d3f85e03f1b00f710a9d28eda70dc6818b26353d081ac17fa41dce119");
     expect(runner).toContain(`"${migrationName}.sql":`);
     expect(runner).toContain(sha256);
   });


### PR DESCRIPTION
Promotes the tested #306 historical migration convergence discovered by the isolated production-copy rehearsal.

## Summary by Sourcery

Promote the SOL-43 historical convergence migration to include client enrichment and idempotency state, aligned with updated rehearsal artifacts and checksums.

New Features:
- Introduce a client contact idempotency table and index as part of the SOL-43 convergence migration to persist idempotency state.

Enhancements:
- Extend SOL-43 historical convergence guards to cover the client enrichment legacy patch, including provenance and schema migration records.
- Tighten SOL-43 preflight and verification scripts to assert presence and checksums of the client enrichment patch and its idempotency structures.
- Update immutable patch checksum wiring and tests to reflect the final SOL-43 migration content and expected provenance count.
- Refresh SOL-06 migration inventory and rehearsal documentation to capture the latest execution metadata.