### PR TITLE
fix(facturation): restore eligible invoice sources

### DIFF
--- a/src/module/facturation/repository/facture-workflow.repository.contract.test.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.contract.test.ts
@@ -40,4 +40,11 @@ describe("facture draft SQL contract", () => {
       expect(repository).toContain("legal_number = $2::text");
     }
   });
+
+  it("versions delivery-line pricing from canonical price values without an optional timestamp column", () => {
+    expect(source).not.toContain("cl.updated_at");
+    expect(source).toContain("COALESCE(cl.prix_unitaire_ht::text, 'NULL')");
+    expect(source).toContain("COALESCE(cl.remise_ligne::text, 'NULL')");
+    expect(source).toContain("COALESCE(cl.taux_tva::text, 'NULL')");
+  });
 });

--- a/src/module/facturation/repository/facture-workflow.repository.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.ts
@@ -174,7 +174,12 @@ const DELIVERY_SOURCE_SELECT = `
     COALESCE(cl.taux_tva, 0)::numeric(9,4)::text AS tax_rate_percent,
     CASE
       WHEN cl.id IS NULL THEN NULL
-      ELSE concat('COMMANDE_LINE:', cl.id::text, ':', COALESCE(cl.updated_at::text, 'unknown'))
+      ELSE concat(
+        'COMMANDE_LINE:', cl.id::text,
+        ':PRICE:', COALESCE(cl.prix_unitaire_ht::text, 'NULL'),
+        ':DISCOUNT:', COALESCE(cl.remise_ligne::text, 'NULL'),
+        ':VAT:', COALESCE(cl.taux_tva::text, 'NULL')
+      )
     END AS pricing_version
   FROM public.bon_livraison_ligne bll
   JOIN public.bon_livraison bl ON bl.id = bll.bon_livraison_id


### PR DESCRIPTION
Closes #585\n\n- retire la dépendance à commande_ligne.updated_at, absente du schéma canonique ;\n- construit pricing_version depuis prix, remise et TVA ;\n- ajoute un test contractuel de compatibilité.\n\nPreuves :\n- 13 tests facturation/SUPER PDP réussis ;\n- npm run build réussi ;\n- aucune écriture cerp_prod.

## Summary by Sourcery

Restore delivery-line pricing versioning using canonical price, discount, and VAT fields instead of the non-canonical updated_at timestamp to ensure invoice source eligibility.

Bug Fixes:
- Remove dependency on the non-canonical commande_ligne.updated_at column when computing delivery-line pricing_version for invoices.

Tests:
- Add a contract test verifying that pricing_version is derived from canonical price, discount, and VAT fields and does not reference an optional timestamp column.