### PR TITLE
release: promote SOL-43 idempotency grants

### DIFF
--- a/db/patches/20260815_z_client_contact_idempotency_grants_sol43.sql
+++ b/db/patches/20260815_z_client_contact_idempotency_grants_sol43.sql
@@ -1,0 +1,25 @@
+-- SOL-43 — grant only the privileges required by the contact idempotency
+-- repository after the production-safe historical convergence created it.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'SOL-43 contact idempotency grant refused on database %', current_database();
+  END IF;
+  IF to_regclass('public.client_contact_create_idempotency') IS NULL THEN
+    RAISE EXCEPTION 'SOL-43 contact idempotency grant refused: table is missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'SOL-43 contact idempotency grant refused: role cerp_app is missing';
+  END IF;
+END
+$$;
+
+GRANT SELECT, INSERT
+  ON TABLE public.client_contact_create_idempotency
+  TO cerp_app;
+
+COMMIT;

--- a/db/patches/support/20260815_z_client_contact_idempotency_grants_sol43.preflight.sql
+++ b/db/patches/support/20260815_z_client_contact_idempotency_grants_sol43.preflight.sql
@@ -1,0 +1,20 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'SOL-43 contact idempotency grant preflight refused on database %', current_database();
+  END IF;
+  IF to_regclass('public.client_contact_create_idempotency') IS NULL THEN
+    RAISE EXCEPTION 'SOL-43 contact idempotency grant preflight refused: table is missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'SOL-43 contact idempotency grant preflight refused: role cerp_app is missing';
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/db/patches/support/20260815_z_client_contact_idempotency_grants_sol43.rollback.sql
+++ b/db/patches/support/20260815_z_client_contact_idempotency_grants_sol43.rollback.sql
@@ -1,0 +1,9 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  RAISE EXCEPTION USING
+    MESSAGE = 'SOL-43 contact idempotency grant rollback requires restoring the verified pre-migration backup',
+    HINT = 'The test database already had these privileges; revoking them in place would not restore a known prior state.';
+END
+$$;

--- a/db/patches/support/20260815_z_client_contact_idempotency_grants_sol43.verify.sql
+++ b/db/patches/support/20260815_z_client_contact_idempotency_grants_sol43.verify.sql
@@ -1,0 +1,14 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+BEGIN
+  IF NOT has_table_privilege('cerp_app', 'public.client_contact_create_idempotency', 'SELECT')
+     OR NOT has_table_privilege('cerp_app', 'public.client_contact_create_idempotency', 'INSERT') THEN
+    RAISE EXCEPTION 'SOL-43 contact idempotency grant verification failed';
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/docs/release/MIGRATION_INVENTORY_SOL_06.json
+++ b/docs/release/MIGRATION_INVENTORY_SOL_06.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-08-15T11:03:39.109Z",
+  "generated_at": "2026-08-15T11:10:40.280Z",
   "source": "filesystem scan of db/patches and db/patches/support",
-  "patch_count": 164,
-  "support_file_count": 284,
-  "recent_patch_count": 106,
+  "patch_count": 165,
+  "support_file_count": 287,
+  "recent_patch_count": 107,
   "recent_support_gaps": [
     {
       "filename": "20260706_affaire_allow_projet.sql",
@@ -3035,6 +3035,20 @@
         "table-lock",
         "blocking-index"
       ]
+    },
+    {
+      "order": 165,
+      "filename": "20260815_z_client_contact_idempotency_grants_sol43.sql",
+      "sha256": "98490c2b57a98cf129ee4ce71bc878d4d5034a39ce46f95dc0e9b192ce67b302",
+      "bytes": 847,
+      "transaction_wrapped": true,
+      "replay_markers": true,
+      "support": {
+        "preflight": true,
+        "verify": true,
+        "rollback": true
+      },
+      "risks": []
     }
   ]
 }

--- a/docs/release/MIGRATION_INVENTORY_SOL_06.md
+++ b/docs/release/MIGRATION_INVENTORY_SOL_06.md
@@ -1,10 +1,10 @@
 # Inventaire des migrations — SOL-06
 
-- Généré : 2026-08-15T11:03:39.109Z
+- Généré : 2026-08-15T11:10:40.280Z
 - Source : filesystem scan of db/patches and db/patches/support
