### PR TITLE
release: promote SUPER PDP UBL qualification fix

### DIFF
--- a/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.adapter.test.ts
+++ b/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.adapter.test.ts
@@ -67,10 +67,12 @@ describe("SUPER PDP adapter", () => {
       buyer: { name: "Client industriel" },
       totals: { total_without_vat: "100.00", amount_due_for_payment: "120.00" },
     });
-    expect((result.lines as Array<Record<string, unknown>>)[0]).toMatchObject({
+    const line = (result.lines as Array<Record<string, unknown>>)[0];
+    expect(line).toMatchObject({
       invoiced_quantity_code: "C62",
       net_amount: "100",
     });
+    expect(line).not.toHaveProperty("line_with_vat_net_amount");
     expect(() => buildSuperPdpEn16931Invoice({
       ...source,
       lines: [{ ...source.lines[0], vat_rate: "0" }],

--- a/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.en16931.ts
+++ b/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.en16931.ts
@@ -232,7 +232,6 @@ function lineRecord(line: Readonly<JsonRecord>, index: number): {
       invoiced_item_vat_rate: formatDecimal(parsedVatRate),
     },
     line_vat_amount: formatDecimal(tax),
-    line_with_vat_net_amount: formatDecimal(gross),
   };
   return { invoiceLine, vatRate: formatDecimal(parsedVatRate), net, tax };
 }


### PR DESCRIPTION
Promotion du correctif #589 après tests ciblés et build strict. La validation finale exécute la conversion et le dépôt réels dans SUPER PDP sandbox ; aucune migration SQL et aucune écriture cerp_prod.

## Summary by Sourcery

Remove incorrect VAT-inclusive line net amount from SUPER PDP EN16931 invoice lines and adjust tests accordingly.

Bug Fixes:
- Stop sending the VAT-inclusive net amount field on SUPER PDP EN16931 invoice lines, keeping only the expected net and tax values.

Tests:
- Extend SUPER PDP adapter tests to assert that the VAT-inclusive line net amount field is no longer present in generated invoice lines.