### PR TITLE
test(portal): freeze invitation clock

### DIFF
--- a/src/module/client-portal/domain/client-portal-security.test.ts
+++ b/src/module/client-portal/domain/client-portal-security.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   hashPortalOpaqueValue,
@@ -13,10 +13,13 @@ const previousSecret = process.env.CLIENT_PORTAL_JWT_SECRET;
 
 describe("client portal security boundary", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-14T12:30:00.000Z"));
     process.env.CLIENT_PORTAL_JWT_SECRET = "sol29-test-secret-with-at-least-32-characters";
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (previousSecret === undefined) delete process.env.CLIENT_PORTAL_JWT_SECRET;
     else process.env.CLIENT_PORTAL_JWT_SECRET = previousSecret;
   });


### PR DESCRIPTION
## Résultat
Fige l'horloge de la suite portail avant l'expiration de la fixture et la restaure après chaque cas.

## Cause racine
La date absolue du token valide est devenue passée le 15 août 2026.

## Validation
- tests portail + recovery : 9/9 PASS
- typecheck PASS

## Summary by Sourcery

Tests:
- Freeze Vitest timers in client portal security tests to a fixed pre-expiration date and restore real timers after each case.