### PR TITLE
fix(einvoice): delegate processing rule to SUPER PDP

### DIFF
--- a/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.adapter.test.ts
+++ b/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.adapter.test.ts
@@ -167,6 +167,14 @@ describe("SUPER PDP adapter", () => {
       attachments: [],
     });
     expect(receipt).toMatchObject({ providerDocumentId: "77", statusCode: null });
+    const submissionCall = fetcher.mock.calls.find(([input, init]) =>
+      new URL(String(input)).pathname === "/v1.beta/invoices" && init?.method === "POST"
+    );
+    expect(submissionCall).toBeDefined();
+    const submissionUrl = new URL(String(submissionCall?.[0]));
+    expect(submissionUrl.searchParams.get("external_id")).toBe("52bb2f7e-51ba-4b8d-a630-c6b4a43da9ad");
+    expect(submissionUrl.searchParams.has("processing_rule")).toBe(false);
+    expect(submissionUrl.searchParams.has("disable_pre_check")).toBe(false);
     const event = await adapter.retrieve("77", "correlation-1", {
       direction: "OUTBOUND",
       documentType: "INVOICE",

--- a/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.client.ts
+++ b/src/module/facturation/electronic-invoicing/providers/super-pdp/super-pdp.client.ts
@@ -513,7 +513,7 @@ export class SuperPdpClient {
   }): Promise<{ invoice: ProviderInvoice; requestId: string | null; replayed: boolean }> {
     const existing = await this.findInvoiceByExternalId(params.localDocumentId);
     if (existing) return { invoice: existing, requestId: null, replayed: true };
-    const query = new URLSearchParams({ external_id: params.localDocumentId, processing_rule: "B2B" });
+    const query = new URLSearchParams({ external_id: params.localDocumentId });
     const response = await this.request(`/v1.beta/invoices?${query.toString()}`, {
       method: "POST",
       headers: {


### PR DESCRIPTION
Closes #596. Removes the guessed B2B processing rule; SUPER PDP computes and validates the correct rule while synchronous pre-checks remain enabled. Electronic invoicing tests: 14/14; build: pass; production dependency audit: 0 vulnerabilities. No database change.

## Summary by Sourcery

Delegate invoice processing rule determination to SUPER PDP while keeping synchronous pre-checks enabled.

Bug Fixes:
- Stop hardcoding the B2B processing rule when submitting invoices to SUPER PDP so the provider can compute the appropriate rule.

Tests:
- Extend SUPER PDP adapter tests to assert that processing_rule is no longer sent and pre-checks remain enabled on invoice submission.