-- Patches exécutables : 164
-- Scripts auxiliaires : 284
-- Patches depuis 2026-07-01 : 106
+- Patches exécutables : 165
+- Scripts auxiliaires : 287
+- Patches depuis 2026-07-01 : 107
 
 ## Risques statiques à examiner
 

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-15T11:04:03.217Z",
+  "started_at": "2026-08-15T11:11:02.148Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,22 +9,22 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 18720,
-    "source_seed": 197,
-    "backup": 785,
-    "preflight": 192,
-    "integrity_before": 623,
-    "migration": 906,
-    "verify": 280,
-    "replay": 169,
-    "integrity_after": 1570,
-    "negative_gate": 41,
-    "rollback": 465,
-    "restore": 4118
+    "source_migration": 18698,
+    "source_seed": 196,
+    "backup": 747,
+    "preflight": 195,
+    "integrity_before": 624,
+    "migration": 901,
+    "verify": 291,
+    "replay": 177,
+    "integrity_after": 1655,
+    "negative_gate": 42,
+    "rollback": 485,
+    "restore": 4170
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-15T11:04:25.628Z",
+    "checked_at": "2026-08-15T11:11:24.436Z",
     "duration_ms": 143,
     "identity": {
       "database": "cerp_test",
@@ -33,10 +33,10 @@
       "database_bytes": "36355095"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-15H0NS\\cerp-test-before-sol06.dump",
-      "bytes": 1968430,
-      "sha256": "1270b357fc646deadc7246bb9276d52415ca60d9d125efe9e14dbff229af0e12",
-      "free_bytes": 400905625600
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-GQpqIC\\cerp-test-before-sol06.dump",
+      "bytes": 1968347,
+      "sha256": "05e505de971e66d42ef5b117f87e9c532e1fa1142366a4dbf481b5f47935d35b",
+      "free_bytes": 400887709696
     },
     "ledger": {
       "applied": 140,
@@ -64,7 +64,8 @@
         "20260814_sol22_quality_intelligence.sql",
         "20260815_historical_test_guard_convergence_sol43.sql",
         "20260815_privileged_mfa_sol32.sql",
-        "20260815_reference_data_center_sol33.sql"
+        "20260815_reference_data_center_sol33.sql",
+        "20260815_z_client_contact_idempotency_grants_sol43.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
@@ -470,13 +471,14 @@
         "20260814_sol22_quality_intelligence.sql",
         "20260815_historical_test_guard_convergence_sol43.sql",
         "20260815_privileged_mfa_sol32.sql",
-        "20260815_reference_data_center_sol33.sql"
+        "20260815_reference_data_center_sol33.sql",
+        "20260815_z_client_contact_idempotency_grants_sol43.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "36318e3291be6dfdcbad2cdeb6c5fca43dc6b3c8312741ea6bd43ed96e9eaa54"
+    "fingerprint": "218759e7dc4505d334be5d506194622ca51a3b10b5746097aae673b30328bf9d"
   },
   "replay": {
     "applied_zero": true,
@@ -484,8 +486,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-15T11:04:29.181Z",
-    "duration_ms": 1555,
+    "checked_at": "2026-08-15T11:11:28.088Z",
+    "duration_ms": 1642,
     "table_counts": {
       "accounting_export_batch_sources": "0",
       "accounting_export_batches": "0",
@@ -565,7 +567,7 @@
       "cerp_migration_supersessions": "5",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "164",
+      "cerp_schema_migrations": "165",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -1016,7 +1018,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1033,7 +1035,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1051,7 +1053,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1077,7 +1079,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1094,7 +1096,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1112,7 +1114,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1132,7 +1134,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1150,7 +1152,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1176,7 +1178,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1194,7 +1196,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1213,7 +1215,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1251,7 +1253,7 @@
         "period_start": "2026-08-14T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-15T11:04:27.627Z",
+        "freshness_at": "2026-08-15T11:11:26.449Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1270,13 +1272,13 @@
       }
     ],
     "ledger": {
-      "applied": 164,
+      "applied": 165,
       "pending": [],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "95a160e7a44b6b8468f54c7cc5029f713006b8ba1c0f39902c71bd83d1798bb0"
+    "fingerprint": "a110dfe2f16585752e5bf4fb399a198df0056509e8d3efaa627fe4530dcbe52e"
   },
   "negative_gate": {
     "status": "passed",
@@ -1319,7 +1321,7 @@
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "36318e3291be6dfdcbad2cdeb6c5fca43dc6b3c8312741ea6bd43ed96e9eaa54",
+    "fingerprint": "218759e7dc4505d334be5d506194622ca51a3b10b5746097aae673b30328bf9d",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1347,12 +1349,13 @@
         "20260814_sol22_quality_intelligence.sql",
         "20260815_historical_test_guard_convergence_sol43.sql",
         "20260815_privileged_mfa_sol32.sql",
-        "20260815_reference_data_center_sol33.sql"
+        "20260815_reference_data_center_sol33.sql",
+        "20260815_z_client_contact_idempotency_grants_sol43.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-15T11:04:33.978Z"
+  "completed_at": "2026-08-15T11:11:32.936Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-15T11:04:33.978Z
+- Exécutée : 2026-08-15T11:11:32.936Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36355095 octets
-- Sauvegarde : 1968430 octets, SHA-256 `1270b357fc646deadc7246bb9276d52415ca60d9d125efe9e14dbff229af0e12`
-- Patches avant/après : 140 / 164
+- Sauvegarde : 1968347 octets, SHA-256 `05e505de971e66d42ef5b117f87e9c532e1fa1142366a4dbf481b5f47935d35b`
+- Patches avant/après : 140 / 165
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `36318e3291be6dfdcbad2cdeb6c5fca43dc6b3c8312741ea6bd43ed96e9eaa54` / `36318e3291be6dfdcbad2cdeb6c5fca43dc6b3c8312741ea6bd43ed96e9eaa54`
+- Empreinte source/restaurée : `218759e7dc4505d334be5d506194622ca51a3b10b5746097aae673b30328bf9d` / `218759e7dc4505d334be5d506194622ca51a3b10b5746097aae673b30328bf9d`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 18720 |
-| source_seed | 197 |
-| backup | 785 |
-| preflight | 192 |
-| integrity_before | 623 |
-| migration | 906 |
-| verify | 280 |
-| replay | 169 |
-| integrity_after | 1570 |
-| negative_gate | 41 |
-| rollback | 465 |
-| restore | 4118 |
+| source_migration | 18698 |
+| source_seed | 196 |
+| backup | 747 |
+| preflight | 195 |
+| integrity_before | 624 |
+| migration | 901 |
+| verify | 291 |
+| replay | 177 |
+| integrity_after | 1655 |
+| negative_gate | 42 |
+| rollback | 485 |
+| restore | 4170 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -73,6 +73,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "a40f4948dfbcee7de8eb00d9077f499a2b92bdda863b6728f29d8e62751a899f",
   "20260815_historical_test_guard_convergence_sol43.sql":
     "f3ccb16d3f85e03f1b00f710a9d28eda70dc6818b26353d081ac17fa41dce119",
+  "20260815_z_client_contact_idempotency_grants_sol43.sql":
+    "98490c2b57a98cf129ee4ce71bc878d4d5034a39ce46f95dc0e9b192ce67b302",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/client-contact-idempotency-grants-sol43.migration.test.ts
+++ b/src/__tests__/client-contact-idempotency-grants-sol43.migration.test.ts
@@ -1,0 +1,42 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(__dirname, "../..");
+const name = "20260815_z_client_contact_idempotency_grants_sol43";
+const read = (relativePath: string) => readFileSync(resolve(root, relativePath), "utf8");
+const migration = read(`db/patches/${name}.sql`);
+const preflight = read(`db/patches/support/${name}.preflight.sql`);
+const verify = read(`db/patches/support/${name}.verify.sql`);
+const rollback = read(`db/patches/support/${name}.rollback.sql`);
+const runner = read("scripts/db-patches.js");
+
+describe("SOL-43 contact idempotency privileges", () => {
+  it("grants only the operations used by the repository", () => {
+    expect(migration).toContain("GRANT SELECT, INSERT");
+    expect(migration).not.toMatch(/GRANT\s+(ALL|UPDATE|DELETE|TRUNCATE)/i);
+    expect(migration).toContain("TO cerp_app");
+  });
+
+  it("fails safely when the target, table, or role is unexpected", () => {
+    expect(migration).toContain("current_database() NOT IN ('cerp_test', 'cerp_prod')");
+    expect(migration).toContain("client_contact_create_idempotency");
+    expect(migration).toContain("role cerp_app is missing");
+    expect(preflight).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(preflight).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE|GRANT|REVOKE)\b/im);
+  });
+
+  it("verifies both required privileges and keeps rollback evidence-safe", () => {
+    expect(verify).toContain("'SELECT'");
+    expect(verify).toContain("'INSERT'");
+    expect(rollback).toContain("restoring the verified pre-migration backup");
+    expect(rollback).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE|GRANT|REVOKE)\b/im);
+  });
+
+  it("registers the immutable patch checksum", () => {
+    const sha256 = createHash("sha256").update(migration.replace(/\r\n?/g, "\n"), "utf8").digest("hex");
+    expect(runner).toContain(`"${name}.sql":`);
+    expect(runner).toContain(sha256);
+  });
+});


### PR DESCRIPTION
Promotes the tested minimal cerp_app privileges required for contact idempotency.

## Summary by Sourcery

Add a production-safe migration to grant minimal client contact idempotency privileges to the cerp_app role and register it in the immutable patch set.

New Features:
- Introduce a SOL-43 migration that grants only SELECT and INSERT on the client_contact_create_idempotency table to cerp_app with strict safety checks.
- Add preflight and verification scripts to enforce safe execution and confirm required privileges for contact idempotency.

Enhancements:
- Register the new SOL-43 idempotency grant migration checksum in the db-patches runner as an immutable patch.
- Update SOL-06 migration rehearsal and inventory artefacts to reflect the new patch and regenerated metadata.

Tests:
- Add a migration test ensuring the SOL-43 contact idempotency grant patch, its safety properties, and checksum registration behave as expected.