### PR TITLE
fix(einvoice): align line VAT with SUPER PDP

### DIFF
--- a/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.adapter.test.ts
+++ b/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.adapter.test.ts
@@ -72,6 +72,7 @@ describe("SUPER PDP adapter", () => {
       invoiced_quantity_code: "C62",
       net_amount: "100",
     });
+    expect(line).not.toHaveProperty("line_vat_amount");
     expect(line).not.toHaveProperty("line_with_vat_net_amount");
     expect(() => buildSuperPdpEn16931Invoice({
       ...source,

--- a/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.en16931.ts
+++ b/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.en16931.ts
@@ -231,7 +231,6 @@ function lineRecord(line: Readonly<JsonRecord>, index: number): {
       invoiced_item_vat_category_code: "S",
       invoiced_item_vat_rate: formatDecimal(parsedVatRate),
     },
-    line_vat_amount: formatDecimal(tax),
   };
   return { invoiceLine, vatRate: formatDecimal(parsedVatRate), net, tax };
 }


### PR DESCRIPTION
Closes #593. Removes optional per-line VAT extensions rejected by the live SUPER PDP UBL converter while retaining reconciled document VAT breakdown and totals. Targeted tests: 8/8; build: pass. No database change.

## Summary by Sourcery

Align SUPER PDP EN16931 invoice lines with the live converter by removing unsupported per-line VAT amount fields.

Bug Fixes:
- Remove the per-line VAT amount field from SUPER PDP EN16931 invoice lines to comply with the live UBL converter expectations.

Tests:
- Update SUPER PDP adapter tests to assert that the removed per-line VAT field is no longer present on invoice lines.