### PR TITLE
fix(backup): verify inline report payloads

### DIFF
--- a/scripts/backup/recovery-set.mjs
+++ b/scripts/backup/recovery-set.mjs
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 const require = createRequire(import.meta.url);
 const pgModule = process.env.CERP_BACKUP_PG_MODULE
   ? require(path.resolve(process.env.CERP_BACKUP_PG_MODULE))
@@ -176,10 +177,59 @@ async function documentReferenceMetadata(client) {
             ),ARRAY[]::text[]) AS primary_key
        FROM information_schema.columns c
       WHERE c.table_schema='public' AND c.column_name = ANY($1::text[])
+        AND NOT (c.table_name='project_report_exports' AND c.column_name='file_path')
       ORDER BY c.table_name,c.column_name`,
     [STORAGE_COLUMNS, SIZE_COLUMNS]
   );
   return result.rows;
+}
+
+export function verifyInlineDocumentRows(rows) {
+  const failures = [];
+  let verifiedCount = 0;
+  let totalBytes = 0;
+  for (const row of rows) {
+    const fingerprint = sha256Buffer(Buffer.from(`project_report_exports|${row.row_ref}`)).slice(0, 16);
+    const payload = typeof row.file_base64 === "string" ? row.file_base64.replace(/\s/g, "") : "";
+    const expected = typeof row.checksum === "string" ? row.checksum.trim().toLowerCase() : "";
+    if (!payload || payload.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(payload)) {
+      failures.push({ reference: fingerprint, reason: "invalid_or_missing_base64" });
+      continue;
+    }
+    if (!/^[a-f0-9]{64}$/.test(expected)) {
+      failures.push({ reference: fingerprint, reason: "invalid_or_missing_checksum" });
+      continue;
+    }
+    const content = Buffer.from(payload, "base64");
+    if (sha256Buffer(content) !== expected) {
+      failures.push({ reference: fingerprint, reason: "checksum_mismatch" });
+      continue;
+    }
+    verifiedCount += 1;
+    totalBytes += content.length;
+  }
+  return {
+    reference_count: rows.length,
+    verified_count: verifiedCount,
+    total_bytes: totalBytes,
+    failure_count: failures.length,
+    failures: failures.slice(0, 100),
+  };
+}
+
+async function inlineDocumentIntegrity(client, tables) {
+  if (!tables.includes("project_report_exports")) {
+    return { reference_count: 0, verified_count: 0, total_bytes: 0, failure_count: 0, failures: [] };
+  }
+  const result = await client.query(
+    `SELECT id::text AS row_ref,file_base64,checksum
+       FROM public.project_report_exports
+      WHERE file_path IS NOT NULL AND btrim(file_path) <> ''
+      ORDER BY id`
+  );
+  const integrity = verifyInlineDocumentRows(result.rows);
+  if (integrity.failure_count) fail(`${integrity.failure_count} inline document payloads failed integrity checks`);
+  return integrity;
 }
 
 function rowReferenceExpression(primaryKey) {
@@ -240,16 +290,15 @@ async function exportRecoverySet(options) {
     );
     const identity = identityResult.rows[0];
     const tables = await existingPublicTables(client);
-    const [references, counts, migrations, readiness, invalidFks] = await Promise.all([
-      documentReferences(client),
-      criticalCounts(client, tables),
-      migrationDigest(client, tables),
-      readinessSummary(client),
-      client.query(
-        `SELECT count(*)::int AS count FROM pg_constraint
-          WHERE connamespace='public'::regnamespace AND contype='f' AND NOT convalidated`
-      ),
-    ]);
+    const references = await documentReferences(client);
+    const counts = await criticalCounts(client, tables);
+    const migrations = await migrationDigest(client, tables);
+    const readiness = await readinessSummary(client);
+    const inlineDocuments = await inlineDocumentIntegrity(client, tables);
+    const invalidFks = await client.query(
+      `SELECT count(*)::int AS count FROM pg_constraint
+        WHERE connamespace='public'::regnamespace AND contype='f' AND NOT convalidated`
+    );
 
     await run(pgDump, [
       "--format=custom",
@@ -286,6 +335,7 @@ async function exportRecoverySet(options) {
       invalid_public_foreign_keys: invalidFks.rows[0].count,
       business_prerequisites: readiness,
       document_reference_count: references.length,
+      inline_document_integrity: inlineDocuments,
       dump: { file: "cerp.dump", bytes: dumpStat.size, sha256: await sha256File(dumpFile) },
       catalog: { file: "cerp.dump.catalog", sha256: await sha256File(catalogFile) },
       document_references: { file: "document-references.jsonl", sha256: await sha256File(referencesFile) },
@@ -424,6 +474,7 @@ async function verifyRestoredDatabase(client, metadata) {
     const counts = await criticalCounts(client, tables);
     const migrations = await migrationDigest(client, tables);
     const readiness = await readinessSummary(client);
+    const inlineDocuments = await inlineDocumentIntegrity(client, tables);
     const invalidFks = await client.query(
       `SELECT count(*)::int AS count FROM pg_constraint
         WHERE connamespace='public'::regnamespace AND contype='f' AND NOT convalidated`
@@ -440,7 +491,13 @@ async function verifyRestoredDatabase(client, metadata) {
     if (metadata.business_prerequisites?.available && readiness.blocking !== metadata.business_prerequisites.blocking) {
       failures.push("business_prerequisites");
     }
-    return { tables: tables.length, critical_table_counts: counts, migrations, readiness, invalid_public_foreign_keys: invalidFks.rows[0].count, failures };
+    if (metadata.inline_document_integrity
+        && (inlineDocuments.reference_count !== metadata.inline_document_integrity.reference_count
+          || inlineDocuments.verified_count !== metadata.inline_document_integrity.verified_count
+          || inlineDocuments.total_bytes !== metadata.inline_document_integrity.total_bytes)) {
+      failures.push("inline_document_integrity");
+    }
+    return { tables: tables.length, critical_table_counts: counts, migrations, readiness, inline_document_integrity: inlineDocuments, invalid_public_foreign_keys: invalidFks.rows[0].count, failures };
   } finally {
     await client.query("COMMIT");
   }
@@ -506,7 +563,11 @@ async function main() {
   fail("command must be export, verify-files or restore-database");
 }
 
-main().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
-  process.exitCode = 1;
-});
+const invokedDirectly = process.argv[1]
+  && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (invokedDirectly) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/__tests__/recovery-set-inline-documents.test.ts
+++ b/src/__tests__/recovery-set-inline-documents.test.ts
@@ -1,0 +1,50 @@
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+type InlineRow = { row_ref: string; file_base64: string | null; checksum: string | null };
+type InlineResult = {
+  reference_count: number;
+  verified_count: number;
+  total_bytes: number;
+  failure_count: number;
+  failures: Array<{ reference: string; reason: string }>;
+};
+
+function verify(rows: InlineRow[]): InlineResult {
+  const moduleUrl = pathToFileURL(path.resolve(process.cwd(), "scripts/backup/recovery-set.mjs")).href;
+  const source = `import { verifyInlineDocumentRows } from ${JSON.stringify(moduleUrl)}; process.stdout.write(JSON.stringify(verifyInlineDocumentRows(JSON.parse(process.argv[1]))));`;
+  const output = execFileSync(process.execPath, ["--input-type=module", "-e", source, JSON.stringify(rows)], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  return JSON.parse(output) as InlineResult;
+}
+
+describe("SOL-10 inline document recovery integrity", () => {
+  it("verifies the database-backed export payload and checksum", () => {
+    const content = Buffer.from("CERP inline report proof", "utf8");
+    const result = verify([{
+      row_ref: "report-export-1",
+      file_base64: content.toString("base64"),
+      checksum: crypto.createHash("sha256").update(content).digest("hex"),
+    }]);
+
+    expect(result).toMatchObject({ reference_count: 1, verified_count: 1, total_bytes: content.length, failure_count: 0 });
+  });
+
+  it.each([
+    { label: "missing payload", file_base64: null, checksum: "a".repeat(64), reason: "invalid_or_missing_base64" },
+    { label: "invalid checksum", file_base64: Buffer.from("proof").toString("base64"), checksum: "bad", reason: "invalid_or_missing_checksum" },
+    { label: "mismatched checksum", file_base64: Buffer.from("proof").toString("base64"), checksum: "a".repeat(64), reason: "checksum_mismatch" },
+  ])("rejects $label", ({ file_base64, checksum, reason }) => {
+    const result = verify([{ row_ref: "report-export-invalid", file_base64, checksum }]);
+
+    expect(result.failure_count).toBe(1);
+    expect(result.failures[0]?.reason).toBe(reason);
+  });
+});


### PR DESCRIPTION
## Résultat
- distingue les vrais fichiers externes des exports Project Office stockés inline en base
- vérifie base64 + SHA-256 des six exports avant sauvegarde et après restauration
- sérialise les requêtes sur la transaction PostgreSQL de snapshot

## Cause racine
file_path est un nom de téléchargement pour project_report_exports ; le contenu autoritaire est file_base64.

## Validation
- test ciblé : 4/4 PASS
- typecheck : PASS
- prod read-only : 6/6 payloads, 35 596 106 octets, 0 échec, 0 référence externe

## Summary by Sourcery

Add integrity verification for inline report export payloads in backup and restore metadata and checks.

New Features:
- Track and validate inline project_report_exports payloads and checksums as part of recovery-set export and restore verification.

Bug Fixes:
- Exclude project_report_exports.file_path from generic document reference discovery to avoid treating inline report exports as external files.

Enhancements:
- Make recovery-set script safe to import as a module by only running main when invoked directly.

Tests:
- Add tests covering inline document payload verification, including valid payloads and failure scenarios for missing, invalid, or mismatched checksums.