### PR TITLE
fix(backup): resolve symlinked entrypoint

### DIFF
--- a/scripts/backup/recovery-set.mjs
+++ b/scripts/backup/recovery-set.mjs
@@ -564,7 +564,8 @@ async function main() {
 }
 
 const invokedDirectly = process.argv[1]
-  && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+  && fs.existsSync(process.argv[1])
+  && fs.realpathSync(path.resolve(process.argv[1])) === fs.realpathSync(fileURLToPath(import.meta.url));
 if (invokedDirectly) {
   main().catch((error) => {
     process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);


### PR DESCRIPTION
## Résultat
Le runner compare les chemins réels afin de s'exécuter via /srv/cerp/backend, tout en restant importable par ses tests.

## Validation
- 4 tests ciblés PASS
- typecheck PASS
- node --check PASS

## Summary by Sourcery

Bug Fixes:
- Fix direct invocation detection of the backup recovery script by resolving real paths and handling symlinked entrypoints.