### PR TITLE
release: promote electronic invoicing workflow compatibility

### DIFF
--- a/src/module/facturation/repository/facture-workflow.repository.contract.test.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.contract.test.ts
@@ -40,4 +40,11 @@ describe("facture draft SQL contract", () => {
       expect(repository).toContain("legal_number = $2::text");
     }
   });
+
+  it("versions delivery-line pricing from canonical price values without an optional timestamp column", () => {
+    expect(source).not.toContain("cl.updated_at");
+    expect(source).toContain("COALESCE(cl.prix_unitaire_ht::text, 'NULL')");
+    expect(source).toContain("COALESCE(cl.remise_ligne::text, 'NULL')");
+    expect(source).toContain("COALESCE(cl.taux_tva::text, 'NULL')");
+  });
 });

--- a/src/module/facturation/repository/facture-workflow.repository.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.ts
@@ -174,7 +174,12 @@ const DELIVERY_SOURCE_SELECT = `
     COALESCE(cl.taux_tva, 0)::numeric(9,4)::text AS tax_rate_percent,
     CASE
       WHEN cl.id IS NULL THEN NULL
-      ELSE concat('COMMANDE_LINE:', cl.id::text, ':', COALESCE(cl.updated_at::text, 'unknown'))
+      ELSE concat(
+        'COMMANDE_LINE:', cl.id::text,
+        ':PRICE:', COALESCE(cl.prix_unitaire_ht::text, 'NULL'),
+        ':DISCOUNT:', COALESCE(cl.remise_ligne::text, 'NULL'),
+        ':VAT:', COALESCE(cl.taux_tva::text, 'NULL')
+      )
     END AS pricing_version
   FROM public.bon_livraison_ligne bll
   JOIN public.bon_livraison bl ON bl.id = bll.bon_livraison_id


### PR DESCRIPTION
Promotion du correctif #585 après validation ciblée.\n\n- GET /factures/workflow/eligible-sources n'interroge plus une colonne absente ;\n- pricing_version reste traçable depuis les valeurs de prix ;\n- 13 tests ciblés et build strict réussis ;\n- aucune migration SQL requise ;\n- validation finale sur cerp_test et SUPER PDP sandbox en cours.

## Summary by Sourcery

Update delivery-line pricing versioning to derive from canonical price fields and align tests with the new workflow contract.

Bug Fixes:
- Ensure pricing_version remains traceable using existing price-related columns instead of a non-existent timestamp column.

Enhancements:
- Revise pricing_version format for delivery lines to encode unit price, discount, and VAT values for improved auditability.

Tests:
- Add repository contract test asserting pricing_version is derived from canonical price values without relying on an optional timestamp column.