### PR TITLE
test(devis): close multipart fixture deterministically

### DIFF
--- a/docs/execution-reports/RELEASE-PROMOTION-20260820.md
+++ b/docs/execution-reports/RELEASE-PROMOTION-20260820.md
@@ -1,0 +1,28 @@
+# Promotion de release — 20 août 2026
+
+## État
+
+Promotion vers `main` suspendue tant que le contrôle `dev` n'a pas été rejoué après le correctif ci-dessous. Aucune base partagée ni aucun environnement de production n'a été modifié à ce stade.
+
+## Incident du contrôle `dev`
+
+Le contrôle `20260820T065502Z-test-decd72b2-40182c48` a correctement bloqué la promotion. Les 4 848 assertions backend étaient réussies, mais Vitest a détecté une exception asynchrone `EBADF: bad file descriptor, close` rattachée au scénario multipart de création d'un devis.
+
+Cause racine : le test créait un fichier client temporaire puis demandait à Supertest de l'envoyer par chemin. Sous Windows avec Node.js 24 et la concurrence de la suite complète, la résolution de la réponse pouvait précéder la fin de fermeture du `ReadStream` client. La suppression de la fixture entrait alors en course avec cette fermeture. Le pipeline serveur, son stockage privé, la validation du contenu et le transfert transactionnel n'étaient pas en échec.
+
+## Correction
+
+Le scénario envoie désormais le même contenu via un `Buffer` multipart nommé `doc.txt`. Cela conserve le contrat HTTP et tout le pipeline disque sécurisé côté serveur, mais supprime le descripteur client inutile et son cycle de vie asynchrone.
+
+## Preuves après correction
+
+- scénario `devis.routes.test.ts` répété 20 fois : 20 réussites, 0 échec ;
+- suite backend complète : 354 fichiers réussis, 3 fichiers conditionnels ignorés, 4 848 tests réussis, 8 conditionnels ignorés, 0 erreur non gérée ;
+- `corepack pnpm typecheck` : réussi ;
+- `corepack pnpm build` : réussi ;
+- contrat OpenAPI : 1 079 opérations inventoriées et contrat émis valide ;
+- frontière des données de production : source et build validés.
+
+## Données, compatibilité et retour arrière
+
+Ce correctif ne modifie ni API, ni logique métier, ni schéma, ni donnée. Le retour arrière consiste à annuler le commit de test, mais réintroduirait la course de descripteur Windows. La promotion, les migrations partagées et le déploiement restent soumis aux contrôles de release suivants.

--- a/src/__tests__/devis.routes.test.ts
+++ b/src/__tests__/devis.routes.test.ts
@@ -3,10 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "events";
 import fs from "node:fs";
 import path from "node:path";
-import {
-  ensureTmpStoragePath,
-  getDocumentStoragePath,
-} from "../utils/cerpStorage";
+import { getDocumentStoragePath } from "../utils/cerpStorage";
 
 const mocks = vi.hoisted(() => ({
   poolQuery: vi.fn(),
@@ -716,10 +713,6 @@ describe("/api/v1/devis", () => {
   });
 
   it("POST /api/v1/devis supports multipart data + optional documents[]", async () => {
-    const tmpDir = fs.mkdtempSync(path.join(ensureTmpStoragePath("fixtures"), "devis-"));
-    const tmpFile = path.join(tmpDir, "doc.txt");
-    fs.writeFileSync(tmpFile, "hello");
-
     const payload = {
       client_id: "001",
       user_id: 1,
@@ -730,7 +723,14 @@ describe("/api/v1/devis", () => {
       .post("/api/v1/devis")
       .set("Idempotency-Key", "devis-create-route-0001")
       .field("data", JSON.stringify(payload))
-      .attach("documents[]", tmpFile);
+      // A Buffer keeps the multipart contract under test without leaving a
+      // client-side ReadStream close pending after Supertest resolves. Under
+      // the full Windows/Node 24 suite that unnecessary fixture descriptor
+      // could race worker teardown and surface as an unhandled EBADF.
+      .attach("documents[]", Buffer.from("hello"), {
+        filename: "doc.txt",
+        contentType: "text/plain",
+      });
 
     expect(res.status).toBe(201);
     expect(res.body).toMatchObject({ id: 7, idempotent_replay: false });
@@ -755,7 +755,6 @@ describe("/api/v1/devis", () => {
     const insertLigneCall = mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("INSERT INTO devis_ligne"));
     expect(String(insertLigneCall?.[0])).toContain("position");
 
-    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it("POST /api/v1/devis requires an idempotency key before any write", async () => {


### PR DESCRIPTION
## Cause
Le gate `dev` a détecté une exception asynchrone Windows/Node 24 `EBADF` après un test multipart Devis. Le scénario Supertest ouvrait inutilement un `ReadStream` client à partir d'une fixture sur disque puis supprimait la fixture alors que la fermeture pouvait encore être en vol sous forte concurrence.

## Correction
Le test envoie le même document par `Buffer` multipart nommé. Le pipeline serveur sécurisé reste intégralement exercé, sans descripteur client asynchrone.

## Preuves
- 20 répétitions ciblées : 20/20
- backend complet : 4 848 pass, 8 skips conditionnels, 0 unhandled error
- typecheck : PASS
- build + OpenAPI 1079/1079 : PASS

Aucun schéma, donnée, API ou comportement métier modifié.

## Summary by Sourcery

Make the Devis multipart test deterministic across the full Windows/Node.js 24 suite without changing application behavior.

Bug Fixes:
- Eliminate the asynchronous Windows/Node.js 24 EBADF race in the Devis multipart route test by using an in-memory upload fixture.

Documentation:
- Add a release-promotion execution report documenting the multipart test failure, fix, validation evidence, and release status.

Tests:
- Stabilize the Devis multipart test while preserving coverage of the multipart contract and server-side document pipeline.