### PR TITLE
release: promote SUPER PDP EN16931 compatibility

### DIFF
--- a/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.adapter.test.ts
+++ b/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.adapter.test.ts
@@ -72,6 +72,7 @@ describe("SUPER PDP adapter", () => {
       invoiced_quantity_code: "C62",
       net_amount: "100",
     });
+    expect(line).not.toHaveProperty("line_vat_amount");
     expect(line).not.toHaveProperty("line_with_vat_net_amount");
     expect(() => buildSuperPdpEn16931Invoice({
       ...source,

--- a/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.en16931.ts
+++ b/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.en16931.ts
@@ -231,7 +231,6 @@ function lineRecord(line: Readonly<JsonRecord>, index: number): {
       invoiced_item_vat_category_code: "S",
       invoiced_item_vat_rate: formatDecimal(parsedVatRate),
     },
-    line_vat_amount: formatDecimal(tax),
   };
   return { invoiceLine, vatRate: formatDecimal(parsedVatRate), net, tax };
 }


### PR DESCRIPTION
Promotes the live-sandbox compatibility correction from dev. Closes #593. Targeted electronic invoicing tests pass (8/8) and backend build passes. No database migration.

## Summary by Sourcery

Align SUPER PDP EN16931 invoice line format with expected schema by removing the per-line VAT amount field.

Enhancements:
- Update SUPER PDP EN16931 invoice line construction to omit the line-level VAT amount field from generated records.

Tests:
- Extend SUPER PDP adapter tests to assert that the line VAT amount field is no longer present in invoice line output.