### PR TITLE
fix(einvoice): restore UBL conversion compatibility

### DIFF
--- a/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.adapter.test.ts
+++ b/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.adapter.test.ts
@@ -67,10 +67,12 @@ describe("SUPER PDP adapter", () => {
       buyer: { name: "Client industriel" },
       totals: { total_without_vat: "100.00", amount_due_for_payment: "120.00" },
     });
-    expect((result.lines as Array<Record<string, unknown>>)[0]).toMatchObject({
+    const line = (result.lines as Array<Record<string, unknown>>)[0];
+    expect(line).toMatchObject({
       invoiced_quantity_code: "C62",
       net_amount: "100",
     });
+    expect(line).not.toHaveProperty("line_with_vat_net_amount");
     expect(() => buildSuperPdpEn16931Invoice({
       ...source,
       lines: [{ ...source.lines[0], vat_rate: "0" }],

--- a/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.en16931.ts
+++ b/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.en16931.ts
@@ -232,7 +232,6 @@ function lineRecord(line: Readonly<JsonRecord>, index: number): {
       invoiced_item_vat_rate: formatDecimal(parsedVatRate),
     },
     line_vat_amount: formatDecimal(tax),
-    line_with_vat_net_amount: formatDecimal(gross),
   };
   return { invoiceLine, vatRate: formatDecimal(parsedVatRate), net, tax };
 }


### PR DESCRIPTION
Closes #589\n\n- omet EXT-FR-FE-184, optionnel et non convertible en UBL par SUPER PDP ;\n- conserve BT-131, TVA de ligne et totaux document ;\n- 15 tests ciblés réussis ;\n- build strict réussi ;\n- aucune écriture cerp_prod.

## Summary by Sourcery

Remove unsupported line gross amount field from SUPER PDP EN16931 invoices to restore UBL conversion compatibility and assert its absence in adapter tests.

Bug Fixes:
- Eliminate inclusion of the non-convertible line_with_vat_net_amount in SUPER PDP EN16931 invoice lines to maintain UBL compatibility.

Tests:
- Extend SUPER PDP adapter tests to verify that invoice lines no longer contain the line_with_vat_net_amount field.