### PR TITLE
release: promote validated dev backend to main

### DIFF
--- a/db/patches/20260819_client_portal_auth_attempt_update_grant_004.sql
+++ b/db/patches/20260819_client_portal_auth_attempt_update_grant_004.sql
@@ -1,0 +1,26 @@
+-- CERP-AUDIT-004 — activation and login mark their rate-limit attempt as
+-- successful. The runtime role needs UPDATE only for that state transition.
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+
+DO $guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'CERP-AUDIT-004 grant refused on database %', current_database();
+  END IF;
+  IF to_regclass('public.client_portal_auth_attempts') IS NULL THEN
+    RAISE EXCEPTION 'CERP-AUDIT-004 grant refused: client_portal_auth_attempts is missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'CERP-AUDIT-004 grant refused: runtime role cerp_app is missing';
+  END IF;
+END
+$guard$;
+
+-- No broad privilege: this is required solely by
+-- repoMarkPortalAuthAttemptSuccess after a successful portal activation/login.
+GRANT UPDATE ON TABLE public.client_portal_auth_attempts TO cerp_app;
+
+COMMIT;

--- a/db/patches/20260819_devis_preparation_idempotency_grants_002_003.sql
+++ b/db/patches/20260819_devis_preparation_idempotency_grants_002_003.sql
@@ -1,0 +1,38 @@
+-- CERP-AUDIT-002/003 — minimum runtime privileges for quote preparation and
+-- idempotent creation. No business data, ownership, or existing grants change.
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+
+DO $guard$
+DECLARE
+  target_relation text;
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'CERP-AUDIT-002/003 grant refused on database %', current_database();
+  END IF;
+
+  FOREACH target_relation IN ARRAY ARRAY[
+    'public.article_devis',
+    'public.dossier_technique_piece_devis',
+    'public.devis_idempotence'
+  ] LOOP
+    IF to_regclass(target_relation) IS NULL THEN
+      RAISE EXCEPTION 'CERP-AUDIT-002/003 grant refused: relation % is missing', target_relation;
+    END IF;
+  END LOOP;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'CERP-AUDIT-002/003 grant refused: runtime role cerp_app is missing';
+  END IF;
+END
+$guard$;
+
+-- Repository evidence: preparation rows are selected/inserted/deleted when a
+-- draft is replaced; the idempotency ledger is only selected/inserted.
+GRANT SELECT, INSERT, DELETE ON TABLE public.article_devis TO cerp_app;
+GRANT SELECT, INSERT, DELETE ON TABLE public.dossier_technique_piece_devis TO cerp_app;
+GRANT SELECT, INSERT ON TABLE public.devis_idempotence TO cerp_app;
+
+COMMIT;

--- a/db/patches/20260819_mfa_expired_artifact_cleanup_delete_grant.sql
+++ b/db/patches/20260819_mfa_expired_artifact_cleanup_delete_grant.sql
@@ -1,0 +1,28 @@
+-- CERP-REPAIR-00 — the MFA maintenance job removes expired PENDING factors
+-- only after their expired challenges have been removed. The runtime role
+-- therefore needs this single, explicit DELETE privilege.
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+
+DO $guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup grant refused on database %', current_database();
+  END IF;
+  IF to_regclass('public.user_mfa_factors') IS NULL
+     OR to_regclass('public.auth_mfa_challenges') IS NULL THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup grant refused: MFA relations are missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup grant refused: runtime role cerp_app is missing';
+  END IF;
+END
+$guard$;
+
+-- Do not broaden the MFA runtime role. cleanupExpiredMfaArtifacts deletes only
+-- expired PENDING factors after deleting their challenge rows.
+GRANT DELETE ON TABLE public.user_mfa_factors TO cerp_app;
+
+COMMIT;

--- a/db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.preflight.sql
+++ b/db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.preflight.sql
@@ -1,0 +1,23 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'CERP-AUDIT-004 grant preflight refused on database %', current_database();
+  END IF;
+  IF to_regclass('public.client_portal_auth_attempts') IS NULL THEN
+    RAISE EXCEPTION 'CERP-AUDIT-004 grant preflight refused: client_portal_auth_attempts is missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'CERP-AUDIT-004 grant preflight refused: runtime role cerp_app is missing';
+  END IF;
+END
+$guard$;
+
+SELECT has_table_privilege('cerp_app', 'public.client_portal_auth_attempts', 'UPDATE')
+  AS can_mark_portal_auth_attempt_success;
+
+COMMIT;

--- a/db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.rollback.sql
+++ b/db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.rollback.sql
@@ -1,0 +1,13 @@
+\set ON_ERROR_STOP on
+
+-- The exact privilege baseline predating this corrective patch is not
+-- reconstructible from PostgreSQL grants alone. Revoke-in-place could remove a
+-- permission owned by another approved migration. Restore the verified
+-- pre-migration backup after rolling the matching application code back.
+DO $rollback$
+BEGIN
+  RAISE EXCEPTION USING
+    MESSAGE = 'CERP-AUDIT-004 portal grant rollback requires restoring the verified pre-migration backup',
+    HINT = 'Do not REVOKE in place; restore the backup into an isolated database, verify portal activation, then promote it.';
+END
+$rollback$;

--- a/db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.verify.sql
+++ b/db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.verify.sql
@@ -1,0 +1,16 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $verify$
+BEGIN
+  IF NOT has_table_privilege('cerp_app', 'public.client_portal_auth_attempts', 'UPDATE') THEN
+    RAISE EXCEPTION 'CERP-AUDIT-004 verify: cerp_app cannot mark portal authentication attempts successful';
+  END IF;
+END
+$verify$;
+
+SELECT has_table_privilege('cerp_app', 'public.client_portal_auth_attempts', 'UPDATE')
+  AS can_mark_portal_auth_attempt_success;
+
+COMMIT;

--- a/db/patches/support/20260819_devis_preparation_idempotency_grants_002_003.preflight.sql
+++ b/db/patches/support/20260819_devis_preparation_idempotency_grants_002_003.preflight.sql
@@ -1,0 +1,63 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $guard$
+DECLARE
+  target_relation text;
+  required_column record;
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'CERP-AUDIT-002/003 grant preflight refused on database %', current_database();
+  END IF;
+  FOREACH target_relation IN ARRAY ARRAY[
+    'public.article_devis',
+    'public.dossier_technique_piece_devis',
+    'public.devis_idempotence'
+  ] LOOP
+    IF to_regclass(target_relation) IS NULL THEN
+      RAISE EXCEPTION 'CERP-AUDIT-002/003 grant preflight refused: relation % is missing', target_relation;
+    END IF;
+  END LOOP;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'CERP-AUDIT-002/003 grant preflight refused: runtime role cerp_app is missing';
+  END IF;
+
+  FOR required_column IN
+    SELECT * FROM (VALUES
+      ('devis', 'root_devis_id'),
+      ('devis', 'parent_devis_id'),
+      ('devis', 'version_number'),
+      ('devis', 'conditions_paiement_id'),
+      ('devis', 'compte_vente_id'),
+      ('devis', 'biller_id'),
+      ('devis_ligne', 'position')
+    ) AS expected(table_name, column_name)
+  LOOP
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = required_column.table_name
+        AND column_name = required_column.column_name
+    ) THEN
+      RAISE EXCEPTION 'CERP-AUDIT-002/003 grant preflight refused: missing %.%',
+        required_column.table_name, required_column.column_name;
+    END IF;
+  END LOOP;
+END
+$guard$;
+
+-- Evidence only: these are expected to be false before this corrective patch.
+SELECT relation,
+       has_table_privilege('cerp_app', relation, 'SELECT') AS can_select,
+       has_table_privilege('cerp_app', relation, 'INSERT') AS can_insert,
+       has_table_privilege('cerp_app', relation, 'DELETE') AS can_delete
+FROM unnest(ARRAY[
+  'public.article_devis',
+  'public.dossier_technique_piece_devis',
+  'public.devis_idempotence'
+]) AS relation;
+
+COMMIT;

--- a/db/patches/support/20260819_devis_preparation_idempotency_grants_002_003.rollback.sql
+++ b/db/patches/support/20260819_devis_preparation_idempotency_grants_002_003.rollback.sql
@@ -1,0 +1,11 @@
+\set ON_ERROR_STOP on
+
+-- No REVOKE is safe here: the pre-migration privilege baseline is not known.
+-- Restore the verified pre-migration backup to return to that exact state.
+DO $rollback$
+BEGIN
+  RAISE EXCEPTION USING
+    MESSAGE = 'CERP-AUDIT-002/003 grant rollback requires restoring the verified pre-migration backup',
+    HINT = 'Do not REVOKE in place: the privileges may predate this corrective patch.';
+END
+$rollback$;

--- a/db/patches/support/20260819_devis_preparation_idempotency_grants_002_003.verify.sql
+++ b/db/patches/support/20260819_devis_preparation_idempotency_grants_002_003.verify.sql
@@ -1,0 +1,30 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $verify$
+BEGIN
+  IF NOT has_table_privilege('cerp_app', 'public.article_devis', 'SELECT')
+     OR NOT has_table_privilege('cerp_app', 'public.article_devis', 'INSERT')
+     OR NOT has_table_privilege('cerp_app', 'public.article_devis', 'DELETE')
+     OR NOT has_table_privilege('cerp_app', 'public.dossier_technique_piece_devis', 'SELECT')
+     OR NOT has_table_privilege('cerp_app', 'public.dossier_technique_piece_devis', 'INSERT')
+     OR NOT has_table_privilege('cerp_app', 'public.dossier_technique_piece_devis', 'DELETE')
+     OR NOT has_table_privilege('cerp_app', 'public.devis_idempotence', 'SELECT')
+     OR NOT has_table_privilege('cerp_app', 'public.devis_idempotence', 'INSERT') THEN
+    RAISE EXCEPTION 'CERP-AUDIT-002/003 grant verification failed for cerp_app';
+  END IF;
+END
+$verify$;
+
+SELECT relation,
+       has_table_privilege('cerp_app', relation, 'SELECT') AS can_select,
+       has_table_privilege('cerp_app', relation, 'INSERT') AS can_insert,
+       has_table_privilege('cerp_app', relation, 'DELETE') AS can_delete
+FROM unnest(ARRAY[
+  'public.article_devis',
+  'public.dossier_technique_piece_devis',
+  'public.devis_idempotence'
+]) AS relation;
+
+COMMIT;

--- a/db/patches/support/20260819_mfa_expired_artifact_cleanup_delete_grant.preflight.sql
+++ b/db/patches/support/20260819_mfa_expired_artifact_cleanup_delete_grant.preflight.sql
@@ -1,0 +1,29 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup grant preflight refused on database %', current_database();
+  END IF;
+  IF to_regclass('public.user_mfa_factors') IS NULL
+     OR to_regclass('public.auth_mfa_challenges') IS NULL THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup grant preflight refused: MFA relations are missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup grant preflight refused: runtime role cerp_app is missing';
+  END IF;
+END
+$guard$;
+
+SELECT current_database() AS database_name,
+       has_table_privilege('cerp_app', 'public.user_mfa_factors', 'DELETE')
+         AS can_delete_expired_pending_factors,
+       count(*) FILTER (WHERE state = 'PENDING' AND pending_expires_at <= now())
+         AS expired_pending_factor_count,
+       now() AS checked_at
+  FROM public.user_mfa_factors;
+
+COMMIT;

--- a/db/patches/support/20260819_mfa_expired_artifact_cleanup_delete_grant.rollback.sql
+++ b/db/patches/support/20260819_mfa_expired_artifact_cleanup_delete_grant.rollback.sql
@@ -1,0 +1,33 @@
+\set ON_ERROR_STOP on
+
+-- This additive grant has a known pre-migration baseline: SOL-32 granted only
+-- SELECT, INSERT and UPDATE on user_mfa_factors. Roll back the matching
+-- application code first; otherwise startup maintenance will fail again.
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod')
+     AND current_database() !~ '^cerp_restore_[a-z0-9_]+$' THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup grant rollback refused on database %', current_database();
+  END IF;
+  IF to_regclass('public.user_mfa_factors') IS NULL THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup grant rollback refused: user_mfa_factors is missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup grant rollback refused: runtime role cerp_app is missing';
+  END IF;
+END
+$guard$;
+
+REVOKE DELETE ON TABLE public.user_mfa_factors FROM cerp_app;
+
+COMMIT;
+
+DO $verify_rollback$
+BEGIN
+  IF has_table_privilege('cerp_app', 'public.user_mfa_factors', 'DELETE') THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup grant rollback verification failed';
+  END IF;
+END
+$verify_rollback$;

--- a/db/patches/support/20260819_mfa_expired_artifact_cleanup_delete_grant.verify.sql
+++ b/db/patches/support/20260819_mfa_expired_artifact_cleanup_delete_grant.verify.sql
@@ -1,0 +1,17 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $verify$
+BEGIN
+  IF NOT has_table_privilege('cerp_app', 'public.user_mfa_factors', 'DELETE') THEN
+    RAISE EXCEPTION 'CERP-REPAIR-00 MFA cleanup verify: cerp_app cannot delete expired pending MFA factors';
+  END IF;
+END
+$verify$;
+
+SELECT has_table_privilege('cerp_app', 'public.user_mfa_factors', 'DELETE')
+         AS can_delete_expired_pending_factors,
+       now() AS verified_at;
+
+COMMIT;

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -88,7 +88,9 @@ if [ "${CERP_SCANNER_SMOKE:-0}" = "1" ]; then
   exit $?
 fi
 
-freshclam --config-file="$FRESHCLAM_CONFIG" --daemon --foreground --stdout &
+# ClamAV 1.4 accepts the cadence only as a CLI option; 12 checks/day keeps the
+# explicit policy without an invalid freshclam.conf directive.
+freshclam --config-file="$FRESHCLAM_CONFIG" --checks=12 --daemon --foreground --stdout &
 freshclam_pid=$!
 
 if [ "$#" -eq 0 ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -99,22 +99,25 @@ fi
 su-exec node "$@" &
 app_pid=$!
 
-# Any critical process exit makes the container restart as a unit; uploads are
-# never silently accepted without the supervised scanner/update processes.
-wait_for_critical_exit() {
-  while :; do
-    for pid in "$app_pid" "$clamd_pid" "$freshclam_pid"; do
-      if ! process_is_running "$pid"; then
-        if wait "$pid"; then status=0; else status=$?; fi
-        # A clean exit is still unexpected for a supervised long-running
-        # process; force a restart-policy-visible failure.
-        if [ "$status" -eq 0 ]; then status=1; fi
-        return "$status"
-      fi
-    done
-    sleep 0.1
-  done
-}
+# The API is the container lifecycle process. A scanner/update failure must not
+# make the whole ERP disappear: readiness becomes degraded and every new GED
+# upload fails closed into quarantine until the orchestrator/operator restores
+# ClamAV. Log and reap those children once, while keeping the API available.
+clamd_exit_reported=0
+freshclam_exit_reported=0
+while process_is_running "$app_pid"; do
+  if [ "$clamd_exit_reported" -eq 0 ] && ! process_is_running "$clamd_pid"; then
+    if wait "$clamd_pid"; then scanner_status=0; else scanner_status=$?; fi
+    echo "[upload_scan] clamd unavailable status=$scanner_status; API remains fail-closed" >&2
+    clamd_exit_reported=1
+  fi
+  if [ "$freshclam_exit_reported" -eq 0 ] && ! process_is_running "$freshclam_pid"; then
+    if wait "$freshclam_pid"; then updater_status=0; else updater_status=$?; fi
+    echo "[upload_scan] freshclam unavailable status=$updater_status; signature freshness is degraded" >&2
+    freshclam_exit_reported=1
+  fi
+  sleep 0.1
+done
 
-if wait_for_critical_exit; then status=0; else status=$?; fi
+if wait "$app_pid"; then status=0; else status=$?; fi
 exit "$status"

--- a/docker/freshclam.conf
+++ b/docker/freshclam.conf
@@ -1,7 +1,10 @@
 DatabaseDirectory /var/lib/clamav
 DatabaseOwner clamav
 DatabaseMirror database.clamav.net
-ScriptedUpdates yes
-Checks 12
+# `ScriptedUpdates` was removed from ClamAV 1.4. Official signed databases
+# remain enabled by default; keeping the retired directive prevents freshclam
+# from parsing the configuration at all.
+# In 1.4 the cadence is a command-line-only daemon option (`--checks`); the
+# configuration parser rejects it.
 PidFile /run/clamav/freshclam.pid
 NotifyClamd /etc/clamav/clamd.conf

--- a/docs/execution-reports/CERP_REPAIR_CODX-E2E-2026-08-19-181940.md
+++ b/docs/execution-reports/CERP_REPAIR_CODX-E2E-2026-08-19-181940.md
@@ -1,72 +1,149 @@
 # CERP-REPAIR-00 — Rapport d'exécution backend
 
-- Date de départ : 2026-08-19
-- Audit source : `CODX-E2E-2026-08-19-181940`
-- Issue : https://github.com/BigFootLime/erp-crp-backend/issues/607
-- Branche : `fix/607-e2e-audit-repair`
-- Base : `origin/dev` à `cbcd10c004dd2f9535249d7da641da00f4b1b0ef`
-- Production écrite : **NON**
+- Date : 2026-08-19
+- Audit de départ : `CODX-E2E-2026-08-19-181940`
+- Issue : [#607](https://github.com/BigFootLime/erp-crp-backend/issues/607)
+- Branche dédiée : `fix/607-e2e-audit-repair`
+- Base de travail : `origin/dev` à `cbcd10c004dd2f9535249d7da641da00f4b1b0ef`
+- Périmètre DB : PostgreSQL jetable isolé uniquement ; **aucune écriture dans `cerp_test` partagé ou `cerp_prod`**.
+- Statut de release : **FINAL_FULL_E2E_PENDING**. Ce document n'est pas une autorisation de promotion `dev → main` ni de déploiement.
 
-## Registre provisoire des anomalies
+## Verdict intermédiaire
 
-| ID | Domaine | État actuel |
-|---|---|---|
-| 001 | GED / antivirus | DIAGNOSTIQUÉ — scanner CERP_TEST indisponible ; réparation opérationnelle à prouver |
-| 002 | Création devis | DIAGNOSTIC EN COURS — transaction/schema réel à reproduire |
-| 003 | Référentiels devis | DIAGNOSTIQUÉ — routes backend absentes |
-| 004 | Combobox métier | À REPRODUIRE |
-| 005 | Familles machine | DÉCISION MÉTIER REQUISE — aucune valeur ne sera inventée |
-| 006 | Complétude pièces | DIAGNOSTIQUÉ — données métier manquantes |
-| 007 | Double indice A | DIAGNOSTIQUÉ — double commande frontend, pas une contrainte DB manquante |
-| 008–011 | Planning / durée / dates / machine | DIAGNOSTIQUÉS — corrections et preuves à réaliser |
-| 012 | OF clôturé sans stock | CORRIGÉ EN CODE — preuve E2E PostgreSQL à réaliser |
-| 013 | Boucle d'erreurs réception | CORRIGÉ côté client |
-| 014 | Référentiels Qualité/Outillage | DÉCISION MÉTIER REQUISE — valeurs réelles non inventées |
-| 015 | Route planning | À CORRIGER |
-| 016 | Responsive | À REPRODUIRE APRÈS LES VAGUES MÉTIER |
+Les anomalies reproductibles de la campagne ont reçu une correction ciblée et une preuve ciblée réelle : clôture OF/réception, création de devis sous le rôle runtime, compatibilité machine/famille, durée de gamme, GED/ClamAV, sélecteurs de formulaires et idempotence. Les corrections sont commitées, sans secret et sans modification de données métier partagées.
 
-## Vague A — réception et clôture OF
+Le verdict final reste volontairement en attente du runner E2E global propre : le périmètre comprend tous les scénarios, les migrations, le navigateur et les artefacts d'échec. Aucun scénario nominal ne doit être déclaré vert avant ce passage complet.
 
-### Cause racine
+## Registre avant / après
 
-`repoGetOfReceiptContext` référençait `magasins.code_magasin` et
-`magasins.libelle` dans un `COALESCE`. PostgreSQL résout tous les identifiants :
-ces colonnes absentes provoquaient `42703`, donc le 500 observé. Par ailleurs,
-la transition `TERMINE → CLOTURE` ne vérifiait ni `of_receipts`, ni lot de
-sortie, ni mouvement stock publié.
+| Audit | Cause racine démontrée | Correction livrée | Preuve ciblée | État |
+|---|---|---|---|---|
+| 001 GED/antivirus | Le scanner/ses signatures pouvaient être indisponibles ; la mort de `clamd` arrêtait auparavant l'API et masquait la quarantaine. | Démarrage ClamAV avec signatures rafraîchies, API maintenue en service dégradé, upload fail-closed, détails publics strictement limités à l'identifiant/état de quarantaine. | GED sain `2/2`, panne scanner `1/1`, 47 tests GED/sécurité, contrat Docker `12/12`. | Corrigé, campagne globale en attente. |
+| 002 création devis | `cerp_app` n'avait pas les droits réels sur les relations de préparation/idempotence ; les tests mockés ne révélaient pas ce défaut. | Patch de droits minimaux, préflight/verify/rollback, refus sans clé idempotente avant écriture et erreurs métier. | PostgreSQL runtime : devis minimal/complet, retry même ID, pas de ligne partielle ; E2E Devis `2/2`. | Corrigé, campagne globale en attente. |
+| 003 référentiels commerciaux | Les routes historiques n'étaient pas montées ; il n'existait pas de référentiel gouverné à inventer. | Routes authentifiées/RBAC, réponse explicite `NOT_CONFIGURED` avec fiabilité `UNAVAILABLE`. | Tests routes/référentiels et contrat OpenAPI ciblés. | Corrigé, campagne globale en attente. |
+| 004 formulaires/combobox | Les chemins clavier/souris pouvaient diverger de la valeur réellement envoyée. | Alignement avec les contrats API et tests réels de persistance. | E2E réel `3/3` : client, fournisseur, article, machine/poste ; reload après sauvegarde. | Corrigé côté backend/intégration, campagne globale en attente. |
+| 005 familles machine | L'éditeur refusait une machine non qualifiée mais l'auto-planificateur pouvait aller plus loin. | Invariant serveur commun : refus explicite `RESOURCE_NOT_QUALIFIED`, action de remédiation `/methodes/parc-machines`, aucune qualification inventée. | E2E réel `1/1` avec machine sans famille et tentative directe 422. | Corrigé ; données réelles à renseigner. |
+| 006 complétude pièces | Données métier obligatoires absentes : ne pas les fabriquer. | Gates et parcours de remédiation ; création de la première révision rendue idempotente. | E2E pièce technique `1/1`. | Correction technique ; complétude réelle opérateur requise. |
+| 007 doublon indice A | Création initiale déclenchée deux fois, non absence d'une règle DB à contourner. | Une seule création de révision initiale, tests de non-duplication. | E2E pièce technique `1/1` et tests ciblés. | Corrigé, campagne globale en attente. |
+| 008–011 planning | Durée calculée/localement réinterprétée ; qualification, affectation et calendrier pouvaient diverger. | Durée canonique `réglage + quantité × temps unitaire`; validation de qualification dans toutes les écritures planning ; propagation de l'affectation/date depuis la source serveur. | Cas de référence `30 + 2 × 12 = 54 min`; groupe planning/méthodes `11/11`; clavier répété `30/30`. | Corrigé, campagne globale en attente. |
+| 012 OF clôturé sans stock | `receipt-context` utilisait des colonnes magasins inexistantes (`42703`) et la clôture ne vérifiait pas les preuves de réception. | Transaction verrouillée, réception explicite/idempotente, clôture bloquée avec `409 OF_RECEIPT_INCOMPLETE` jusqu'à lot + mouvement `POSTED`. | Parcours production isolé : blocage, réception `201`, retry `200`, clôture `200`. | Corrigé, campagne globale en attente. |
+| 013 boucle de réception | L'interface relançait durablement une erreur de contexte. | Contrat backend d'exception exploitable ; frontend corrigé dans le dépôt associé (pas de retry automatique durable). | Parcours OF/réception réel ci-dessus. | Corrigé inter-dépôts, campagne globale en attente. |
+| 014 prérequis Qualité/Outillage | Référentiels et paramètres opérationnels réels manquants. | Gates, messages et liens de remédiation, sans zéro ou valeur synthétique. | Contrôles de préparation et parcours de remédiation ciblés. | Décision/données opérateur requises. |
+| 015 route planning | Route historique non canonique. | Contrat backend/planning et redirection frontend associée vers `/production/planning`. | E2E responsive/planning réel `2/2`. | Corrigé inter-dépôts, campagne globale en attente. |
+| 016 responsive | Risque de commandes inaccessibles selon largeur. | Backend : données et erreurs actionnables préservées ; validation frontend dédiée. | 375/430/538/768/1024/1440, responsive planning `2/2`. | Corrigé inter-dépôts, campagne globale en attente. |
 
-### Correction et invariant
+## Diagnostic et architecture retenue
 
-- lecture des seules colonnes canoniques `magasins.code` et `magasins.name` ;
-- OF verrouillé avant transition ;
-- clôture autorisée seulement si la quantité bonne déclarée est couverte par
-  le registre immuable, un lot de sortie et un mouvement d'entrée `POSTED` ;
-- refus `409 OF_RECEIPT_INCOMPLETE` avec quantités et compteur de preuves
-  invalides ;
-- la réception reste une commande explicite et idempotente car emplacement et
-  qualité ne peuvent pas être déduits sans décision utilisateur.
+### Réception et clôture d'OF
 
-### Fichiers backend
+Le contexte de réception échouait parce que la requête citait `magasins.code_magasin` et `magasins.libelle`, colonnes absentes du schéma courant. PostgreSQL résout toutes les références d'un `COALESCE` : le résultat était donc `42703`, exposé en 500. La transition `TERMINE → CLOTURE` ne liait pas suffisamment la production déclarée à la réception stock.
 
-- `src/module/production/repository/production-receipts.repository.ts`
-- `src/module/production/repository/production.repository.ts`
-- `src/__tests__/production-of-170.routes.test.ts`
+La clôture repose maintenant sur des preuves persistées : quantité bonne couverte par un reçu immuable, lot de sortie et mouvement d'entrée `POSTED`. La ressource OF est verrouillée pendant la transition. La réception est intentionnellement une commande séparée — emplacement et décision qualité ne sont pas déductibles — mais idempotente. Le résultat incomplet est explicite (`409 OF_RECEIPT_INCOMPLETE`), jamais un OF « clôturé » avec stock manquant.
 
-### Contrôles exécutés
+### Devis, permissions et idempotence
 
-| Commande | Résultat |
+Le correctif n'élargit pas les droits par confort. Le rôle `cerp_app` reçoit uniquement `SELECT/INSERT/DELETE` sur les lignes de préparation nécessaires et `SELECT/INSERT` sur le journal d'idempotence. Les lectures concurrentes sont sérialisées par verrou consultatif transactionnel, plutôt que `FOR SHARE`, afin de conserver un registre append-only et de ne pas requérir `UPDATE`.
+
+Les routes de conditions de paiement et compte de vente ne prétendent plus fournir des données qui n'existent pas : elles indiquent `NOT_CONFIGURED`, avec source/période absentes et fiabilité `UNAVAILABLE`.
+
+Le même principe append-only a été appliqué au registre de commandes achats et au portail client. Pour le portail, seule la transition réellement nécessaire de tentative d'authentification réussie reçoit `UPDATE`; le retry des commandes reste sérialisé par verrou consultatif sans mutation du reçu.
+
+### Planning
+
+La durée planifiée est une donnée serveur unique : `temps de réglage + quantité × temps unitaire`, donc 54 minutes pour le cas de référence. Auto-planification, déplacement manuel et validation interrogent le même invariant machine/famille. Une machine sans famille produit une erreur métier et une action de correction ; l'ERP ne déduit aucune famille machine réelle.
+
+### GED et ClamAV
+
+Les documents restent en quarantaine tant qu'un verdict propre n'est pas acquis. Un scanner indisponible ne publie aucun fichier : l'upload échoue de manière explicite, conserve l'état `scan_failed`/`quarantined` et n'expose ni contenu, ni chemin, ni sortie du scanner. L'API reste disponible, mais la readiness devient dégradée. Seuls un UUID de quarantaine valide et l'état `quarantined` peuvent être retournés dans ce cas, via une allowlist dédiée des détails 5xx.
+
+L'image actualise les signatures au démarrage puis les maintient avec `freshclam`; elle conserve l'API comme processus de cycle de vie. La sortie de `clamd` est journalisée et reaped sans faire disparaître l'ERP, tandis que les nouveaux uploads continuent d'échouer fermement.
+
+## Commits backend
+
+| Commit | Objet |
 |---|---|
-| `npm run test:run -- src/__tests__/production-of-170.routes.test.ts src/module/production/repository/production-receipts.repository.test.ts` | PASS — 2 fichiers, 39 tests |
-| `npm run typecheck` | PASS |
-| `npm run build` | PASS — OpenAPI 1 077 opérations, contrat et frontière production validés |
+| `bf19e54` | Blocage de clôture OF sans réception complète. |
+| `cb51e26` | Qualification machine et durée/capacité planning. |
+| `599ffbe` | Préparation Devis et idempotence. |
+| `c723806` | Refresh des signatures ClamAV. |
+| `5f98ae1` | Stack E2E Docker réellement isolée. |
+| `d26936a` | Erreur GED de quarantaine actionnable, sans fuite. |
+| `d5a1e50` | Idempotence commerciale append-only. |
+| `d5beab3` | Remédiation qualification planning conservée. |
+| `f724e37` | Idempotence achats append-only. |
+| `f5dfa69` | Fixtures séparées machine qualifiée/non qualifiée. |
+| `1387bd7` | API disponible et fail-closed durant panne scanner. |
+| `b59089a` | Idempotence portail client append-only. |
+| `1e6722f` | Droit portail minimal pour marquer la tentative réussie. |
+| `3fdabdd` | Rollback explicite du patch de droit portail. |
 
-PostgreSQL réel, concurrence multi-session, build/image, navigateur et E2E
-complet : **NOT TESTED à ce stade**. Ils restent obligatoires avant le verdict
-final.
+## Fichiers backend principaux
 
-## Migration et rollback provisoire
+- Production : `src/module/production/repository/production.repository.ts`, `src/module/production/repository/production-receipts.repository.ts`, `src/module/production/domain/planned-operation-duration.ts`.
+- Planning : `src/module/planning/repository/planning.repository.ts`, `src/module/planning/services/planning.service.ts`, `src/module/planning/types/planning.types.ts`.
+- Commercial : `src/module/devis/repository/devis.repository.ts`, `src/module/commercial-references/**`, `src/module/commercial-reliability/repository/commercial-reliability.repository.ts`.
+- Achats / portail : `src/module/procurement-reliability/repository/procurement-reliability.repository.ts`, `src/module/client-portal/repository/client-portal.repository.ts`.
+- GED : `src/shared/uploads/upload-scanner.ts`, `src/module/ged/services/ged.service.ts`, `src/middlewares/errorHandler.ts`, `docker/entrypoint.sh`, `docker/freshclam.conf`.
+- Exécution : `src/config/e2e-isolation.ts`, `scripts/e2e/seed-isolated.js`, `scripts/migrations/release-gate.js`, `scripts/db-patches.js`.
 
-Aucune migration ni donnée n'est modifiée par la vague A. Le rollback consiste
-à revert le commit backend correspondant. Après rollback, un OF déjà `TERMINE`
-pourrait à nouveau être clôturé sans réception ; les écritures stock existantes
-ne doivent jamais être supprimées.
+## Migrations, preflight, vérification et retour arrière
+
+| Patch | Effet | Préflight / vérification | Rollback réaliste |
+|---|---|---|---|
+| `db/patches/20260819_devis_preparation_idempotency_grants_002_003.sql` | Droits minimaux Devis pour `cerp_app`. | DB autorisée, rôle, relations/colonnes ; `has_table_privilege` après application. | Restaurer la sauvegarde pré-migration vérifiée : un `REVOKE` aveugle pourrait supprimer un droit légitime préexistant. |
+| `db/patches/20260819_client_portal_auth_attempt_update_grant_004.sql` | `UPDATE` minimal de `client_portal_auth_attempts` afin de marquer une tentative authentifiée comme réussie. | DB autorisée, rôle, relation ; vérification précise du droit `UPDATE`. | Restaurer la sauvegarde pré-migration vérifiée, après revert code correspondant ; pas de `REVOKE` destructeur. |
+
+Les scripts de support sont sous `db/patches/support/` (`*.preflight.sql`, `*.verify.sql`, `*.rollback.sql`). Les patches refusent une base autre que `cerp_test`, `cerp_prod` ou une restauration isolée nommée `cerp_restore_*`; le runner de cette campagne a utilisé uniquement un environnement jetable. Avant toute application partagée : sauvegarde vérifiée, preflight en lecture seule, application, verify, smoke fonctionnel, et conservation de la sauvegarde jusqu'à validation.
+
+## Tests et preuves réellement exécutés
+
+| Portée | Commande/scénario | Résultat observé |
+|---|---|---|
+| Backend ciblé OF | `npm run test:run -- src/__tests__/production-of-170.routes.test.ts src/module/production/repository/production-receipts.repository.test.ts` | PASS — 2 fichiers, 39 tests. |
+| GED et sécurité | Tests GED/sécurité ciblés | PASS — 47/47. |
+| Contrat image scanner | Tests contrat Docker upload scanner | PASS — 12/12. |
+| Devis/référentiels/migration | Tests Devis, références commerciales et garde migration | PASS — 3 fichiers, 24 tests. |
+| Planning | Groupe planning/méthodes | PASS — 11/11. |
+| Clavier planning | 10 répétitions ciblées | PASS — 30/30. |
+| TypeScript/build backend | `npm run typecheck`, `npm run build` | PASS sur les vagues ; build génère OpenAPI, frontières et image. |
+| Migration isolée | Répétition PostgreSQL tmpfs sur `127.0.0.1:55489/cerp_test` | PASS — 167 patches, rejeu 0, intégrité et restauration vérifiées. |
+| Least privilege runtime | `SET LOCAL ROLE cerp_app` | Devis : privilèges exacts ; achats : `SELECT/INSERT` autorisés, `UPDATE` refusé ; verrou consultatif + lecture sans `FOR SHARE` réussis. |
+| Devis E2E isolé | Minimal, complet, retry/idempotence | PASS — 2/2. |
+| Production E2E isolé | Déclaration, blocage clôture, réception, retry, clôture | PASS. |
+| Achats E2E isolé | Réception nominale + partielle/anomalie + retry | PASS — 2/2. |
+| Qualification planning E2E isolé | Machine sans famille, autoplan, tentative directe | PASS — 1/1. |
+| Formulaires E2E isolé | Client/fournisseur/article/machine-poste, clavier/souris et reload | PASS — 3/3. |
+| GED saine E2E isolée | Fichiers propres et publication après verdict | PASS — 2/2. |
+| Panne scanner E2E isolée | Arrêt `clamd`, readiness dégradée, upload 503, quarantaine, aucun téléchargement | PASS — 1/1. |
+| Responsive navigateur | 375, 430, 538, 768, 1024, 1440 px ; route et actions planning | PASS — 2/2. |
+
+Les données de preuve sont préfixées par le runner isolé et vivent dans ses volumes/DB éphémères. Elles ne sont pas des données de production.
+
+## Sécurité, compatibilité et limites
+
+- Aucune autorisation n'est contournée : JWT/RBAC existants restent appliqués et les nouvelles routes commerciales sont authentifiées.
+- Aucun secret, URL de production, contenu de document, token ou PII n'est placé dans ce rapport, les logs publics ou les réponses d'erreur.
+- Le mode scanner est `enforce` hors tests ; une configuration invalide ou un scanner absent ne permet pas de publication de GED.
+- Les changements de privilèges sont additifs, minimaux et validables. Ils exigent une sauvegarde avant application sur une base partagée.
+- Les données métier réelles ne sont pas inventées : familles machine, calendriers de production, centres de coûts/taux horaires, structures et référentiels Qualité/Outillage doivent être renseignés par les rôles responsables via les gates fournis.
+- Le build peut signaler des seuils de bundle frontend : ce n'est pas un échec backend, mais le contrôle de release global doit le juger selon son seuil configuré.
+
+## Procédure de rollback
+
+1. Stopper la promotion et conserver les logs/artefacts corrélés au SHA de l'image.
+2. Revenir au commit applicatif immédiatement antérieur à la vague concernée, reconstruire l'image puis exécuter les tests ciblés et le smoke de santé.
+3. Pour les patches de droits, **ne pas exécuter de `REVOKE` en place** : restaurer la sauvegarde pré-migration vérifiée dans un environnement isolé, vérifier le portail/Devis, puis appliquer le runbook de promotion validé.
+4. Pour GED/ClamAV, restaurer le service scanner et ses signatures, contrôler `/health/ready`, puis tester un fichier propre et EICAR dans l'environnement isolé avant de rouvrir les uploads.
+5. Rejouer le scénario métier affecté puis la campagne E2E complète avant toute nouvelle promotion.
+
+## Éléments restant réellement à faire
+
+1. Attendre et consigner le résultat du **runner E2E complet propre** ; tout échec doit être reproduit, corrigé et relancé sans assouplir les assertions métier.
+2. Exécuter les gates globaux finaux backend/frontend (collection complète, build, audit, release gate) sur les SHA finaux.
+3. Produire les artefacts horodatés et l'empreinte du run global, puis comparer le nouveau registre à l'audit initial.
+4. Avant `cerp_test` partagé : obtenir l'autorisation de migration, réaliser sauvegarde/preflight/verify/rollback documenté. `cerp_prod` reste hors périmètre de cette campagne.
+5. Les responsables métier doivent renseigner les référentiels signalés par les gates (notamment familles machines, calendriers et coûts) ; aucune valeur ne doit être fabriquée pour obtenir un faux vert.
+
+## GO / NO-GO
+
+**NO-GO temporaire** pour promotion et déploiement : `FINAL_FULL_E2E_PENDING`. Les preuves ciblées sont favorables, mais la sortie CERP-REPAIR-00 exige encore le run E2E global, les gates complets et l'inventaire final d'artefacts. Aucune promotion `main`, aucun push et aucune écriture `cerp_prod` ne sont présentés comme effectués.

--- a/docs/execution-reports/CERP_REPAIR_CODX-E2E-2026-08-19-181940.md
+++ b/docs/execution-reports/CERP_REPAIR_CODX-E2E-2026-08-19-181940.md
@@ -1,0 +1,72 @@
+# CERP-REPAIR-00 — Rapport d'exécution backend
+
+- Date de départ : 2026-08-19
+- Audit source : `CODX-E2E-2026-08-19-181940`
+- Issue : https://github.com/BigFootLime/erp-crp-backend/issues/607
+- Branche : `fix/607-e2e-audit-repair`
+- Base : `origin/dev` à `cbcd10c004dd2f9535249d7da641da00f4b1b0ef`
+- Production écrite : **NON**
+
+## Registre provisoire des anomalies
+
+| ID | Domaine | État actuel |
+|---|---|---|
+| 001 | GED / antivirus | DIAGNOSTIQUÉ — scanner CERP_TEST indisponible ; réparation opérationnelle à prouver |
+| 002 | Création devis | DIAGNOSTIC EN COURS — transaction/schema réel à reproduire |
+| 003 | Référentiels devis | DIAGNOSTIQUÉ — routes backend absentes |
+| 004 | Combobox métier | À REPRODUIRE |
+| 005 | Familles machine | DÉCISION MÉTIER REQUISE — aucune valeur ne sera inventée |
+| 006 | Complétude pièces | DIAGNOSTIQUÉ — données métier manquantes |
+| 007 | Double indice A | DIAGNOSTIQUÉ — double commande frontend, pas une contrainte DB manquante |
+| 008–011 | Planning / durée / dates / machine | DIAGNOSTIQUÉS — corrections et preuves à réaliser |
+| 012 | OF clôturé sans stock | CORRIGÉ EN CODE — preuve E2E PostgreSQL à réaliser |
+| 013 | Boucle d'erreurs réception | CORRIGÉ côté client |
+| 014 | Référentiels Qualité/Outillage | DÉCISION MÉTIER REQUISE — valeurs réelles non inventées |
+| 015 | Route planning | À CORRIGER |
+| 016 | Responsive | À REPRODUIRE APRÈS LES VAGUES MÉTIER |
+
+## Vague A — réception et clôture OF
+
+### Cause racine
+
+`repoGetOfReceiptContext` référençait `magasins.code_magasin` et
+`magasins.libelle` dans un `COALESCE`. PostgreSQL résout tous les identifiants :
+ces colonnes absentes provoquaient `42703`, donc le 500 observé. Par ailleurs,
+la transition `TERMINE → CLOTURE` ne vérifiait ni `of_receipts`, ni lot de
+sortie, ni mouvement stock publié.
+
+### Correction et invariant
+
+- lecture des seules colonnes canoniques `magasins.code` et `magasins.name` ;
+- OF verrouillé avant transition ;
+- clôture autorisée seulement si la quantité bonne déclarée est couverte par
+  le registre immuable, un lot de sortie et un mouvement d'entrée `POSTED` ;
+- refus `409 OF_RECEIPT_INCOMPLETE` avec quantités et compteur de preuves
+  invalides ;
+- la réception reste une commande explicite et idempotente car emplacement et
+  qualité ne peuvent pas être déduits sans décision utilisateur.
+
+### Fichiers backend
+
+- `src/module/production/repository/production-receipts.repository.ts`
+- `src/module/production/repository/production.repository.ts`
+- `src/__tests__/production-of-170.routes.test.ts`
+
+### Contrôles exécutés
+
+| Commande | Résultat |
+|---|---|
+| `npm run test:run -- src/__tests__/production-of-170.routes.test.ts src/module/production/repository/production-receipts.repository.test.ts` | PASS — 2 fichiers, 39 tests |
+| `npm run typecheck` | PASS |
+| `npm run build` | PASS — OpenAPI 1 077 opérations, contrat et frontière production validés |
+
+PostgreSQL réel, concurrence multi-session, build/image, navigateur et E2E
+complet : **NOT TESTED à ce stade**. Ils restent obligatoires avant le verdict
+final.
+
+## Migration et rollback provisoire
+
+Aucune migration ni donnée n'est modifiée par la vague A. Le rollback consiste
+à revert le commit backend correspondant. Après rollback, un OF déjà `TERMINE`
+pourrait à nouveau être clôturé sans réception ; les écritures stock existantes
+ne doivent jamais être supprimées.

--- a/docs/execution-reports/CERP_REPAIR_CODX-E2E-2026-08-19-181940.md
+++ b/docs/execution-reports/CERP_REPAIR_CODX-E2E-2026-08-19-181940.md
@@ -6,31 +6,33 @@
 - Branche dédiée : `fix/607-e2e-audit-repair`
 - Base de travail : `origin/dev` à `cbcd10c004dd2f9535249d7da641da00f4b1b0ef`
 - Périmètre DB : PostgreSQL jetable isolé uniquement ; **aucune écriture dans `cerp_test` partagé ou `cerp_prod`**.
-- Statut de release : **FINAL_FULL_E2E_PENDING**. Ce document n'est pas une autorisation de promotion `dev → main` ni de déploiement.
+- Gate final candidat : **PASS** le 2026-08-19, release `20260819T224909Z-candidate-f00cd579-1f35a533`.
+- SHA validés : frontend `f00cd579aec82275b6327aebac9937ccc1dca17d`, backend `1f35a5334d28eeea5cd18fb1609c83111023b49b`.
+- Statut de release : **GO candidat uniquement**. Ce document n'est pas une autorisation de promotion `dev → main`, de déploiement, ni d'écriture dans une base partagée.
 
-## Verdict intermédiaire
+## Verdict final
 
-Les anomalies reproductibles de la campagne ont reçu une correction ciblée et une preuve ciblée réelle : clôture OF/réception, création de devis sous le rôle runtime, compatibilité machine/famille, durée de gamme, GED/ClamAV, sélecteurs de formulaires et idempotence. Les corrections sont commitées, sans secret et sans modification de données métier partagées.
+Les anomalies reproductibles de la campagne ont reçu une correction ciblée et une preuve globale réelle : clôture OF/réception, création de devis sous le rôle runtime, compatibilité machine/famille, durée de gamme, GED/ClamAV, sélecteurs de formulaires et idempotence. Les corrections sont commitées, sans secret et sans modification de données métier partagées.
 
-Le verdict final reste volontairement en attente du runner E2E global propre : le périmètre comprend tous les scénarios, les migrations, le navigateur et les artefacts d'échec. Aucun scénario nominal ne doit être déclaré vert avant ce passage complet.
+Le gate global propre a validé les deux SHA ci-dessus : 2 595 tests frontend, 4 848 tests backend (8 ignorés), 154 scénarios Playwright passés (4 ignorés, 0 inattendu), migration/rejeu/restauration isolés et intégrité des artefacts. Le verdict est donc **GO pour revue et promotion contrôlée vers `dev`**, jamais une promotion automatique vers `main` ou la production.
 
 ## Registre avant / après
 
 | Audit | Cause racine démontrée | Correction livrée | Preuve ciblée | État |
 |---|---|---|---|---|
-| 001 GED/antivirus | Le scanner/ses signatures pouvaient être indisponibles ; la mort de `clamd` arrêtait auparavant l'API et masquait la quarantaine. | Démarrage ClamAV avec signatures rafraîchies, API maintenue en service dégradé, upload fail-closed, détails publics strictement limités à l'identifiant/état de quarantaine. | GED sain `2/2`, panne scanner `1/1`, 47 tests GED/sécurité, contrat Docker `12/12`. | Corrigé, campagne globale en attente. |
-| 002 création devis | `cerp_app` n'avait pas les droits réels sur les relations de préparation/idempotence ; les tests mockés ne révélaient pas ce défaut. | Patch de droits minimaux, préflight/verify/rollback, refus sans clé idempotente avant écriture et erreurs métier. | PostgreSQL runtime : devis minimal/complet, retry même ID, pas de ligne partielle ; E2E Devis `2/2`. | Corrigé, campagne globale en attente. |
-| 003 référentiels commerciaux | Les routes historiques n'étaient pas montées ; il n'existait pas de référentiel gouverné à inventer. | Routes authentifiées/RBAC, réponse explicite `NOT_CONFIGURED` avec fiabilité `UNAVAILABLE`. | Tests routes/référentiels et contrat OpenAPI ciblés. | Corrigé, campagne globale en attente. |
-| 004 formulaires/combobox | Les chemins clavier/souris pouvaient diverger de la valeur réellement envoyée. | Alignement avec les contrats API et tests réels de persistance. | E2E réel `3/3` : client, fournisseur, article, machine/poste ; reload après sauvegarde. | Corrigé côté backend/intégration, campagne globale en attente. |
+| 001 GED/antivirus | Le scanner/ses signatures pouvaient être indisponibles ; la mort de `clamd` arrêtait auparavant l'API et masquait la quarantaine. | Démarrage ClamAV avec signatures rafraîchies, API maintenue en service dégradé, upload fail-closed, détails publics strictement limités à l'identifiant/état de quarantaine. | GED sain `2/2`, panne scanner `1/1`, 47 tests GED/sécurité, contrat Docker `12/12`, gate global vert. | Corrigé et validé. |
+| 002 création devis | `cerp_app` n'avait pas les droits réels sur les relations de préparation/idempotence ; les tests mockés ne révélaient pas ce défaut. | Patch de droits minimaux, préflight/verify/rollback, refus sans clé idempotente avant écriture et erreurs métier. | PostgreSQL runtime : devis minimal/complet, retry même ID, pas de ligne partielle ; E2E Devis `2/2`, gate global vert. | Corrigé et validé. |
+| 003 référentiels commerciaux | Les routes historiques n'étaient pas montées ; il n'existait pas de référentiel gouverné à inventer. | Routes authentifiées/RBAC, réponse explicite `NOT_CONFIGURED` avec fiabilité `UNAVAILABLE`. | Tests routes/référentiels, contrat OpenAPI ciblé et gate global vert. | Corrigé et validé. |
+| 004 formulaires/combobox | Les chemins clavier/souris pouvaient diverger de la valeur réellement envoyée. | Alignement avec les contrats API et tests réels de persistance. | E2E réel `3/3` : client, fournisseur, article, machine/poste ; reload après sauvegarde et gate global vert. | Corrigé côté backend/intégration. |
 | 005 familles machine | L'éditeur refusait une machine non qualifiée mais l'auto-planificateur pouvait aller plus loin. | Invariant serveur commun : refus explicite `RESOURCE_NOT_QUALIFIED`, action de remédiation `/methodes/parc-machines`, aucune qualification inventée. | E2E réel `1/1` avec machine sans famille et tentative directe 422. | Corrigé ; données réelles à renseigner. |
 | 006 complétude pièces | Données métier obligatoires absentes : ne pas les fabriquer. | Gates et parcours de remédiation ; création de la première révision rendue idempotente. | E2E pièce technique `1/1`. | Correction technique ; complétude réelle opérateur requise. |
-| 007 doublon indice A | Création initiale déclenchée deux fois, non absence d'une règle DB à contourner. | Une seule création de révision initiale, tests de non-duplication. | E2E pièce technique `1/1` et tests ciblés. | Corrigé, campagne globale en attente. |
-| 008–011 planning | Durée calculée/localement réinterprétée ; qualification, affectation et calendrier pouvaient diverger. | Durée canonique `réglage + quantité × temps unitaire`; validation de qualification dans toutes les écritures planning ; propagation de l'affectation/date depuis la source serveur. | Cas de référence `30 + 2 × 12 = 54 min`; groupe planning/méthodes `11/11`; clavier répété `30/30`. | Corrigé, campagne globale en attente. |
-| 012 OF clôturé sans stock | `receipt-context` utilisait des colonnes magasins inexistantes (`42703`) et la clôture ne vérifiait pas les preuves de réception. | Transaction verrouillée, réception explicite/idempotente, clôture bloquée avec `409 OF_RECEIPT_INCOMPLETE` jusqu'à lot + mouvement `POSTED`. | Parcours production isolé : blocage, réception `201`, retry `200`, clôture `200`. | Corrigé, campagne globale en attente. |
-| 013 boucle de réception | L'interface relançait durablement une erreur de contexte. | Contrat backend d'exception exploitable ; frontend corrigé dans le dépôt associé (pas de retry automatique durable). | Parcours OF/réception réel ci-dessus. | Corrigé inter-dépôts, campagne globale en attente. |
+| 007 doublon indice A | Création initiale déclenchée deux fois, non absence d'une règle DB à contourner. | Une seule création de révision initiale, tests de non-duplication. | E2E pièce technique `1/1`, puis gate global vert. | Corrigé et validé. |
+| 008–011 planning | Durée calculée/localement réinterprétée ; qualification, affectation et calendrier pouvaient diverger. | Durée canonique `réglage + quantité × temps unitaire`; validation de qualification dans toutes les écritures planning ; propagation de l'affectation/date depuis la source serveur. | Cas de référence `30 + 2 × 12 = 54 min`; groupe planning/méthodes `11/11`; clavier répété `30/30`, puis gate global vert. | Corrigé et validé. |
+| 012 OF clôturé sans stock | `receipt-context` utilisait des colonnes magasins inexistantes (`42703`) et la clôture ne vérifiait pas les preuves de réception. | Transaction verrouillée, réception explicite/idempotente, clôture bloquée avec `409 OF_RECEIPT_INCOMPLETE` jusqu'à lot + mouvement `POSTED`. | Parcours production isolé : blocage, réception `201`, retry `200`, clôture `200`, puis gate global vert. | Corrigé et validé. |
+| 013 boucle de réception | L'interface relançait durablement une erreur de contexte. | Contrat backend d'exception exploitable ; frontend corrigé dans le dépôt associé (pas de retry automatique durable). | Parcours OF/réception réel et gate global vert. | Corrigé inter-dépôts. |
 | 014 prérequis Qualité/Outillage | Référentiels et paramètres opérationnels réels manquants. | Gates, messages et liens de remédiation, sans zéro ou valeur synthétique. | Contrôles de préparation et parcours de remédiation ciblés. | Décision/données opérateur requises. |
-| 015 route planning | Route historique non canonique. | Contrat backend/planning et redirection frontend associée vers `/production/planning`. | E2E responsive/planning réel `2/2`. | Corrigé inter-dépôts, campagne globale en attente. |
-| 016 responsive | Risque de commandes inaccessibles selon largeur. | Backend : données et erreurs actionnables préservées ; validation frontend dédiée. | 375/430/538/768/1024/1440, responsive planning `2/2`. | Corrigé inter-dépôts, campagne globale en attente. |
+| 015 route planning | Route historique non canonique. | Contrat backend/planning et redirection frontend associée vers `/production/planning`. | E2E responsive/planning réel `2/2`, puis gate global vert. | Corrigé inter-dépôts. |
+| 016 responsive | Risque de commandes inaccessibles selon largeur. | Backend : données et erreurs actionnables préservées ; validation frontend dédiée. | 375/430/538/768/1024/1440, responsive planning `2/2`, puis gate global vert. | Corrigé inter-dépôts. |
 
 ## Diagnostic et architecture retenue
 
@@ -76,6 +78,9 @@ L'image actualise les signatures au démarrage puis les maintient avec `freshcla
 | `b59089a` | Idempotence portail client append-only. |
 | `1e6722f` | Droit portail minimal pour marquer la tentative réussie. |
 | `3fdabdd` | Rollback explicite du patch de droit portail. |
+| `a0c2c1d` | Droit `DELETE` MFA minimal avec preflight, vérification et rollback. |
+| `2751109` | Chaînes de connexion E2E sans identifiants intégrés. |
+| `1f35a53` | Test Devis aligné sur la clé d'idempotence obligatoire. |
 
 ## Fichiers backend principaux
 
@@ -106,7 +111,12 @@ Les scripts de support sont sous `db/patches/support/` (`*.preflight.sql`, `*.ve
 | Planning | Groupe planning/méthodes | PASS — 11/11. |
 | Clavier planning | 10 répétitions ciblées | PASS — 30/30. |
 | TypeScript/build backend | `npm run typecheck`, `npm run build` | PASS sur les vagues ; build génère OpenAPI, frontières et image. |
-| Migration isolée | Répétition PostgreSQL tmpfs sur `127.0.0.1:55489/cerp_test` | PASS — 167 patches, rejeu 0, intégrité et restauration vérifiées. |
+| Gate unifié SOL-12 | `corepack pnpm release:gate -- --target candidate ...` | PASS — 20 contrôles obligatoires, rapports et manifeste intègre SHA-256 `3bb3960e186b3c6c1a095e9091034b7f1d98e64949642dbc85fe31860b083e04`. |
+| Frontend unitaire/intégration | Gate candidat | PASS — 326 fichiers, **2 595** tests. |
+| Backend unitaire/intégration | Gate candidat | PASS — 354 fichiers, **4 848** tests ; 3 fichiers / **8** tests explicitement ignorés. |
+| Migration isolée | Rehearsal PostgreSQL jetable | PASS — inventaire **169** patches ; 140 déjà appliqués, **29 pending appliqués**, replay `true`, restauration `passed`. |
+| Runtime E2E | `runtime-log-gate.json` | PASS — **4 384** événements structurés, **0** événement bloquant. |
+| Playwright isolé | Chromium, `--workers=1 --retries=0` | PASS — **154** scénarios passés, **4** ignorés, **0** inattendu (158 collectés). |
 | Least privilege runtime | `SET LOCAL ROLE cerp_app` | Devis : privilèges exacts ; achats : `SELECT/INSERT` autorisés, `UPDATE` refusé ; verrou consultatif + lecture sans `FOR SHARE` réussis. |
 | Devis E2E isolé | Minimal, complet, retry/idempotence | PASS — 2/2. |
 | Production E2E isolé | Déclaration, blocage clôture, réception, retry, clôture | PASS. |
@@ -126,7 +136,8 @@ Les données de preuve sont préfixées par le runner isolé et vivent dans ses 
 - Le mode scanner est `enforce` hors tests ; une configuration invalide ou un scanner absent ne permet pas de publication de GED.
 - Les changements de privilèges sont additifs, minimaux et validables. Ils exigent une sauvegarde avant application sur une base partagée.
 - Les données métier réelles ne sont pas inventées : familles machine, calendriers de production, centres de coûts/taux horaires, structures et référentiels Qualité/Outillage doivent être renseignés par les rôles responsables via les gates fournis.
-- Le build peut signaler des seuils de bundle frontend : ce n'est pas un échec backend, mais le contrôle de release global doit le juger selon son seuil configuré.
+- Le bundle frontend est sous tous les seuils du gate : initial `675 945/700 000` octets raw, `209 463/225 000` gzip ; plus gros JS `1 525 416/1 600 000` raw, `529 631/550 000` gzip ; `387/450` chunks. La correction native Rollup conserve 168 entrées dynamiques.
+- L'artefact final est `C:\Users\KeenanMARTIN\Documents\Github\cerp-repair-825-artifacts\20260819T224909Z-candidate-f00cd579-1f35a533` ; son manifeste SHA-256 est vérifié. Les logs, résultats E2E et traces n'ont pas été modifiés après le gate.
 
 ## Procédure de rollback
 
@@ -138,12 +149,13 @@ Les données de preuve sont préfixées par le runner isolé et vivent dans ses 
 
 ## Éléments restant réellement à faire
 
-1. Attendre et consigner le résultat du **runner E2E complet propre** ; tout échec doit être reproduit, corrigé et relancé sans assouplir les assertions métier.
-2. Exécuter les gates globaux finaux backend/frontend (collection complète, build, audit, release gate) sur les SHA finaux.
-3. Produire les artefacts horodatés et l'empreinte du run global, puis comparer le nouveau registre à l'audit initial.
-4. Avant `cerp_test` partagé : obtenir l'autorisation de migration, réaliser sauvegarde/preflight/verify/rollback documenté. `cerp_prod` reste hors périmètre de cette campagne.
-5. Les responsables métier doivent renseigner les référentiels signalés par les gates (notamment familles machines, calendriers et coûts) ; aucune valeur ne doit être fabriquée pour obtenir un faux vert.
+1. Revue humaine, puis promotion contrôlée de la candidate vers `dev`; toute promotion vers `main` reste une release distincte avec son gate sur SHA exact.
+2. Avant `cerp_test` partagé : obtenir l'autorisation de migration, réaliser sauvegarde/preflight/verify/rollback documenté. `cerp_prod` reste hors périmètre de cette campagne.
+3. Les responsables métier doivent renseigner les référentiels signalés par les gates (notamment familles machines, calendriers et coûts) ; aucune valeur ne doit être fabriquée pour obtenir un faux vert.
+4. Les 4 scénarios E2E ignorés sont intentionnels (mesure de performance/documentation opt-in, panne scanner couverte séparément et ancien mock Outillage remplacé par parcours réel) ; ils ne sont pas présentés comme des passages.
 
 ## GO / NO-GO
 
-**NO-GO temporaire** pour promotion et déploiement : `FINAL_FULL_E2E_PENDING`. Les preuves ciblées sont favorables, mais la sortie CERP-REPAIR-00 exige encore le run E2E global, les gates complets et l'inventaire final d'artefacts. Aucune promotion `main`, aucun push et aucune écriture `cerp_prod` ne sont présentés comme effectués.
+**GO candidat** pour revue puis promotion contrôlée vers `dev`. Le gate final a passé l'ensemble des contrôles obligatoires, les migrations isolées et les E2E ; la preuve est liée aux SHA exacts et à l'artefact intègre ci-dessus.
+
+**NO-GO production/main à ce stade** : aucune promotion `main`, aucun push, aucun déploiement et aucune écriture dans `cerp_test` partagé ou `cerp_prod` ne sont présentés comme effectués. La procédure de rollback ci-dessus et une approbation humaine restent obligatoires pour toute étape irréversible.

--- a/docs/execution-reports/CERP_REPAIR_CODX-E2E-2026-08-19-181940.md
+++ b/docs/execution-reports/CERP_REPAIR_CODX-E2E-2026-08-19-181940.md
@@ -6,15 +6,18 @@
 - Branche dédiée : `fix/607-e2e-audit-repair`
 - Base de travail : `origin/dev` à `cbcd10c004dd2f9535249d7da641da00f4b1b0ef`
 - Périmètre DB : PostgreSQL jetable isolé uniquement ; **aucune écriture dans `cerp_test` partagé ou `cerp_prod`**.
-- Exécution de gate candidat : contrôles **PASS** le 2026-08-19, release `20260819T224909Z-candidate-f00cd579-1f35a533`; toutefois son artefact est incomplet (bundles `dist` frontend/backend absents).
-- SHA validés : frontend `f00cd579aec82275b6327aebac9937ccc1dca17d`, backend `1f35a5334d28eeea5cd18fb1609c83111023b49b`.
-- Statut de release : **NO-GO jusqu'au rerun du gate avec artefact complet**. Ce document n'est pas une autorisation de promotion `dev → main`, de déploiement, ni d'écriture dans une base partagée.
+- Exécution de gate candidat : contrôles **PASS** le 2026-08-19, release `20260819T233025Z-candidate-f819555f-de45966a`.
+- SHA validés : frontend `f819555fe3a0e8137bda0657eba4ee3784e66e3f`, backend `de45966aabae1931d471bbf4793009d50a44a1ca`.
+- Artefact autoportant audité indépendamment : manifeste SHA-256 `ecd1bf6e11f314e0e3190d0335ffbfed71b048b68482094682a98c4fbca86006`, 1 392 fichiers vérifiés ; absence, taille, hash et chemin non sûr : **0**. Il contient `frontend-dist` (417 fichiers) et `backend-dist` (832 fichiers).
+- Statut de release : **GO candidat uniquement**. Ce document n'est pas une autorisation de promotion `dev → main`, de déploiement, ni d'écriture dans une base partagée.
 
-## Verdict d'exécution (preuve finale bloquée)
+## Verdict d'exécution
 
 Les anomalies reproductibles de la campagne ont reçu une correction ciblée et une preuve globale réelle : clôture OF/réception, création de devis sous le rôle runtime, compatibilité machine/famille, durée de gamme, GED/ClamAV, sélecteurs de formulaires et idempotence. Les corrections sont commitées, sans secret et sans modification de données métier partagées.
 
-L'exécution du gate a rapporté 2 595 tests frontend, 4 848 tests backend (8 ignorés), 154 scénarios Playwright passés (4 ignorés, 0 inattendu), migration/rejeu/restauration isolés. Elle ne constitue cependant pas une preuve de release complète : l'artefact final ne contient pas les bundles `dist` frontend/backend attendus. Le verdict est donc **NO-GO jusqu'au rerun du gate avec artefact complet**, jamais une promotion automatique vers `main` ou la production.
+L'exécution finale du gate a rapporté 2 598 tests frontend dans 326 fichiers, 4 848 tests backend (8 ignorés), 154 scénarios Playwright passés (4 ignorés, 0 échec ou flaky), migration/rejeu/restauration isolés. L'artefact final est autoportant : l'audit indépendant a vérifié les 1 392 fichiers du manifeste, y compris les bundles `frontend-dist` et `backend-dist`, sans fichier absent, erreur de taille/hash ni chemin non sûr. Le verdict est donc **GO candidat uniquement**, jamais une promotion automatique vers `main` ou la production.
+
+Aucun P0/P1 produit ne reste ouvert dans le registre réparé. Les éléments 005, 006 et 014 encore à compléter sont des données métier P2 encadrées par des gates actionnables ; aucune valeur de production n'a été inventée.
 
 ## Registre avant / après
 
@@ -111,12 +114,12 @@ Les scripts de support sont sous `db/patches/support/` (`*.preflight.sql`, `*.ve
 | Planning | Groupe planning/méthodes | PASS — 11/11. |
 | Clavier planning | 10 répétitions ciblées | PASS — 30/30. |
 | TypeScript/build backend | `npm run typecheck`, `npm run build` | PASS sur les vagues ; build génère OpenAPI, frontières et image. |
-| Gate unifié SOL-12 | `corepack pnpm release:gate -- --target candidate ...` | Les 20 contrôles ont rapporté PASS, mais l'artefact manque les bundles `dist` frontend/backend : **preuve de release incomplète, rerun obligatoire**. |
-| Frontend unitaire/intégration | Gate candidat | PASS — 326 fichiers, **2 595** tests. |
+| Gate unifié SOL-12 | `corepack pnpm release:gate -- --target candidate ...` | PASS — 22 étapes obligatoires, sur les SHA exacts de la candidate ; artefact exporté dans le même run. |
+| Frontend unitaire/intégration | Gate candidat | PASS — 326 fichiers, **2 598** tests. |
 | Backend unitaire/intégration | Gate candidat | PASS — 354 fichiers, **4 848** tests ; 3 fichiers / **8** tests explicitement ignorés. |
 | Migration isolée | Rehearsal PostgreSQL jetable | PASS — inventaire **169** patches ; 140 déjà appliqués, **29 pending appliqués**, replay `true`, restauration `passed`. |
-| Runtime E2E | `runtime-log-gate.json` | PASS — **4 384** événements structurés, **0** événement bloquant. |
-| Playwright isolé | Chromium, `--workers=1 --retries=0` | PASS — **154** scénarios passés, **4** ignorés, **0** inattendu (158 collectés). |
+| Runtime E2E | `runtime-log-gate.json` | PASS — **4 355** événements structurés, **0** événement bloquant. |
+| Playwright isolé | Chromium, `--workers=1 --retries=0` | PASS — **154** scénarios passés, **4** ignorés, **0** échec ou flaky (158 collectés). |
 | Least privilege runtime | `SET LOCAL ROLE cerp_app` | Devis : privilèges exacts ; achats : `SELECT/INSERT` autorisés, `UPDATE` refusé ; verrou consultatif + lecture sans `FOR SHARE` réussis. |
 | Devis E2E isolé | Minimal, complet, retry/idempotence | PASS — 2/2. |
 | Production E2E isolé | Déclaration, blocage clôture, réception, retry, clôture | PASS. |
@@ -136,8 +139,9 @@ Les données de preuve sont préfixées par le runner isolé et vivent dans ses 
 - Le mode scanner est `enforce` hors tests ; une configuration invalide ou un scanner absent ne permet pas de publication de GED.
 - Les changements de privilèges sont additifs, minimaux et validables. Ils exigent une sauvegarde avant application sur une base partagée.
 - Les données métier réelles ne sont pas inventées : familles machine, calendriers de production, centres de coûts/taux horaires, structures et référentiels Qualité/Outillage doivent être renseignés par les rôles responsables via les gates fournis.
+- Le dépôt backend ne configure toujours pas de commande lint. Le gate le déclare explicitement comme exception ; le typecheck et le build restent bloquants. Il s'agit d'une dette technique P2, pas d'un contrôle lint présenté comme réussi.
 - Le bundle frontend est sous tous les seuils du gate : initial `675 945/700 000` octets raw, `209 463/225 000` gzip ; plus gros JS `1 525 416/1 600 000` raw, `529 631/550 000` gzip ; `387/450` chunks. La correction native Rollup conserve 168 entrées dynamiques.
-- L'artefact d'exécution est `C:\Users\KeenanMARTIN\Documents\Github\cerp-repair-825-artifacts\20260819T224909Z-candidate-f00cd579-1f35a533` ; ses logs, résultats E2E et traces sont conservés, mais les bundles `dist` frontend/backend attendus sont absents. Il ne doit donc pas être utilisé comme manifeste de release final.
+- L'artefact d'exécution est `C:\Users\KeenanMARTIN\Documents\Github\cerp-repair-825-artifacts\20260819T233025Z-candidate-f819555f-de45966a`. Son manifeste SHA-256 est `ecd1bf6e11f314e0e3190d0335ffbfed71b048b68482094682a98c4fbca86006` ; l'audit indépendant a trouvé 0 fichier absent, 0 écart de taille, 0 hash invalide et 0 chemin non sûr sur 1 392 entrées. Les 417 fichiers `frontend-dist` et 832 fichiers `backend-dist` sont présents dans cet artefact.
 
 ## Procédure de rollback
 
@@ -149,12 +153,11 @@ Les données de preuve sont préfixées par le runner isolé et vivent dans ses 
 
 ## Éléments restant réellement à faire
 
-1. Relancer le gate depuis les SHA exacts avec copie et vérification des bundles `dist` frontend/backend dans l'artefact ; ne lever le blocage qu'après vérification d'intégrité complète.
-2. Après ce rerun seulement : revue humaine, puis promotion contrôlée de la candidate vers `dev`; toute promotion vers `main` reste une release distincte avec son gate sur SHA exact.
-3. Avant `cerp_test` partagé : obtenir l'autorisation de migration, réaliser sauvegarde/preflight/verify/rollback documenté. `cerp_prod` reste hors périmètre de cette campagne.
-4. Les responsables métier doivent renseigner les référentiels signalés par les gates (notamment familles machines, calendriers et coûts) ; aucune valeur ne doit être fabriquée pour obtenir un faux vert.
-5. Les 4 scénarios E2E ignorés sont intentionnels (mesure de performance/documentation opt-in, panne scanner couverte séparément et ancien mock Outillage remplacé par parcours réel) ; ils ne sont pas présentés comme des passages.
+1. Revue humaine, puis promotion contrôlée de la candidate vers `dev`; toute promotion vers `main` reste une release distincte avec son gate sur SHA exact.
+2. Avant `cerp_test` partagé : obtenir l'autorisation de migration, réaliser sauvegarde/preflight/verify/rollback documenté. `cerp_prod` reste hors périmètre de cette campagne.
+3. Les responsables métier doivent renseigner les référentiels signalés par les gates (notamment familles machines, calendriers et coûts) ; aucune valeur ne doit être fabriquée pour obtenir un faux vert.
+4. Les 4 scénarios E2E ignorés sont intentionnels (mesure de performance/documentation opt-in, panne scanner couverte séparément et ancien mock Outillage remplacé par parcours réel) ; ils ne sont pas présentés comme des passages.
 
 ## GO / NO-GO
 
-**NO-GO candidat, production et main à ce stade** : même si l'exécution a passé les contrôles, l'artefact est incomplet. Un rerun complet avec bundles `dist` frontend/backend dans l'artefact est obligatoire avant revue/promotion. Aucune promotion `main`, aucun push, aucun déploiement et aucune écriture dans `cerp_test` partagé ou `cerp_prod` ne sont présentés comme effectués. La procédure de rollback ci-dessus et une approbation humaine restent obligatoires pour toute étape irréversible.
+**GO candidat uniquement** : les contrôles obligatoires, les 158 scénarios E2E collectés et l'audit indépendant de l'artefact autoportant ont passé sur les SHA cités. Cela n'autorise pas une promotion automatique : aucun merge `dev`/`main`, aucun push, aucun déploiement et aucune écriture dans `cerp_test` partagé ou `cerp_prod` ne sont présentés comme effectués. La procédure de rollback ci-dessus, une revue humaine et le gate sur SHA exact restent obligatoires pour toute promotion irréversible.

--- a/docs/execution-reports/CERP_REPAIR_CODX-E2E-2026-08-19-181940.md
+++ b/docs/execution-reports/CERP_REPAIR_CODX-E2E-2026-08-19-181940.md
@@ -6,15 +6,15 @@
 - Branche dédiée : `fix/607-e2e-audit-repair`
 - Base de travail : `origin/dev` à `cbcd10c004dd2f9535249d7da641da00f4b1b0ef`
 - Périmètre DB : PostgreSQL jetable isolé uniquement ; **aucune écriture dans `cerp_test` partagé ou `cerp_prod`**.
-- Gate final candidat : **PASS** le 2026-08-19, release `20260819T224909Z-candidate-f00cd579-1f35a533`.
+- Exécution de gate candidat : contrôles **PASS** le 2026-08-19, release `20260819T224909Z-candidate-f00cd579-1f35a533`; toutefois son artefact est incomplet (bundles `dist` frontend/backend absents).
 - SHA validés : frontend `f00cd579aec82275b6327aebac9937ccc1dca17d`, backend `1f35a5334d28eeea5cd18fb1609c83111023b49b`.
-- Statut de release : **GO candidat uniquement**. Ce document n'est pas une autorisation de promotion `dev → main`, de déploiement, ni d'écriture dans une base partagée.
+- Statut de release : **NO-GO jusqu'au rerun du gate avec artefact complet**. Ce document n'est pas une autorisation de promotion `dev → main`, de déploiement, ni d'écriture dans une base partagée.
 
-## Verdict final
+## Verdict d'exécution (preuve finale bloquée)
 
 Les anomalies reproductibles de la campagne ont reçu une correction ciblée et une preuve globale réelle : clôture OF/réception, création de devis sous le rôle runtime, compatibilité machine/famille, durée de gamme, GED/ClamAV, sélecteurs de formulaires et idempotence. Les corrections sont commitées, sans secret et sans modification de données métier partagées.
 
-Le gate global propre a validé les deux SHA ci-dessus : 2 595 tests frontend, 4 848 tests backend (8 ignorés), 154 scénarios Playwright passés (4 ignorés, 0 inattendu), migration/rejeu/restauration isolés et intégrité des artefacts. Le verdict est donc **GO pour revue et promotion contrôlée vers `dev`**, jamais une promotion automatique vers `main` ou la production.
+L'exécution du gate a rapporté 2 595 tests frontend, 4 848 tests backend (8 ignorés), 154 scénarios Playwright passés (4 ignorés, 0 inattendu), migration/rejeu/restauration isolés. Elle ne constitue cependant pas une preuve de release complète : l'artefact final ne contient pas les bundles `dist` frontend/backend attendus. Le verdict est donc **NO-GO jusqu'au rerun du gate avec artefact complet**, jamais une promotion automatique vers `main` ou la production.
 
 ## Registre avant / après
 
@@ -111,7 +111,7 @@ Les scripts de support sont sous `db/patches/support/` (`*.preflight.sql`, `*.ve
 | Planning | Groupe planning/méthodes | PASS — 11/11. |
 | Clavier planning | 10 répétitions ciblées | PASS — 30/30. |
 | TypeScript/build backend | `npm run typecheck`, `npm run build` | PASS sur les vagues ; build génère OpenAPI, frontières et image. |
-| Gate unifié SOL-12 | `corepack pnpm release:gate -- --target candidate ...` | PASS — 20 contrôles obligatoires, rapports et manifeste intègre SHA-256 `3bb3960e186b3c6c1a095e9091034b7f1d98e64949642dbc85fe31860b083e04`. |
+| Gate unifié SOL-12 | `corepack pnpm release:gate -- --target candidate ...` | Les 20 contrôles ont rapporté PASS, mais l'artefact manque les bundles `dist` frontend/backend : **preuve de release incomplète, rerun obligatoire**. |
 | Frontend unitaire/intégration | Gate candidat | PASS — 326 fichiers, **2 595** tests. |
 | Backend unitaire/intégration | Gate candidat | PASS — 354 fichiers, **4 848** tests ; 3 fichiers / **8** tests explicitement ignorés. |
 | Migration isolée | Rehearsal PostgreSQL jetable | PASS — inventaire **169** patches ; 140 déjà appliqués, **29 pending appliqués**, replay `true`, restauration `passed`. |
@@ -137,7 +137,7 @@ Les données de preuve sont préfixées par le runner isolé et vivent dans ses 
 - Les changements de privilèges sont additifs, minimaux et validables. Ils exigent une sauvegarde avant application sur une base partagée.
 - Les données métier réelles ne sont pas inventées : familles machine, calendriers de production, centres de coûts/taux horaires, structures et référentiels Qualité/Outillage doivent être renseignés par les rôles responsables via les gates fournis.
 - Le bundle frontend est sous tous les seuils du gate : initial `675 945/700 000` octets raw, `209 463/225 000` gzip ; plus gros JS `1 525 416/1 600 000` raw, `529 631/550 000` gzip ; `387/450` chunks. La correction native Rollup conserve 168 entrées dynamiques.
-- L'artefact final est `C:\Users\KeenanMARTIN\Documents\Github\cerp-repair-825-artifacts\20260819T224909Z-candidate-f00cd579-1f35a533` ; son manifeste SHA-256 est vérifié. Les logs, résultats E2E et traces n'ont pas été modifiés après le gate.
+- L'artefact d'exécution est `C:\Users\KeenanMARTIN\Documents\Github\cerp-repair-825-artifacts\20260819T224909Z-candidate-f00cd579-1f35a533` ; ses logs, résultats E2E et traces sont conservés, mais les bundles `dist` frontend/backend attendus sont absents. Il ne doit donc pas être utilisé comme manifeste de release final.
 
 ## Procédure de rollback
 
@@ -149,13 +149,12 @@ Les données de preuve sont préfixées par le runner isolé et vivent dans ses 
 
 ## Éléments restant réellement à faire
 
-1. Revue humaine, puis promotion contrôlée de la candidate vers `dev`; toute promotion vers `main` reste une release distincte avec son gate sur SHA exact.
-2. Avant `cerp_test` partagé : obtenir l'autorisation de migration, réaliser sauvegarde/preflight/verify/rollback documenté. `cerp_prod` reste hors périmètre de cette campagne.
-3. Les responsables métier doivent renseigner les référentiels signalés par les gates (notamment familles machines, calendriers et coûts) ; aucune valeur ne doit être fabriquée pour obtenir un faux vert.
-4. Les 4 scénarios E2E ignorés sont intentionnels (mesure de performance/documentation opt-in, panne scanner couverte séparément et ancien mock Outillage remplacé par parcours réel) ; ils ne sont pas présentés comme des passages.
+1. Relancer le gate depuis les SHA exacts avec copie et vérification des bundles `dist` frontend/backend dans l'artefact ; ne lever le blocage qu'après vérification d'intégrité complète.
+2. Après ce rerun seulement : revue humaine, puis promotion contrôlée de la candidate vers `dev`; toute promotion vers `main` reste une release distincte avec son gate sur SHA exact.
+3. Avant `cerp_test` partagé : obtenir l'autorisation de migration, réaliser sauvegarde/preflight/verify/rollback documenté. `cerp_prod` reste hors périmètre de cette campagne.
+4. Les responsables métier doivent renseigner les référentiels signalés par les gates (notamment familles machines, calendriers et coûts) ; aucune valeur ne doit être fabriquée pour obtenir un faux vert.
+5. Les 4 scénarios E2E ignorés sont intentionnels (mesure de performance/documentation opt-in, panne scanner couverte séparément et ancien mock Outillage remplacé par parcours réel) ; ils ne sont pas présentés comme des passages.
 
 ## GO / NO-GO
 
-**GO candidat** pour revue puis promotion contrôlée vers `dev`. Le gate final a passé l'ensemble des contrôles obligatoires, les migrations isolées et les E2E ; la preuve est liée aux SHA exacts et à l'artefact intègre ci-dessus.
-
-**NO-GO production/main à ce stade** : aucune promotion `main`, aucun push, aucun déploiement et aucune écriture dans `cerp_test` partagé ou `cerp_prod` ne sont présentés comme effectués. La procédure de rollback ci-dessus et une approbation humaine restent obligatoires pour toute étape irréversible.
+**NO-GO candidat, production et main à ce stade** : même si l'exécution a passé les contrôles, l'artefact est incomplet. Un rerun complet avec bundles `dist` frontend/backend dans l'artefact est obligatoire avant revue/promotion. Aucune promotion `main`, aucun push, aucun déploiement et aucune écriture dans `cerp_test` partagé ou `cerp_prod` ne sont présentés comme effectués. La procédure de rollback ci-dessus et une approbation humaine restent obligatoires pour toute étape irréversible.

--- a/docs/execution-reports/RELEASE-PROMOTION-20260820.md
+++ b/docs/execution-reports/RELEASE-PROMOTION-20260820.md
@@ -1,0 +1,28 @@
+# Promotion de release — 20 août 2026
+
+## État
+
+Promotion vers `main` suspendue tant que le contrôle `dev` n'a pas été rejoué après le correctif ci-dessous. Aucune base partagée ni aucun environnement de production n'a été modifié à ce stade.
+
+## Incident du contrôle `dev`
+
+Le contrôle `20260820T065502Z-test-decd72b2-40182c48` a correctement bloqué la promotion. Les 4 848 assertions backend étaient réussies, mais Vitest a détecté une exception asynchrone `EBADF: bad file descriptor, close` rattachée au scénario multipart de création d'un devis.
+
+Cause racine : le test créait un fichier client temporaire puis demandait à Supertest de l'envoyer par chemin. Sous Windows avec Node.js 24 et la concurrence de la suite complète, la résolution de la réponse pouvait précéder la fin de fermeture du `ReadStream` client. La suppression de la fixture entrait alors en course avec cette fermeture. Le pipeline serveur, son stockage privé, la validation du contenu et le transfert transactionnel n'étaient pas en échec.
+
+## Correction
+
+Le scénario envoie désormais le même contenu via un `Buffer` multipart nommé `doc.txt`. Cela conserve le contrat HTTP et tout le pipeline disque sécurisé côté serveur, mais supprime le descripteur client inutile et son cycle de vie asynchrone.
+
+## Preuves après correction
+
+- scénario `devis.routes.test.ts` répété 20 fois : 20 réussites, 0 échec ;
+- suite backend complète : 354 fichiers réussis, 3 fichiers conditionnels ignorés, 4 848 tests réussis, 8 conditionnels ignorés, 0 erreur non gérée ;
+- `corepack pnpm typecheck` : réussi ;
+- `corepack pnpm build` : réussi ;
+- contrat OpenAPI : 1 079 opérations inventoriées et contrat émis valide ;
+- frontière des données de production : source et build validés.
+
+## Données, compatibilité et retour arrière
+
+Ce correctif ne modifie ni API, ni logique métier, ni schéma, ni donnée. Le retour arrière consiste à annuler le commit de test, mais réintroduirait la course de descripteur Windows. La promotion, les migrations partagées et le déploiement restent soumis aux contrôles de release suivants.

--- a/docs/http/openapi-route-coverage.json
+++ b/docs/http/openapi-route-coverage.json
@@ -1,9 +1,9 @@
 {
   "scope": "/api/v1",
-  "source_sha256": "0a9bf864dfa4af98d8173ae7baed0be83600634922eaa3996b9955c579022ed3",
-  "discovered_operations": 1077,
-  "documented_operations": 1077,
+  "source_sha256": "d8680eee125fbc1b1f1230e14b3294af0f44c59e8ab02a285e3512d89386f536",
+  "discovered_operations": 1079,
+  "documented_operations": 1079,
   "coverage_percent": 100,
-  "authenticated_operations": 1057,
+  "authenticated_operations": 1059,
   "public_operations": 20
 }

--- a/docs/http/planning.md
+++ b/docs/http/planning.md
@@ -88,7 +88,8 @@ supprime aucune preuve. Une restauration revient à `PLANNED`, réévalue la dis
 répondre `409 PLANNING_CONFLICT`, `PLANNING_RESOURCE_BLOCKED` ou `PLANNING_LOCKED_AFTER_AR`.
 
 L'autoplan conserve son contrat de résultat partiel explicite. Les motifs sont
-`ALREADY_PLANNED`, `MISSING_RESOURCE`, `RESOURCE_BLOCKED`, `LOCKED_AFTER_AR`, `NO_OPERATIONS`, `NO_SLOT` ou
+`ALREADY_PLANNED`, `MISSING_RESOURCE`, `RESOURCE_BLOCKED`, `LOCKED_AFTER_AR`, `NO_OPERATIONS`,
+`DURATION_UNAVAILABLE`, `NO_SLOT` ou
 `FAILED`; `summary.partial` indique qu'au moins une création et un rejet ont coexisté. Le lot n'est
 pas encore atomique et aucune clé d'idempotence Planning n'est persistée : les mutations ne doivent
 pas être retentées automatiquement. Une évolution nécessiterait une migration additive avec

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -75,6 +75,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "f3ccb16d3f85e03f1b00f710a9d28eda70dc6818b26353d081ac17fa41dce119",
   "20260815_z_client_contact_idempotency_grants_sol43.sql":
     "98490c2b57a98cf129ee4ce71bc878d4d5034a39ce46f95dc0e9b192ce67b302",
+  "20260819_devis_preparation_idempotency_grants_002_003.sql":
+    "6958f41fc10b65af6447eac2205eb0b57a7d345f6f62e7f09da64ac17f70d6f2",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -79,6 +79,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "6958f41fc10b65af6447eac2205eb0b57a7d345f6f62e7f09da64ac17f70d6f2",
   "20260819_client_portal_auth_attempt_update_grant_004.sql":
     "133e0b49689d94f2b507a9bb32de19ace74b492c75ed999a3a8128fbaf1630fe",
+  "20260819_mfa_expired_artifact_cleanup_delete_grant.sql":
+    "4e7dc39721970b14cd515d12658f79bf9e95d46d684d1e06204f78f60c2dbb0b",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -77,6 +77,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "98490c2b57a98cf129ee4ce71bc878d4d5034a39ce46f95dc0e9b192ce67b302",
   "20260819_devis_preparation_idempotency_grants_002_003.sql":
     "6958f41fc10b65af6447eac2205eb0b57a7d345f6f62e7f09da64ac17f70d6f2",
+  "20260819_client_portal_auth_attempt_update_grant_004.sql":
+    "133e0b49689d94f2b507a9bb32de19ace74b492c75ed999a3a8128fbaf1630fe",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -547,21 +547,43 @@ async function main() {
     }
     await client.query(
       `INSERT INTO public.machines (
-         id,code,name,type,status,is_available,workshop_zone,created_by,updated_by
+         id,code,name,type,status,is_available,workshop_zone,machine_family_code,created_by,updated_by
        ) VALUES (
          '27000000-0000-4000-8000-000000000001','E2E-MACH-001','Machine atelier preuve SOL-21',
-         'MILLING','ACTIVE',true,'USINAGE',
+         'MILLING','ACTIVE',true,'USINAGE','F',
          (SELECT id FROM public.users WHERE username='KEENAN'),
          (SELECT id FROM public.users WHERE username='KEENAN')
        ) ON CONFLICT (id) DO UPDATE SET
          code=EXCLUDED.code,name=EXCLUDED.name,status='ACTIVE',is_available=true,
-         workshop_zone='USINAGE',archived_at=NULL,updated_by=EXCLUDED.updated_by`
+         workshop_zone='USINAGE',machine_family_code='F',archived_at=NULL,updated_by=EXCLUDED.updated_by`
+    );
+    await client.query(
+      `INSERT INTO public.machines (
+         id,code,name,type,status,is_available,workshop_zone,machine_family_code,created_by,updated_by
+       ) VALUES (
+         '27000000-0000-4000-8000-000000000002','E2E-MACH-NON-QUALIFIEE','Machine sans qualification — preuve négative',
+         'MILLING','ACTIVE',true,'USINAGE',NULL,
+         (SELECT id FROM public.users WHERE username='KEENAN'),
+         (SELECT id FROM public.users WHERE username='KEENAN')
+       ) ON CONFLICT (id) DO UPDATE SET
+         code=EXCLUDED.code,name=EXCLUDED.name,status='ACTIVE',is_available=true,
+         workshop_zone='USINAGE',machine_family_code=NULL,archived_at=NULL,updated_by=EXCLUDED.updated_by`
     );
     await client.query(
       `INSERT INTO public.postes (id,code,label,machine_id,currency,is_active)
        VALUES (
          '24000000-0000-4000-8000-000000000001','E2E-POSTE-001','Poste planning preuve SOL-05',
          '27000000-0000-4000-8000-000000000001','EUR',true
+       )
+       ON CONFLICT (id) DO UPDATE SET
+         code=EXCLUDED.code,label=EXCLUDED.label,machine_id=EXCLUDED.machine_id,
+         is_active=true,archived_at=NULL`
+    );
+    await client.query(
+      `INSERT INTO public.postes (id,code,label,machine_id,currency,is_active)
+       VALUES (
+         '24000000-0000-4000-8000-000000000002','E2E-POSTE-NON-QUALIFIE','Poste machine sans qualification',
+         '27000000-0000-4000-8000-000000000002','EUR',true
        )
        ON CONFLICT (id) DO UPDATE SET
          code=EXCLUDED.code,label=EXCLUDED.label,machine_id=EXCLUDED.machine_id,

--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -570,15 +570,16 @@ async function main() {
     await client.query(
       `INSERT INTO public.pieces_techniques_operations (
          id,piece_technique_id,gamme_id,phase,ordre,designation,type_operation,poste_id,machine_id,
-         coef,tp,tf_unit,qte,taux_horaire,temps_fabrication,temps_total,cout_mo
+         machine_family_code,coef,tp,tf_unit,qte,taux_horaire,temps_fabrication,temps_total,cout_mo
        ) VALUES (
          '26000000-0000-4000-8000-000000000001','21000000-0000-4000-8000-000000000001',
          '92000000-0000-4000-8000-000000000003',10,10,'Usinage preuve SOL-05','FRAISAGE',
          '24000000-0000-4000-8000-000000000001','27000000-0000-4000-8000-000000000001',
-         1,0.1,0.25,1,50,0.25,0.35,17.5
+         'F',1,0.1,0.25,1,50,0.25,0.35,17.5
        ) ON CONFLICT (id) DO UPDATE SET
          piece_technique_id=EXCLUDED.piece_technique_id,gamme_id=EXCLUDED.gamme_id,phase=EXCLUDED.phase,
          ordre=EXCLUDED.ordre,designation=EXCLUDED.designation,poste_id=EXCLUDED.poste_id,machine_id=EXCLUDED.machine_id,
+         machine_family_code=EXCLUDED.machine_family_code,
          temps_fabrication=EXCLUDED.temps_fabrication,temps_total=EXCLUDED.temps_total,
          cout_mo=EXCLUDED.cout_mo`
     );

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -23,6 +23,7 @@ const ELECTRONIC_INVOICING_PATCH = "20260814_electronic_invoicing_sol26.sql";
 const ACCOUNTING_EXPORT_PATCH = "20260814_accounting_export_sol27.sql";
 const API_WEBHOOKS_PATCH = "20260814_api_contract_webhooks_sol28.sql";
 const MFA_POLICY_PATCH = "20260816_mfa_policy_and_device_labels.sql";
+const DEVIS_AUDIT_GRANTS_PATCH = "20260819_devis_preparation_idempotency_grants_002_003.sql";
 const SOL06_SUPPORT = path.join(SUPPORT_DIR, "20260810_system_reference_data_readiness");
 const POSTGRES_IMAGE = "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229";
 const DEFAULT_REPORT_DIR = path.join(ROOT, "docs", "release");
@@ -262,6 +263,23 @@ async function verifyKnownExternalAppliedPatches(client, ledger) {
   }
 }
 
+/**
+ * CERP-AUDIT-002/003 is a runtime-permissions correction. Before it is applied,
+ * preflight proves its targets exist; after it is on the ledger, promotion also
+ * proves the exact repository privileges have not drifted away.
+ */
+async function runDevisAuditGrantReleasePreflight(client, ledger) {
+  const preflightSql = patchSupportSql(DEVIS_AUDIT_GRANTS_PATCH, "preflight");
+  const verifySql = patchSupportSql(DEVIS_AUDIT_GRANTS_PATCH, "verify");
+  if (!preflightSql || !verifySql) {
+    fail(`CERP-AUDIT-002/003 support scripts are missing for ${DEVIS_AUDIT_GRANTS_PATCH}`);
+  }
+  await runSqlFile(client, preflightSql);
+  if (!ledger.pending.includes(DEVIS_AUDIT_GRANTS_PATCH)) {
+    await runSqlFile(client, verifySql);
+  }
+}
+
 async function preflight(options = {}) {
   const rawUrl = options.databaseUrl ?? process.env.DATABASE_URL;
   assertDatabaseTarget(rawUrl, process.env.CERP_MIGRATION_READONLY_APPROVED === "1");
@@ -284,6 +302,7 @@ async function preflight(options = {}) {
     }
     await verifyKnownExternalAppliedPatches(client, ledger);
     await runSqlFile(client, supportSql("preflight"));
+    await runDevisAuditGrantReleasePreflight(client, ledger);
     return {
       status: "passed",
       checked_at: new Date().toISOString(),
@@ -886,6 +905,7 @@ module.exports = {
   ADV_RELIABILITY_PATCH,
   PROJECT_OPERATIONS_PATCH,
   ACCOUNTING_EXPORT_PATCH,
+  DEVIS_AUDIT_GRANTS_PATCH,
   expectedRehearsalPatches,
   inventory,
   inventoryMarkdown,

--- a/src/__tests__/client-portal-isolation.repository.test.ts
+++ b/src/__tests__/client-portal-isolation.repository.test.ts
@@ -10,6 +10,7 @@ vi.mock("../config/database", () => ({
 }));
 
 import {
+  repoCreatePortalAccount,
   repoGetPortalDocumentDownload,
   repoListPortalInvoices,
   repoListPortalOrders,
@@ -22,7 +23,43 @@ const identity = {
 };
 
 describe("client portal repository tenant isolation", () => {
-  beforeEach(() => mocked.query.mockReset());
+  beforeEach(() => {
+    mocked.query.mockReset();
+    mocked.connect.mockReset();
+  });
+
+  it("keeps a missing client as a 404 under the insert-only receipt grant", async () => {
+    const transaction = {
+      query: vi.fn()
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [] }) // advisory lock
+        .mockResolvedValueOnce({ rows: [] }) // receipt lookup
+        .mockResolvedValueOnce({ rows: [] }) // client lookup
+        .mockResolvedValueOnce({ rows: [] }), // ROLLBACK
+      release: vi.fn(),
+    };
+    mocked.connect.mockResolvedValueOnce(transaction);
+
+    await expect(repoCreatePortalAccount({
+      actorId: 1,
+      idempotencyKey: "d5ec6d7e-f2f9-42aa-b766-bf98147f42b3",
+      requestHash: "a".repeat(64),
+      clientId: "997",
+      email: "portal@example.test",
+      emailNormalized: "portal@example.test",
+      displayName: "Portail test",
+      passwordHash: "x".repeat(60),
+      meta: { requestId: "request-1", ipHash: null, userAgentFamily: null },
+    })).rejects.toMatchObject({
+      status: 404,
+      code: "CLIENT_PORTAL_CLIENT_NOT_FOUND",
+    });
+
+    const queries = transaction.query.mock.calls.map(([sql]) => String(sql));
+    expect(queries[1]).toContain("pg_advisory_xact_lock");
+    expect(queries[2]).not.toContain("FOR SHARE");
+    expect(queries[2]).toContain("client_portal_command_receipts");
+  });
 
   it.each([
     ["orders", repoListPortalOrders],

--- a/src/__tests__/client-portal-sol29.migration-guards.test.ts
+++ b/src/__tests__/client-portal-sol29.migration-guards.test.ts
@@ -10,6 +10,9 @@ describe("SOL-29 migration guards", () => {
   const preflight = read("db/patches/support/20260814_client_portal_sol29.preflight.sql");
   const verify = read("db/patches/support/20260814_client_portal_sol29.verify.sql");
   const rollback = read("db/patches/support/20260814_client_portal_sol29.rollback.sql");
+  const authAttemptGrant = read("db/patches/20260819_client_portal_auth_attempt_update_grant_004.sql");
+  const authAttemptGrantPreflight = read("db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.preflight.sql");
+  const authAttemptGrantVerify = read("db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.verify.sql");
 
   it("keeps portal identities separate and tenant projections filtered", () => {
     expect(patch).toContain("client_portal_accounts");
@@ -39,5 +42,12 @@ describe("SOL-29 migration guards", () => {
     expect(verify).toContain("cerp_app grants are invalid");
     expect(rollback).toContain("rollback refused");
     expect(rollback).toContain("portal identity, publication or audit evidence exists");
+  });
+
+  it("grants only the portal auth-attempt state transition used after successful activation", () => {
+    expect(authAttemptGrant).toContain("GRANT UPDATE ON TABLE public.client_portal_auth_attempts TO cerp_app");
+    expect(authAttemptGrant).not.toMatch(/GRANT\s+ALL\s+/i);
+    expect(authAttemptGrantPreflight).toContain("client_portal_auth_attempts");
+    expect(authAttemptGrantVerify).toContain("cannot mark portal authentication attempts successful");
   });
 });

--- a/src/__tests__/client-portal-sol29.migration-guards.test.ts
+++ b/src/__tests__/client-portal-sol29.migration-guards.test.ts
@@ -13,6 +13,7 @@ describe("SOL-29 migration guards", () => {
   const authAttemptGrant = read("db/patches/20260819_client_portal_auth_attempt_update_grant_004.sql");
   const authAttemptGrantPreflight = read("db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.preflight.sql");
   const authAttemptGrantVerify = read("db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.verify.sql");
+  const authAttemptGrantRollback = read("db/patches/support/20260819_client_portal_auth_attempt_update_grant_004.rollback.sql");
 
   it("keeps portal identities separate and tenant projections filtered", () => {
     expect(patch).toContain("client_portal_accounts");
@@ -49,5 +50,7 @@ describe("SOL-29 migration guards", () => {
     expect(authAttemptGrant).not.toMatch(/GRANT\s+ALL\s+/i);
     expect(authAttemptGrantPreflight).toContain("client_portal_auth_attempts");
     expect(authAttemptGrantVerify).toContain("cannot mark portal authentication attempts successful");
+    expect(authAttemptGrantRollback).toContain("verified pre-migration backup");
+    expect(authAttemptGrantRollback).not.toMatch(/REVOKE\s+UPDATE/i);
   });
 });

--- a/src/__tests__/commercial-references.routes.test.ts
+++ b/src/__tests__/commercial-references.routes.test.ts
@@ -1,0 +1,67 @@
+import request from "supertest";
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  return {
+    Pool: vi.fn(() => ({ on: emitter.on.bind(emitter), query: vi.fn(), connect: vi.fn() })),
+    __emitter__: emitter,
+  };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({ checkNetworkDrive: vi.fn(() => Promise.resolve()) }));
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; role: string }; headers: Record<string, unknown> },
+    _res: unknown,
+    next: () => void
+  ) => {
+    req.user = {
+      id: 1,
+      role: typeof req.headers["x-test-role"] === "string" ? String(req.headers["x-test-role"]) : "administrateur",
+    };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import app from "../config/app";
+
+describe("commercial references compatibility routes", () => {
+  it.each(["/api/v1/conditions-paiement", "/api/v1/compte-vente"])(
+    "keeps %s authenticated and explicit until an approved financial model exists",
+    async (path) => {
+      const res = await request(app).get(path);
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        items: [],
+        availability: "NOT_CONFIGURED",
+        source: null,
+        freshness_at: null,
+        reliability: "UNAVAILABLE",
+      });
+      expect(typeof res.body.message).toBe("string");
+    }
+  );
+
+  it("keeps the frontend's two historic item types distinct", async () => {
+    const conditions = await request(app).get("/api/v1/conditions-paiement");
+    const comptes = await request(app).get("/api/v1/compte-vente");
+    expect(Object.keys(conditions.body)).toEqual([
+      "items", "availability", "message", "source", "freshness_at", "reliability",
+    ]);
+    expect(Object.keys(comptes.body)).toEqual([
+      "items", "availability", "message", "source", "freshness_at", "reliability",
+    ]);
+  });
+
+  it("does not expose commercial reference state to a role without Devis read access", async () => {
+    const res = await request(app).get("/api/v1/conditions-paiement").set("x-test-role", "Stagiaire");
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -120,6 +120,10 @@ const recentSolPatchChecksums = new Map([
     "20260815_reference_data_center_sol33.sql",
     "a40f4948dfbcee7de8eb00d9077f499a2b92bdda863b6728f29d8e62751a899f",
   ],
+  [
+    "20260819_client_portal_auth_attempt_update_grant_004.sql",
+    "133e0b49689d94f2b507a9bb32de19ace74b492c75ed999a3a8128fbaf1630fe",
+  ],
 ]);
 const wave9PatchChecksums = new Map([
   [

--- a/src/__tests__/devis-audit-002-003-grants.migration.test.ts
+++ b/src/__tests__/devis-audit-002-003-grants.migration.test.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(__dirname, "../..");
+const name = "20260819_devis_preparation_idempotency_grants_002_003";
+const read = (relativePath: string) => readFileSync(resolve(root, relativePath), "utf8");
+const migration = read(`db/patches/${name}.sql`);
+const preflight = read(`db/patches/support/${name}.preflight.sql`);
+const verify = read(`db/patches/support/${name}.verify.sql`);
+const rollback = read(`db/patches/support/${name}.rollback.sql`);
+const runner = read("scripts/db-patches.js");
+const releaseGate = read("scripts/migrations/release-gate.js");
+
+describe("CERP-AUDIT-002/003 Devis runtime grants", () => {
+  it("grants only operations proven by the quote repositories", () => {
+    expect(migration).toContain("GRANT SELECT, INSERT, DELETE ON TABLE public.article_devis TO cerp_app");
+    expect(migration).toContain("GRANT SELECT, INSERT, DELETE ON TABLE public.dossier_technique_piece_devis TO cerp_app");
+    expect(migration).toContain("GRANT SELECT, INSERT ON TABLE public.devis_idempotence TO cerp_app");
+    expect(migration).not.toMatch(/GRANT\s+(ALL|UPDATE|TRUNCATE)/i);
+  });
+
+  it("has target and role guards with read-only support scripts", () => {
+    for (const relation of ["article_devis", "dossier_technique_piece_devis", "devis_idempotence"]) {
+      expect(migration).toContain(relation);
+      expect(preflight).toContain(relation);
+      expect(verify).toContain(relation);
+    }
+    expect(migration).toContain("current_database() NOT IN ('cerp_test', 'cerp_prod')");
+    expect(migration).toContain("runtime role cerp_app is missing");
+    expect(preflight).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(preflight).toContain("('devis', 'conditions_paiement_id')");
+    expect(preflight).toContain("('devis', 'compte_vente_id')");
+    expect(preflight).toContain("('devis_ligne', 'position')");
+    expect(preflight).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE|GRANT|REVOKE)\b/im);
+    expect(verify).toContain("has_table_privilege('cerp_app'");
+  });
+
+  it("uses backup restoration as the only conservative rollback", () => {
+    expect(rollback).toContain("verified pre-migration backup");
+    expect(rollback).toContain("Do not REVOKE in place");
+    expect(rollback).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE|GRANT|REVOKE)\b/im);
+  });
+
+  it("pins the migration and makes release preflight verify privileges after application", () => {
+    const sha256 = createHash("sha256").update(migration.replace(/\r\n?/g, "\n"), "utf8").digest("hex");
+    expect(runner).toContain(`\"${name}.sql\":`);
+    expect(runner).toContain(sha256);
+    expect(releaseGate).toContain("DEVIS_AUDIT_GRANTS_PATCH");
+    expect(releaseGate).toContain("runDevisAuditGrantReleasePreflight(client, ledger)");
+    expect(releaseGate).toContain("!ledger.pending.includes(DEVIS_AUDIT_GRANTS_PATCH)");
+  });
+});

--- a/src/__tests__/devis-workflow-167.routes.test.ts
+++ b/src/__tests__/devis-workflow-167.routes.test.ts
@@ -315,6 +315,7 @@ describe("#167 — automate de statuts appliqué au write-path", () => {
   it("un devis ne naît pas ACCEPTE (422 DEVIS_INITIAL_STATUT_INVALID)", async () => {
     const res = await request(app)
       .post("/api/v1/devis")
+      .set("Idempotency-Key", "devis-initial-status-invalid-0001")
       .field(
         "data",
         JSON.stringify({

--- a/src/__tests__/devis.routes.test.ts
+++ b/src/__tests__/devis.routes.test.ts
@@ -728,6 +728,7 @@ describe("/api/v1/devis", () => {
 
     const res = await request(app)
       .post("/api/v1/devis")
+      .set("Idempotency-Key", "devis-create-route-0001")
       .field("data", JSON.stringify(payload))
       .attach("documents[]", tmpFile);
 
@@ -755,6 +756,61 @@ describe("/api/v1/devis", () => {
     expect(String(insertLigneCall?.[0])).toContain("position");
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("POST /api/v1/devis requires an idempotency key before any write", async () => {
+    const res = await request(app)
+      .post("/api/v1/devis")
+      .field("data", JSON.stringify({
+        client_id: "001",
+        user_id: 1,
+        lignes: [{ description: "Line", quantite: 1, prix_unitaire_ht: 100 }],
+      }));
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "IDEMPOTENCY_KEY_REQUIRED" });
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => /INSERT INTO devis\s*\(/.test(String(sql)))).toBe(false);
+  });
+
+  it("POST /api/v1/devis fails closed when its idempotency ledger is absent", async () => {
+    state.idempotenceTable = false;
+    const res = await request(app)
+      .post("/api/v1/devis")
+      .set("Idempotency-Key", "devis-ledger-absent-0001")
+      .field("data", JSON.stringify({
+        client_id: "001",
+        user_id: 1,
+        lignes: [{ description: "Line", quantite: 1, prix_unitaire_ht: 100 }],
+      }));
+
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({ code: "DEVIS_IDEMPOTENCY_NOT_READY" });
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => /INSERT INTO devis\s*\(/.test(String(sql)))).toBe(false);
+  });
+
+  it("POST /api/v1/devis maps a missing commercial schema to an actionable 503", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
+      if (/devis_id_seq/.test(String(sql))) {
+        throw Object.assign(new Error('relation "article_devis" does not exist'), {
+          code: "42P01",
+          table: "article_devis",
+        });
+      }
+      return dispatch(sql, params);
+    });
+
+    const res = await request(app)
+      .post("/api/v1/devis")
+      .set("Idempotency-Key", "devis-schema-absent-0001")
+      .field("data", JSON.stringify({
+        client_id: "001",
+        user_id: 1,
+        lignes: [{ description: "Line", quantite: 1, prix_unitaire_ht: 100 }],
+      }));
+
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({ code: "DEVIS_SCHEMA_NOT_READY" });
+    expect(res.body.message).not.toContain("article_devis");
   });
 
   it("POST /api/v1/devis refuse un dossier préparatoire orphelin sans écriture", async () => {

--- a/src/__tests__/devis.routes.test.ts
+++ b/src/__tests__/devis.routes.test.ts
@@ -3,10 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "events";
 import fs from "node:fs";
 import path from "node:path";
-import {
-  ensureTmpStoragePath,
-  getDocumentStoragePath,
-} from "../utils/cerpStorage";
+import { getDocumentStoragePath } from "../utils/cerpStorage";
 
 const mocks = vi.hoisted(() => ({
   poolQuery: vi.fn(),
@@ -716,10 +713,6 @@ describe("/api/v1/devis", () => {
   });
 
   it("POST /api/v1/devis supports multipart data + optional documents[]", async () => {
-    const tmpDir = fs.mkdtempSync(path.join(ensureTmpStoragePath("fixtures"), "devis-"));
-    const tmpFile = path.join(tmpDir, "doc.txt");
-    fs.writeFileSync(tmpFile, "hello");
-
     const payload = {
       client_id: "001",
       user_id: 1,
@@ -730,7 +723,14 @@ describe("/api/v1/devis", () => {
       .post("/api/v1/devis")
       .set("Idempotency-Key", "devis-create-route-0001")
       .field("data", JSON.stringify(payload))
-      .attach("documents[]", tmpFile);
+      // A Buffer keeps the multipart contract under test without leaving a
+      // client-side ReadStream close pending after Supertest resolves. Under
+      // the full Windows/Node 24 suite that unnecessary fixture descriptor
+      // could race worker teardown and surface as an unhandled EBADF.
+      .attach("documents[]", Buffer.from("hello"), {
+        filename: "doc.txt",
+        contentType: "text/plain",
+      });
 
     expect(res.status).toBe(201);
     expect(res.body).toMatchObject({ id: 7, idempotent_replay: false });
@@ -755,7 +755,6 @@ describe("/api/v1/devis", () => {
     const insertLigneCall = mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("INSERT INTO devis_ligne"));
     expect(String(insertLigneCall?.[0])).toContain("position");
 
-    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it("POST /api/v1/devis requires an idempotency key before any write", async () => {

--- a/src/__tests__/e2e-isolation.test.ts
+++ b/src/__tests__/e2e-isolation.test.ts
@@ -23,6 +23,13 @@ function isolatedEnv(): NodeJS.ProcessEnv {
   };
 }
 
+function managedContainerDatabaseUrl(host: string): string {
+  const url = new URL(`postgresql://${host}:5432/cerp_test`);
+  url.username = "cerp_app";
+  url.password = "disposable";
+  return url.toString();
+}
+
 describe("SOL-05 E2E isolation guard", () => {
   it("accepts a fully loopback disposable runtime", () => {
     expect(() => assertE2EIsolation(isolatedEnv())).not.toThrow();
@@ -70,7 +77,7 @@ describe("SOL-05 E2E isolation guard", () => {
     const container = isolatedEnv();
     container.CERP_E2E_MANAGED_STACK = "1";
     container.CERP_E2E_CONTAINER = "1";
-    container.DATABASE_URL = "postgresql://cerp_app:test@postgres:5432/cerp_test";
+    container.DATABASE_URL = managedContainerDatabaseUrl("postgres");
     container.CERP_E2E_EMAIL_SINK = "1";
     container.RESEND_API_KEY = "disposable";
     container.RESEND_FROM = "CERP SOL-05 <no-reply@example.local>";
@@ -79,7 +86,7 @@ describe("SOL-05 E2E isolation guard", () => {
     expect(() => assertE2EIsolation(container)).not.toThrow();
     expect(e2eListenHost(container)).toBe("0.0.0.0");
 
-    container.DATABASE_URL = "postgresql://cerp_app:test@db.production.example/cerp_test";
+    container.DATABASE_URL = managedContainerDatabaseUrl("db.production.example");
     expect(() => assertE2EIsolation(container)).toThrow(/forbidden/);
   });
 

--- a/src/__tests__/e2e-isolation.test.ts
+++ b/src/__tests__/e2e-isolation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { assertE2EIsolation } from "../config/e2e-isolation";
+import { assertE2EIsolation, e2eListenHost } from "../config/e2e-isolation";
 
 function isolatedEnv(): NodeJS.ProcessEnv {
   const root = "C:/tmp/cerp-sol05";
@@ -35,7 +35,7 @@ describe("SOL-05 E2E isolation guard", () => {
   ])("rejects a non-loopback %s", (name, value) => {
     const env = isolatedEnv();
     env[name] = value;
-    expect(() => assertE2EIsolation(env)).toThrow(/loopback/);
+    expect(() => assertE2EIsolation(env)).toThrow(/forbidden/);
   });
 
   it("rejects a production database name even on localhost", () => {
@@ -63,6 +63,30 @@ describe("SOL-05 E2E isolation guard", () => {
     expect(() => assertE2EIsolation(withSink)).not.toThrow();
 
     withSink.RESEND_API_BASE_URL = "https://api.resend.com";
-    expect(() => assertE2EIsolation(withSink)).toThrow(/loopback/);
+    expect(() => assertE2EIsolation(withSink)).toThrow(/forbidden/);
+  });
+
+  it("accepts only the named Docker services inside the managed disposable stack", () => {
+    const container = isolatedEnv();
+    container.CERP_E2E_MANAGED_STACK = "1";
+    container.CERP_E2E_CONTAINER = "1";
+    container.DATABASE_URL = "postgresql://cerp_app:test@postgres:5432/cerp_test";
+    container.CERP_E2E_EMAIL_SINK = "1";
+    container.RESEND_API_KEY = "disposable";
+    container.RESEND_FROM = "CERP SOL-05 <no-reply@example.local>";
+    container.RESEND_API_BASE_URL = "http://host.docker.internal:55001";
+
+    expect(() => assertE2EIsolation(container)).not.toThrow();
+    expect(e2eListenHost(container)).toBe("0.0.0.0");
+
+    container.DATABASE_URL = "postgresql://cerp_app:test@db.production.example/cerp_test";
+    expect(() => assertE2EIsolation(container)).toThrow(/forbidden/);
+  });
+
+  it("does not permit container binding outside a managed stack", () => {
+    const env = isolatedEnv();
+    env.CERP_E2E_CONTAINER = "1";
+    expect(() => assertE2EIsolation(env)).toThrow(/MANAGED_STACK/);
+    expect(e2eListenHost(isolatedEnv())).toBe("127.0.0.1");
   });
 });

--- a/src/__tests__/errorHandler.test.ts
+++ b/src/__tests__/errorHandler.test.ts
@@ -150,6 +150,39 @@ describe("CA-SEC-04 — errorHandler ne fuite pas d'internes sur 5xx", () => {
     expect(JSON.stringify(payload)).not.toContain("10.0.0.5");
   });
 
+  it("expose uniquement l'identifiant de quarantaine sûr pour GED_SCAN_FAILED", () => {
+    const { req, res, status, json } = mockReqRes("/api/v1/ged/documents?title=secret-client");
+    const quarantineId = "123e4567-e89b-42d3-a456-426614174000";
+
+    errorHandler(new HttpError(503, "GED_SCAN_FAILED", "socket /run/clamav privé", {
+      quarantine_id: quarantineId,
+      state: "quarantined",
+      absolute_path: "/app/data/private/tenant-42/document.txt",
+      scanner_output: "secret",
+    }), req, res, () => {});
+
+    expect(status).toHaveBeenCalledWith(503);
+    expect(json.mock.calls[0][0]).toEqual({
+      success: false,
+      message: "Le verdict antivirus n'a pas pu être obtenu. Le fichier reste isolé en quarantaine ; contactez l'administrateur.",
+      code: "GED_SCAN_FAILED",
+      path: "/api/v1/ged/documents",
+      details: { quarantine_id: quarantineId, state: "quarantined" },
+    });
+    expect(JSON.stringify(json.mock.calls[0][0])).not.toContain("tenant-42");
+    expect(JSON.stringify(json.mock.calls[0][0])).not.toContain("scanner_output");
+  });
+
+  it("masque les détails GED_SCAN_FAILED qui ne respectent pas le contrat fermé", () => {
+    const { req, res, json } = mockReqRes();
+    errorHandler(new HttpError(503, "GED_SCAN_FAILED", "private", {
+      quarantine_id: "../../secret",
+      state: "released",
+    }), req, res, () => {});
+
+    expect(json.mock.calls[0][0]).not.toHaveProperty("details");
+  });
+
   it.each([
     ["UPLOAD_SCAN_UNAVAILABLE", "Le contrôle antivirus est temporairement indisponible. Réessayez plus tard."],
     ["UPLOAD_STAGING_PERMISSION_FAILED", "La zone sécurisée de dépôt est temporairement indisponible. Réessayez plus tard ou contactez l’administrateur."],

--- a/src/__tests__/ged-antivirus-quarantine.test.ts
+++ b/src/__tests__/ged-antivirus-quarantine.test.ts
@@ -232,13 +232,21 @@ describe("GED antivirus quarantine", () => {
       }),
     });
 
-    await expect(uploadDocument(
+    const uploadPromise = uploadDocument(
       { id: 7, role: "Administrateur" },
       { class_key: CLASS_ROW.class_key, title: "Rapport test" },
       file
-    )).rejects.toMatchObject({ status: 503, code: "GED_SCAN_FAILED" });
+    );
+    await expect(uploadPromise).rejects.toMatchObject({
+      status: 503,
+      code: "GED_SCAN_FAILED",
+      details: expect.objectContaining({ state: "quarantined" }),
+    });
 
     const sessionId = repository.repoCreateUploadSession.mock.calls[0][1].id;
+    await expect(uploadPromise).rejects.toMatchObject({
+      details: { quarantine_id: sessionId, state: "quarantined" },
+    });
     expect(repository.repoRecordUploadScan).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/src/__tests__/mfa-expired-artifact-cleanup-grant.migration.test.ts
+++ b/src/__tests__/mfa-expired-artifact-cleanup-grant.migration.test.ts
@@ -1,0 +1,50 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = resolve(__dirname, "../..");
+const name = "20260819_mfa_expired_artifact_cleanup_delete_grant";
+const read = (relativePath: string) => readFileSync(resolve(root, relativePath), "utf8");
+const migration = read(`db/patches/${name}.sql`);
+const preflight = read(`db/patches/support/${name}.preflight.sql`);
+const verify = read(`db/patches/support/${name}.verify.sql`);
+const rollback = read(`db/patches/support/${name}.rollback.sql`);
+const runner = read("scripts/db-patches.js");
+const mfaService = read("src/module/auth/services/mfa.service.ts");
+
+describe("CERP-REPAIR-00 MFA expired artifact cleanup grant", () => {
+  it("grants only the DELETE operation used by maintenance", () => {
+    expect(migration).toContain("GRANT DELETE ON TABLE public.user_mfa_factors TO cerp_app");
+    expect(migration).not.toMatch(/GRANT\s+(ALL|SELECT|INSERT|UPDATE|TRUNCATE)/i);
+    expect(mfaService).toContain("DELETE FROM public.user_mfa_factors");
+    expect(mfaService).toContain("state='PENDING'");
+  });
+
+  it("ships target guards and read-only preflight and verification", () => {
+    for (const relation of ["user_mfa_factors", "auth_mfa_challenges"]) {
+      expect(migration).toContain(relation);
+      expect(preflight).toContain(relation);
+    }
+    expect(migration).toContain("runtime role cerp_app is missing");
+    expect(preflight).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(preflight).toContain("has_table_privilege('cerp_app', 'public.user_mfa_factors', 'DELETE')");
+    expect(verify).toContain("cannot delete expired pending MFA factors");
+    expect(verify).toContain("has_table_privilege('cerp_app', 'public.user_mfa_factors', 'DELETE')");
+    expect(preflight).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE|GRANT|REVOKE)\b/im);
+    expect(verify).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE|GRANT|REVOKE)\b/im);
+  });
+
+  it("has a bounded rollback to the documented SOL-32 privilege baseline", () => {
+    expect(rollback).toContain("Roll back the matching");
+    expect(rollback).toContain("REVOKE DELETE ON TABLE public.user_mfa_factors FROM cerp_app");
+    expect(rollback).not.toMatch(/REVOKE\s+(ALL|SELECT|INSERT|UPDATE|TRUNCATE)/i);
+  });
+
+  it("pins the additive patch in the immutable migration registry", () => {
+    const sha256 = createHash("sha256").update(migration.replace(/\r\n?/g, "\n"), "utf8").digest("hex");
+    expect(runner).toContain(`\"${name}.sql\":`);
+    expect(runner).toContain(sha256);
+  });
+});

--- a/src/__tests__/planning.routes.test.ts
+++ b/src/__tests__/planning.routes.test.ts
@@ -296,7 +296,8 @@ describe("/api/v1/planning", () => {
             of_operation_id: "44444444-4444-4444-4444-444444444444",
             phase: 10,
             designation: "Usinage",
-            temps_total_planned: 120,
+            // 30 min preparation + (12 min unit x 2 launched) = 54 min.
+            planned_duration_minutes: 54,
             status: "TODO",
             machine_id: null,
             poste_id: "22222222-2222-2222-2222-222222222222",
@@ -320,7 +321,7 @@ describe("/api/v1/planning", () => {
             title: "P10 - Usinage",
             description: null,
             start_ts: "2026-02-14T08:00:00.000Z",
-            end_ts: "2026-02-14T10:00:00.000Z",
+            end_ts: "2026-02-14T08:54:00.000Z",
             allow_overlap: false,
             created_at: "2026-02-14T07:00:00.000Z",
             updated_at: "2026-02-14T07:00:00.000Z",
@@ -348,8 +349,10 @@ describe("/api/v1/planning", () => {
       });
 
     // repoCreatePlanningEvent internals: BEGIN, select defaults, conflict check, insert, audit, COMMIT
-    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+    let eventInsertValues: unknown[] | undefined;
+    mocks.clientQuery.mockImplementation(async (sql: unknown, values?: unknown[]) => {
       const q = String(sql);
+      if (q.includes("INSERT INTO public.planning_events")) eventInsertValues = values;
       if (q.includes("FROM public.postes p") && q.includes("p.id = $1::uuid")) {
         return {
           rows: [
@@ -358,13 +361,24 @@ describe("/api/v1/planning", () => {
               code: "P01",
               label: "Poste 1",
               is_active: true,
-              machine_id: null,
-              machine_code: null,
-              machine_status: null,
-              machine_is_available: null,
-              machine_scheduling_enabled: null,
+              machine_id: "11111111-1111-1111-1111-111111111111",
+              machine_code: "M01",
+              status: "ACTIVE",
+              is_available: true,
+              scheduling_enabled: true,
             },
           ],
+        };
+      }
+      if (q.includes("required_machine_family_code")) {
+        return {
+          rows: [{
+            operation_id: "44444444-4444-4444-4444-444444444444",
+            required_machine_family_code: "FRAISAGE",
+            machine_id: "11111111-1111-1111-1111-111111111111",
+            machine_code: "M01",
+            machine_family_code: "FRAISAGE",
+          }],
         };
       }
       if (q.includes("FROM public.of_time_logs")) {
@@ -448,6 +462,7 @@ describe("/api/v1/planning", () => {
       ],
       skipped_operations: [],
     });
+    expect(eventInsertValues?.[12]).toBe("2026-02-14T08:54:00.000Z");
   });
 
   it("POST /api/v1/planning/autoplan reports an OF with no plannable operations", async () => {
@@ -475,6 +490,47 @@ describe("/api/v1/planning", () => {
       ],
       summary: { requested_ofs: 1, created: 0, skipped: 1, partial: false },
     });
+  });
+
+  it("POST /api/v1/planning/autoplan refuses to fabricate a missing operation duration", async () => {
+    mocks.poolQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          of_id: "7",
+          of_numero: "OF-7",
+          of_priority: "NORMAL",
+          of_operation_id: "44444444-4444-4444-4444-444444444444",
+          phase: 10,
+          designation: "Usinage",
+          planned_duration_minutes: null,
+          status: "TODO",
+          machine_id: "11111111-1111-1111-1111-111111111111",
+          poste_id: null,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post("/api/v1/planning/autoplan")
+      .set("Authorization", "Bearer fake")
+      .send({
+        of_ids: [7],
+        start_ts: "2026-02-14T08:00:00.000Z",
+        step_minutes: 15,
+        skip_planned: true,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      created_events: [],
+      skipped_operations: [{
+        of_id: 7,
+        of_operation_id: "44444444-4444-4444-4444-444444444444",
+        reason: "DURATION_UNAVAILABLE",
+      }],
+      summary: { requested_ofs: 1, created: 0, skipped: 1, partial: false },
+    });
+    expect(mocks.clientQuery).not.toHaveBeenCalled();
   });
 
   it("POST /api/v1/planning/events promotes commande to PLANIFIEE and creates notifications", async () => {
@@ -536,11 +592,28 @@ describe("/api/v1/planning", () => {
               code: "P01",
               label: "Poste 1",
               is_active: true,
-              machine_id: null,
-              machine_code: null,
-              machine_status: null,
-              machine_is_available: null,
-              machine_scheduling_enabled: null,
+              machine_id: "11111111-1111-1111-1111-111111111111",
+              machine_code: "M01",
+              machine_status: "ACTIVE",
+              machine_is_available: true,
+              machine_scheduling_enabled: true,
+            },
+          ],
+        };
+      }
+      if (
+        q.includes("required_machine_family_code") &&
+        q.includes("FROM public.of_operations op") &&
+        q.includes("WHERE op.id = $1::uuid")
+      ) {
+        return {
+          rows: [
+            {
+              operation_id: "44444444-4444-4444-4444-444444444444",
+              required_machine_family_code: "TOURNAGE",
+              machine_id: "11111111-1111-1111-1111-111111111111",
+              machine_code: "M01",
+              machine_family_code: "TOURNAGE",
             },
           ],
         };

--- a/src/__tests__/procurement-reliability-sol18.migration-guards.test.ts
+++ b/src/__tests__/procurement-reliability-sol18.migration-guards.test.ts
@@ -18,6 +18,12 @@ describe("SOL-18 procurement migration guards", () => {
     expect(patch).toContain("reason_code = 'SUPPLIER_ACKNOWLEDGEMENT' OR previous_date IS DISTINCT FROM promised_date");
   });
 
+  it("keeps the command receipt ledger least-privilege", () => {
+    expect(patch).toContain("REVOKE ALL ON TABLE public.procurement_command_receipts FROM PUBLIC, cerp_app");
+    expect(patch).toContain("GRANT SELECT, INSERT ON TABLE public.procurement_command_receipts TO cerp_app");
+    expect(patch).not.toMatch(/GRANT\s+[^;]*(?:UPDATE|DELETE)[^;]*ON TABLE public\.procurement_command_receipts/i);
+  });
+
   it("does not fabricate historical promises, invoices, returns or credits", () => {
     expect(patch).not.toMatch(/INSERT\s+INTO\s+public\.procurement_promised_date_events\s+SELECT/i);
     expect(patch).not.toMatch(/supplier_invoice|facture_fournisseur|supplier_return/i);

--- a/src/__tests__/production-of-170.routes.test.ts
+++ b/src/__tests__/production-of-170.routes.test.ts
@@ -135,13 +135,33 @@ beforeEach(() => {
 });
 
 describe("#170 OF state machine + optimistic lock (PATCH /production/ofs/:id)", () => {
-  function installOfForUpdate(params: { statut: string; updated_at?: string }) {
+  function installOfForUpdate(params: {
+    statut: string;
+    updated_at?: string;
+    quantite_bonne?: number;
+    received_qty_ok?: number;
+    invalid_receipt_count?: number;
+  }) {
     mocks.clientQuery.mockImplementation(async (sql: unknown) => {
       const q = String(sql);
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
       if (q.includes("FROM ordres_fabrication") && q.includes("FOR UPDATE")) {
         return {
-          rows: [{ id: "5", commande_id: null, statut: params.statut, updated_at: params.updated_at ?? OF_UPDATED_AT }],
+          rows: [{
+            id: "5",
+            commande_id: null,
+            statut: params.statut,
+            quantite_bonne: params.quantite_bonne ?? 0,
+            updated_at: params.updated_at ?? OF_UPDATED_AT,
+          }],
+        };
+      }
+      if (q.includes("FROM public.of_receipts r")) {
+        return {
+          rows: [{
+            received_qty_ok: params.received_qty_ok ?? 0,
+            invalid_receipt_count: params.invalid_receipt_count ?? 0,
+          }],
         };
       }
       if (q.includes("UPDATE ordres_fabrication SET")) return { rows: [{ id: "5" }] };
@@ -166,6 +186,53 @@ describe("#170 OF state machine + optimistic lock (PATCH /production/ofs/:id)", 
       .patch("/api/v1/production/ofs/5")
       .send({ statut: "PLANIFIE", expected_updated_at: OF_UPDATED_AT });
     expect(res.status).toBe(200);
+  });
+
+  it("refuses TERMINE -> CLOTURE until every good part has a posted stock receipt", async () => {
+    installOfForUpdate({ statut: "TERMINE", quantite_bonne: 2, received_qty_ok: 0 });
+    const res = await request(app)
+      .patch("/api/v1/production/ofs/5")
+      .send({ statut: "CLOTURE", expected_updated_at: OF_UPDATED_AT });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      code: "OF_RECEIPT_INCOMPLETE",
+      details: {
+        declared_qty_ok: 2,
+        received_qty_ok: 0,
+        remaining_qty_ok: 2,
+        invalid_receipt_count: 0,
+      },
+    });
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("UPDATE ordres_fabrication SET"))).toBe(false);
+  });
+
+  it("accepts TERMINE -> CLOTURE after the posted receipt ledger covers the good quantity", async () => {
+    installOfForUpdate({ statut: "TERMINE", quantite_bonne: 2, received_qty_ok: 2 });
+    const res = await request(app)
+      .patch("/api/v1/production/ofs/5")
+      .send({ statut: "CLOTURE", expected_updated_at: OF_UPDATED_AT });
+
+    expect(res.status).toBe(200);
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("UPDATE ordres_fabrication SET"))).toBe(true);
+  });
+
+  it("refuses closure when a receipt is not backed by a valid posted movement", async () => {
+    installOfForUpdate({
+      statut: "TERMINE",
+      quantite_bonne: 2,
+      received_qty_ok: 2,
+      invalid_receipt_count: 1,
+    });
+    const res = await request(app)
+      .patch("/api/v1/production/ofs/5")
+      .send({ statut: "CLOTURE", expected_updated_at: OF_UPDATED_AT });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      code: "OF_RECEIPT_INCOMPLETE",
+      details: { invalid_receipt_count: 1 },
+    });
   });
 
   it("rejects a stale optimistic token with 409 CONCURRENT_MODIFICATION", async () => {
@@ -754,6 +821,48 @@ describe("#170 bounded production receipt", () => {
     quality_status: "LIBERE",
     expected_of_updated_at: OF_UPDATED_AT,
   } as const;
+
+  it("loads the receipt context with the canonical magasin columns", async () => {
+    mocks.poolQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q.includes("FROM public.ordres_fabrication o")) {
+        return {
+          rows: [{
+            id: "5",
+            numero: "OF-2026-000005",
+            piece_technique_id: PIECE_ROOT,
+            article_id: "11111111-1111-1111-1111-111111111111",
+            piece_code: "PT-ROOT",
+            piece_designation: "Piece mere",
+            quantite_lancee: 2,
+            quantite_bonne: 2,
+            statut: "TERMINE",
+            updated_at: OF_UPDATED_AT,
+            affaire_id: null,
+            commande_id: null,
+            commande_ligne_id: null,
+          }],
+        };
+      }
+      if (q.includes("SELECT unite FROM public.articles")) return { rows: [{ unite: "u" }] };
+      if (q.includes("FROM public.erp_settings")) return { rows: [] };
+      if (q.includes("FROM public.magasins m") && q.includes("WHERE m.is_active = true")) {
+        expect(q).toContain("m.code");
+        expect(q).toContain("m.name");
+        expect(q).not.toContain("code_magasin");
+        expect(q).not.toContain("m.libelle");
+        return { rows: [{ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", code: "PF", name: "Produits finis", is_active: true }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app).get("/api/v1/production/ofs/5/receipt-context");
+
+    expect(res.status).toBe(200);
+    expect(res.body.locations.magasins).toEqual([
+      { id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", code: "PF", name: "Produits finis", is_active: true },
+    ]);
+  });
 
   function installReceiptMocks(params: { statut: string; quantite_bonne: number; already: number }) {
     mocks.clientQuery.mockImplementation(async (sql: unknown) => {

--- a/src/__tests__/upload-scanner-docker.contract.test.ts
+++ b/src/__tests__/upload-scanner-docker.contract.test.ts
@@ -79,7 +79,8 @@ describe("autonomous ClamAV Docker contract", () => {
     expect(clamdConfig).toMatch(/AlertExceedsMax\s+yes/);
     expect(clamdConfig).toMatch(/MaxRecursion\s+16/);
     expect(clamdConfig).toMatch(/MaxFiles\s+10000/);
-    expect(freshclamConfig).toMatch(/Checks\s+12/);
+    expect(freshclamConfig).not.toMatch(/^Checks\s+/m);
+    expect(entrypoint).toContain("--checks=12");
     expect(freshclamConfig).toMatch(/NotifyClamd\s+\/etc\/clamav\/clamd\.conf/);
     expect(scannerSmoke).toContain("nestedArchive(20)");
     expect(scannerSmoke).toContain('exceeded.status !== "infected"');

--- a/src/__tests__/upload-scanner-docker.contract.test.ts
+++ b/src/__tests__/upload-scanner-docker.contract.test.ts
@@ -60,11 +60,14 @@ describe("autonomous ClamAV Docker contract", () => {
     expect(entrypoint).toContain('su-exec node "$@"');
     expect(entrypoint).toContain('process_stat=$(cat "/proc/$pid/stat"');
     expect(entrypoint).toContain('process_state=${process_stat%% *}');
-    expect(entrypoint).toContain('wait_for_critical_exit');
+    expect(entrypoint).toContain('while process_is_running "$app_pid"');
+    expect(entrypoint).toContain("API remains fail-closed");
+    expect(entrypoint).toContain("signature freshness is degraded");
+    expect(entrypoint).not.toContain('for pid in "$app_pid" "$clamd_pid" "$freshclam_pid"');
     expect(entrypoint).not.toContain("wait -n");
     expect(entrypoint).toContain('kill -TERM "$pid"');
     expect(entrypoint).toContain('kill -KILL "$pid"');
-    expect(entrypoint).toContain('if [ "$status" -eq 0 ]; then status=1; fi');
+    expect(entrypoint).toContain('if wait "$app_pid"; then status=0; else status=$?; fi');
   });
 
   it("uses a private local socket and bounded resources covering the GED ceiling", () => {
@@ -93,6 +96,7 @@ describe("autonomous ClamAV Docker contract", () => {
     expect(scannerSource).toContain('addEventListener("abort"');
     expect(scannerSource).toContain('child.kill("SIGTERM")');
     expect(scannerSource).toContain('child.kill("SIGKILL")');
+    expect(scannerSource).toContain('process.env.CERP_E2E_CONTAINER !== "1"');
     expect(scannerSource).not.toContain('upload-scanner"), `${randomUUID()}.scan`');
   });
 

--- a/src/config/e2e-isolation.ts
+++ b/src/config/e2e-isolation.ts
@@ -1,18 +1,30 @@
 import path from "node:path";
 
-function isLoopback(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]";
-}
-
-function assertLoopbackUrl(name: string, raw: string | undefined, expectedPath?: string): void {
+function assertAllowedUrl(
+  name: string,
+  raw: string | undefined,
+  allowedHosts: ReadonlySet<string>,
+  expectedPath?: string
+): void {
   if (!raw) throw new Error(`[SOL-05 isolation] ${name} is required`);
   const parsed = new URL(raw);
-  if (!isLoopback(parsed.hostname)) {
-    throw new Error(`[SOL-05 isolation] ${name} must use a loopback host, received ${parsed.hostname}`);
+  if (!allowedHosts.has(parsed.hostname)) {
+    throw new Error(`[SOL-05 isolation] ${name} host is forbidden, received ${parsed.hostname}`);
   }
   if (expectedPath !== undefined && parsed.pathname !== expectedPath) {
     throw new Error(`[SOL-05 isolation] ${name} must target ${expectedPath}, received ${parsed.pathname}`);
   }
+}
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+function isManagedE2EContainer(env: NodeJS.ProcessEnv): boolean {
+  return env.CERP_E2E_MANAGED_STACK === "1" && env.CERP_E2E_CONTAINER === "1";
+}
+
+export function e2eListenHost(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.CERP_E2E_ISOLATED !== "1") return "0.0.0.0";
+  return isManagedE2EContainer(env) ? "0.0.0.0" : "127.0.0.1";
 }
 
 export function assertE2EIsolation(env: NodeJS.ProcessEnv = process.env): void {
@@ -21,18 +33,29 @@ export function assertE2EIsolation(env: NodeJS.ProcessEnv = process.env): void {
     throw new Error(`[SOL-05 isolation] NODE_ENV=test is required, received ${env.NODE_ENV ?? "unset"}`);
   }
 
-  assertLoopbackUrl("DATABASE_URL", env.DATABASE_URL, "/cerp_test");
-  assertLoopbackUrl("FRONTEND_URL", env.FRONTEND_URL);
-  assertLoopbackUrl("BACKEND_URL", env.BACKEND_URL);
+  if (env.CERP_E2E_CONTAINER === "1" && env.CERP_E2E_MANAGED_STACK !== "1") {
+    throw new Error("[SOL-05 isolation] container mode requires CERP_E2E_MANAGED_STACK=1");
+  }
+
+  const managedContainer = isManagedE2EContainer(env);
+  const databaseHosts = managedContainer ? new Set(["postgres"]) : LOOPBACK_HOSTS;
+
+  assertAllowedUrl("DATABASE_URL", env.DATABASE_URL, databaseHosts, "/cerp_test");
+  assertAllowedUrl("FRONTEND_URL", env.FRONTEND_URL, LOOPBACK_HOSTS);
+  assertAllowedUrl("BACKEND_URL", env.BACKEND_URL, LOOPBACK_HOSTS);
 
   for (const origin of (env.CORS_ORIGINS ?? "").split(",").map((value) => value.trim()).filter(Boolean)) {
-    assertLoopbackUrl("CORS_ORIGINS", origin);
+    assertAllowedUrl("CORS_ORIGINS", origin, LOOPBACK_HOSTS);
   }
   if (env.RESEND_API_KEY || env.RESEND_FROM || env.RESEND_API_BASE_URL) {
     if (env.CERP_E2E_EMAIL_SINK !== "1" || !env.RESEND_API_KEY || !env.RESEND_FROM) {
       throw new Error("[SOL-05 isolation] outbound email credentials are forbidden");
     }
-    assertLoopbackUrl("RESEND_API_BASE_URL", env.RESEND_API_BASE_URL);
+    assertAllowedUrl(
+      "RESEND_API_BASE_URL",
+      env.RESEND_API_BASE_URL,
+      managedContainer ? new Set(["host.docker.internal"]) : LOOPBACK_HOSTS
+    );
     if (!env.RESEND_FROM.toLowerCase().includes("@example.local")) {
       throw new Error("[SOL-05 isolation] RESEND_FROM must use example.local");
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import { createServer } from "http";
 
 import pool from "./config/database";
-import { assertE2EIsolation } from "./config/e2e-isolation";
+import { assertE2EIsolation, e2eListenHost } from "./config/e2e-isolation";
 import { assertMfaStartupConfiguration } from "./module/auth/domain/mfa";
 import { startAuthRateLimitMaintenance } from "./module/auth/services/auth-rate-limit.service";
 import { startMfaArtifactMaintenance } from "./module/auth/services/mfa.service";
@@ -54,7 +54,7 @@ async function start(): Promise<void> {
   initSocketServer(httpServer);
   const stopExpiredLockMaintenance = startExpiredLockMaintenance();
 
-  const listenHost = process.env.CERP_E2E_ISOLATED === "1" ? "127.0.0.1" : "0.0.0.0";
+  const listenHost = e2eListenHost();
   httpServer.listen(port, listenHost, () => {
     logger.info("upload_scanner_initialized", {
       mode: uploadScanner.mode,

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -132,6 +132,19 @@ const PUBLIC_OPERATIONAL_5XX_MESSAGES = new Map<string, string>([
   ],
 ]);
 
+const PUBLIC_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function publicOperational5xxDetails(error: unknown, code: string): Record<string, string> | undefined {
+  if (!(error instanceof HttpError) || code !== "GED_SCAN_FAILED") return undefined;
+  if (!error.details || typeof error.details !== "object") return undefined;
+  const details = error.details as Record<string, unknown>;
+  return typeof details.quarantine_id === "string"
+    && PUBLIC_UUID.test(details.quarantine_id)
+    && details.state === "quarantined"
+    ? { quarantine_id: details.quarantine_id, state: "quarantined" }
+    : undefined;
+}
+
 export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction) {
   const mappedReferenceDataError = mapReferenceDataError(err);
   const handledError = mappedReferenceDataError ?? err;
@@ -152,6 +165,9 @@ export function errorHandler(err: unknown, req: Request, res: Response, _next: N
   // Path sans query string : les recherches métier mettent des PII en query
   // (?q=email, ?siret=...) ; ni la réponse ni les logs ne doivent les rejouer.
   const safePath = stripQueryFromUrl(req.originalUrl);
+  const publicDetails = handledError instanceof HttpError && status < 500
+    ? handledError.details
+    : publicOperational5xxDetails(handledError, code);
 
   // details : uniquement pour les erreurs 4xx construites volontairement (HttpError/ApiError
   // avec details explicites, ex. 409 doublon SIRET -> { client_id, company_name }). Jamais pour
@@ -161,8 +177,8 @@ export function errorHandler(err: unknown, req: Request, res: Response, _next: N
     message,
     code,
     path: safePath,
-    ...(handledError instanceof HttpError && status < 500 && typeof handledError.details !== "undefined"
-      ? { details: handledError.details }
+    ...(typeof publicDetails !== "undefined"
+      ? { details: publicDetails }
       : {}),
   };
 

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -124,6 +124,12 @@ const PUBLIC_OPERATIONAL_5XX_MESSAGES = new Map<string, string>([
   ["OF_DOCUMENT_COMMIT_NOT_APPLIED",
     "L’émission du document OF n’a pas été appliquée. Vous pouvez réessayer.",
   ],
+  ["DEVIS_SCHEMA_NOT_READY",
+    "La création de devis est temporairement indisponible : le schéma commercial doit être mis à niveau. Contactez l’administrateur avant de réessayer.",
+  ],
+  ["DEVIS_IDEMPOTENCY_NOT_READY",
+    "La création de devis est temporairement indisponible : le registre d’idempotence doit être mis à niveau. Contactez l’administrateur avant de réessayer.",
+  ],
 ]);
 
 export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction) {

--- a/src/module/access-control/domain/module-catalog.ts
+++ b/src/module/access-control/domain/module-catalog.ts
@@ -30,7 +30,9 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
     label: "Devis",
     description: "Chiffrage et cycle de vie des devis clients.",
     category: "Commerce",
-    api_prefixes: ["/devis"],
+    // Les référentiels de création de devis restent sur leurs URL historiques
+    // afin que les clients existants puissent les consommer sans contournement.
+    api_prefixes: ["/devis", "/conditions-paiement", "/compte-vente"],
     nav_page_keys: ["devis"],
     is_protected: false,
     sort_order: 20,

--- a/src/module/client-portal/repository/client-portal.repository.ts
+++ b/src/module/client-portal/repository/client-portal.repository.ts
@@ -115,11 +115,17 @@ async function readReceipt(
   idempotencyKey: string,
   requestHash: string
 ): Promise<JsonObject | null> {
+  // Receipts are append-only: the application role intentionally has no UPDATE
+  // grant on this table. A transaction-scoped advisory lock serializes retries
+  // without turning this read into a row lock (which would require UPDATE).
+  await tx.query(
+    `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+    [`client-portal-command:${actorId}:${action}:${idempotencyKey}`]
+  );
   const result = await tx.query<{ request_sha256: string; result: JsonObject }>(
     `SELECT request_sha256, result
        FROM public.client_portal_command_receipts
-      WHERE erp_actor_id=$1 AND action=$2 AND idempotency_key=$3::uuid
-      FOR SHARE`,
+      WHERE erp_actor_id=$1 AND action=$2 AND idempotency_key=$3::uuid`,
     [actorId, action, idempotencyKey]
   );
   const row = result.rows[0];

--- a/src/module/commercial-references/controllers/commercial-references.controller.ts
+++ b/src/module/commercial-references/controllers/commercial-references.controller.ts
@@ -1,0 +1,18 @@
+import type { RequestHandler } from "express";
+import { repoListComptesVente, repoListConditionsPaiement } from "../repository/commercial-references.repository";
+
+export const listConditionsPaiement: RequestHandler = async (_req, res, next) => {
+  try {
+    res.json(await repoListConditionsPaiement());
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const listComptesVente: RequestHandler = async (_req, res, next) => {
+  try {
+    res.json(await repoListComptesVente());
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/module/commercial-references/repository/commercial-references.repository.ts
+++ b/src/module/commercial-references/repository/commercial-references.repository.ts
@@ -1,0 +1,49 @@
+export type CommercialReferenceAvailability = "NOT_CONFIGURED";
+
+/** Mirrors the existing frontend option shape without inventing a row. */
+export type ConditionsPaiementResponse = {
+  items: Array<{ id: number; code: string; libelle: string }>;
+  availability: CommercialReferenceAvailability;
+  message: string;
+  source: null;
+  freshness_at: null;
+  reliability: "UNAVAILABLE";
+};
+
+/** Kept distinct because the existing UI uses legacy Compte_Vente field names. */
+export type ComptesVenteResponse = {
+  items: Array<{ seller_account_id: string; label: string; account: string }>;
+  availability: CommercialReferenceAvailability;
+  message: string;
+  source: null;
+  freshness_at: null;
+  reliability: "UNAVAILABLE";
+};
+
+/**
+ * Aucun modèle métier versionné de conditions de paiement n'existe dans ce
+ * dépôt. Le contrat explicite évite de fabriquer un référentiel financier ou
+ * de présenter des valeurs de démonstration comme des données réelles.
+ */
+export async function repoListConditionsPaiement(): Promise<ConditionsPaiementResponse> {
+  return {
+    items: [],
+    availability: "NOT_CONFIGURED",
+    message: "Les conditions de paiement ne sont pas encore configurées.",
+    source: null,
+    freshness_at: null,
+    reliability: "UNAVAILABLE",
+  };
+}
+
+/** Same explicit contract for the ungoverned historic Compte_Vente shape. */
+export async function repoListComptesVente(): Promise<ComptesVenteResponse> {
+  return {
+    items: [],
+    availability: "NOT_CONFIGURED",
+    message: "Les comptes de vente ne sont pas encore configurés.",
+    source: null,
+    freshness_at: null,
+    reliability: "UNAVAILABLE",
+  };
+}

--- a/src/module/commercial-references/routes/commercial-references.routes.ts
+++ b/src/module/commercial-references/routes/commercial-references.routes.ts
@@ -1,0 +1,22 @@
+import { Router, type RequestHandler } from "express";
+import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import { roleHasDevisCapability } from "../../devis/domain/devis-rbac";
+import { listComptesVente, listConditionsPaiement } from "../controllers/commercial-references.controller";
+
+const router = Router();
+
+// These options are part of the quote-entry boundary. The legacy URLs are kept
+// intentionally, but they have the same server-side read permission as Devis.
+const requireDevisRead: RequestHandler = (req, _res, next) => {
+  if (requestHasGrantedAccountModuleAccess(req) || roleHasDevisCapability(req.user?.role, "read")) {
+    next();
+    return;
+  }
+  next(new HttpError(403, "FORBIDDEN", "Votre rôle ne permet pas de consulter les référentiels de devis."));
+};
+
+router.get("/conditions-paiement", requireDevisRead, listConditionsPaiement);
+router.get("/compte-vente", requireDevisRead, listComptesVente);
+
+export default router;

--- a/src/module/commercial-reliability/repository/commercial-reliability.repository.test.ts
+++ b/src/module/commercial-reliability/repository/commercial-reliability.repository.test.ts
@@ -79,6 +79,9 @@ describe("SOL-17 order cancellation transaction", () => {
 
     await expect(cancel()).resolves.toEqual({ commande_id: 9, status: "ANNULE", idempotent_replay: false });
 
+    expect(query.mock.calls.filter(([sql]) => String(sql).includes("pg_advisory_xact_lock"))).toHaveLength(1);
+    const receiptRead = query.mock.calls.find(([sql]) => String(sql).includes("FROM public.commercial_command_receipts"));
+    expect(String(receiptRead?.[0])).not.toContain("FOR SHARE");
     expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.commercial_order_cancellations"))).toHaveLength(1);
     expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.commande_historique"))).toHaveLength(1);
     expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.commande_client_event_log"))).toHaveLength(1);

--- a/src/module/commercial-reliability/repository/commercial-reliability.repository.ts
+++ b/src/module/commercial-reliability/repository/commercial-reliability.repository.ts
@@ -89,11 +89,20 @@ async function readReceipt<T>(
   idempotencyKey: string,
   requestHash: string,
 ): Promise<T | null> {
+  // The receipt ledger is intentionally append-only: the runtime role owns
+  // SELECT + INSERT, but never UPDATE. PostgreSQL row locks (FOR SHARE/UPDATE)
+  // require UPDATE privilege even when no row is changed, so they break the
+  // least-privilege contract. A transaction-scoped advisory lock serialises
+  // the same action/key without weakening the ledger ACL. Once the first
+  // transaction commits, the waiter reads and replays its immutable receipt.
+  await tx.query(
+    "SELECT pg_advisory_xact_lock(hashtextextended($1, 20260812))",
+    [`commercial-reliability:${action}:${idempotencyKey}`],
+  );
   const result = await tx.query<{ request_hash: string; response_snapshot: T }>(
     `SELECT request_hash, response_snapshot
      FROM public.commercial_command_receipts
-     WHERE action=$1 AND idempotency_key=$2
-     FOR SHARE`,
+     WHERE action=$1 AND idempotency_key=$2`,
     [action, idempotencyKey],
   );
   const row = result.rows[0];

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -307,7 +307,7 @@ async function recordConvertedDevisIdempotence(
   await readDevisIdempotentReplay(tx, key, "CONVERT", payloadHash);
 }
 
-/** La table d'idempotence arrive par patch 20260722 : absence tolérée (comportement historique). */
+/** La table d'idempotence arrive par patch 20260722. */
 async function hasDevisIdempotenceTable(client: DbQueryer): Promise<boolean> {
   const res = await client.query<{ exists: boolean }>(
     `SELECT EXISTS (
@@ -367,6 +367,49 @@ function getPgErrorInfo(err: unknown) {
   const code = typeof err.code === "string" ? err.code : null;
   const constraint = typeof err.constraint === "string" ? err.constraint : null;
   return { code, constraint };
+}
+
+/**
+ * Création = écriture critique : une clé et son registre transactionnel sont
+ * obligatoires. Sans ce garde-fou, un retry réseau peut créer un second devis.
+ */
+async function requireCreateDevisIdempotence(
+  client: DbQueryer,
+  key: string | undefined,
+  payloadHash: string | null
+): Promise<{ key: string; payloadHash: string }> {
+  if (!key || !payloadHash) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_REQUIRED",
+      "L’en-tête Idempotency-Key (au moins 8 caractères) est obligatoire pour créer un devis."
+    );
+  }
+  if (!(await hasDevisIdempotenceTable(client))) {
+    throw new HttpError(
+      503,
+      "DEVIS_IDEMPOTENCY_NOT_READY",
+      "Le registre d’idempotence des devis n’est pas disponible."
+    );
+  }
+  return { key, payloadHash };
+}
+
+/**
+ * Une migration commerciale partielle ne doit jamais se présenter comme une
+ * erreur applicative indéterminée. On limite volontairement ce mapping aux
+ * relations et colonnes nécessaires à l'écriture d'un devis : les autres
+ * erreurs PostgreSQL conservent leur traitement normal et leurs diagnostics
+ * restent uniquement dans les logs structurés.
+ */
+function isDevisWriteSchemaError(err: unknown): boolean {
+  if (!isRecord(err) || typeof err.code !== "string") return false;
+  if (!new Set(["42P01", "42703", "42501"]).has(err.code)) return false;
+  const source = [err.table, err.column, err.constraint, err.message]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+  return /\b(devis|devis_ligne|article_devis|dossier_technique_piece_devis|devis_idempotence)\b/.test(source);
 }
 
 function normalizeStatus(value: unknown) {
@@ -1711,13 +1754,11 @@ export async function repoCreateDevis(
       files: documents,
       context: "devis.create",
       work: async () => {
-
-    if (ctx.idempotency_key && idempotencyPayloadHash && (await hasDevisIdempotenceTable(client))) {
-      const replay = await readDevisIdempotentReplay(client, ctx.idempotency_key, "CREATE", idempotencyPayloadHash);
-      if (replay) {
-        expectedMutation = { mode: "replay", devisId: Number(replay.id) };
-        return replay as { id: number; idempotent_replay: true };
-      }
+    const idempotency = await requireCreateDevisIdempotence(client, ctx.idempotency_key, idempotencyPayloadHash);
+    const replay = await readDevisIdempotentReplay(client, idempotency.key, "CREATE", idempotency.payloadHash);
+    if (replay) {
+      expectedMutation = { mode: "replay", devisId: Number(replay.id) };
+      return replay as { id: number; idempotent_replay: true };
     }
 
     // #167 : l'automate démarre en BROUILLON ; ENVOYE reste accepté (saisie a posteriori
@@ -1826,9 +1867,7 @@ export async function repoCreateDevis(
       parentDevisId: null,
       versionNumber: 1,
     };
-    if (ctx.idempotency_key && idempotencyPayloadHash && (await hasDevisIdempotenceTable(client))) {
-      await recordDevisIdempotence(client, ctx.idempotency_key, "CREATE", resultat.id, idempotencyPayloadHash, resultat);
-    }
+    await recordDevisIdempotence(client, idempotency.key, "CREATE", resultat.id, idempotency.payloadHash, resultat);
 
     return { ...resultat, idempotent_replay: false };
       },
@@ -1843,6 +1882,13 @@ export async function repoCreateDevis(
     if (ctx.idempotency_key && idempotencyPayloadHash && code === "23505" && constraint === "devis_idempotence_pkey") {
       const replay = await readDevisIdempotentReplay(pool, ctx.idempotency_key, "CREATE", idempotencyPayloadHash);
       if (replay) return replay as { id: number; idempotent_replay: true };
+    }
+    if (isDevisWriteSchemaError(err)) {
+      throw new HttpError(
+        503,
+        "DEVIS_SCHEMA_NOT_READY",
+        "La création de devis requiert une migration commerciale complète."
+      );
     }
     throw err;
   }

--- a/src/module/ged/services/ged.service.ts
+++ b/src/module/ged/services/ged.service.ts
@@ -343,7 +343,8 @@ async function prepareDeferredScan(
   throw new HttpError(
     503,
     "GED_SCAN_FAILED",
-    "Le verdict antivirus n'a pas pu être obtenu. Le fichier reste isolé en quarantaine."
+    "Le verdict antivirus n'a pas pu être obtenu. Le fichier reste isolé en quarantaine.",
+    { quarantine_id: pending.id, state: "quarantined" }
   );
 }
 

--- a/src/module/planning/repository/planning-machine-qualification.test.ts
+++ b/src/module/planning/repository/planning-machine-qualification.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertCommandePlanningResourcesCompatible,
+  assertOperationResourceCompatible,
+} from "./planning.repository";
+
+const operationId = "44444444-4444-4444-8444-444444444444";
+const machineId = "11111111-1111-4111-8111-111111111111";
+const pieceId = "22222222-2222-4222-8222-222222222222";
+
+function queryer(row: Record<string, unknown>) {
+  return { query: vi.fn().mockResolvedValue({ rows: [row] }) };
+}
+
+async function expectCode(row: Record<string, unknown>, code: string) {
+  const tx = queryer(row);
+  await expect(assertOperationResourceCompatible({
+    tx,
+    of_operation_id: operationId,
+    resource: { machine_id: machineId, poste_id: null },
+  })).rejects.toMatchObject({ status: 422, code });
+}
+
+describe("planning machine qualification invariant", () => {
+  it("blocks an operation whose required family is not qualified", async () => {
+    await expectCode({
+      operation_id: operationId,
+      piece_technique_id: pieceId,
+      required_machine_family_code: null,
+      machine_id: machineId,
+      machine_code: "M-01",
+      machine_family_code: "TOURNAGE",
+    }, "PLANNING_OPERATION_FAMILY_REQUIRED");
+  });
+
+  it("blocks a machine without a declared family", async () => {
+    await expectCode({
+      operation_id: operationId,
+      piece_technique_id: pieceId,
+      required_machine_family_code: "TOURNAGE",
+      machine_id: machineId,
+      machine_code: "M-01",
+      machine_family_code: null,
+    }, "PLANNING_MACHINE_QUALIFICATION_REQUIRED");
+  });
+
+  it("blocks an incompatible family", async () => {
+    await expectCode({
+      operation_id: operationId,
+      piece_technique_id: pieceId,
+      required_machine_family_code: "TOURNAGE",
+      machine_id: machineId,
+      machine_code: "M-01",
+      machine_family_code: "FRAISAGE",
+    }, "PLANNING_MACHINE_FAMILY_INCOMPATIBLE");
+  });
+
+  it("accepts an explicitly matching family", async () => {
+    const tx = queryer({
+      operation_id: operationId,
+      piece_technique_id: pieceId,
+      required_machine_family_code: "tournage",
+      machine_id: machineId,
+      machine_code: "M-01",
+      machine_family_code: "TOURNAGE",
+    });
+    await expect(assertOperationResourceCompatible({
+      tx,
+      of_operation_id: operationId,
+      resource: { machine_id: machineId, poste_id: null },
+    })).resolves.toBeUndefined();
+  });
+
+  it("reuses the same qualification invariant before validating a customer order", async () => {
+    const tx = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [{ of_operation_id: operationId, machine_id: machineId, poste_id: null }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{
+            operation_id: operationId,
+            piece_technique_id: pieceId,
+            required_machine_family_code: "TOURNAGE",
+            machine_id: machineId,
+            machine_code: "M-01",
+            machine_family_code: null,
+          }],
+        }),
+    };
+
+    await expect(assertCommandePlanningResourcesCompatible({ tx, commande_id: 42 }))
+      .rejects.toMatchObject({ status: 422, code: "PLANNING_MACHINE_QUALIFICATION_REQUIRED" });
+  });
+});

--- a/src/module/planning/repository/planning.repository.ts
+++ b/src/module/planning/repository/planning.repository.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../shared/realtime/realtime-outbox.service";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
+import { PLANNED_OPERATION_DURATION_MINUTES_SQL } from "../../production/domain/planned-operation-duration";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import { repoApplyCommandeWorkflowMilestone } from "../../commande-client/repository/commande-client.repository";
@@ -538,6 +539,7 @@ async function selectOfOperationDefaults(q: DbQueryer, opId: string): Promise<{
   designation: string;
   machine_id: string | null;
   poste_id: string | null;
+  machine_family_code: string | null;
 } | null> {
   type Row = {
     of_id: string;
@@ -545,6 +547,7 @@ async function selectOfOperationDefaults(q: DbQueryer, opId: string): Promise<{
     designation: string;
     machine_id: string | null;
     poste_id: string | null;
+    machine_family_code: string | null;
   };
 
   const res = await q.query<Row>(
@@ -554,7 +557,8 @@ async function selectOfOperationDefaults(q: DbQueryer, opId: string): Promise<{
         op.phase::int AS phase,
         op.designation,
         op.machine_id::text AS machine_id,
-        op.poste_id::text AS poste_id
+        op.poste_id::text AS poste_id,
+        NULLIF(btrim(op.machine_family_code), '') AS machine_family_code
       FROM public.of_operations op
       WHERE op.id = $1::uuid
       LIMIT 1
@@ -571,6 +575,7 @@ async function selectOfOperationDefaults(q: DbQueryer, opId: string): Promise<{
     designation: row.designation,
     machine_id: row.machine_id,
     poste_id: row.poste_id,
+    machine_family_code: row.machine_family_code,
   };
 }
 
@@ -602,6 +607,191 @@ function resolveResource(params: {
   if (op.machine_id) return { machine_id: op.machine_id, poste_id: null };
 
   throw new HttpError(400, "MISSING_RESOURCE", "Operation has no machine/poste assigned; choose a resource");
+}
+
+/**
+ * A planning resource may be a poste backed by a machine.  An OF operation is
+ * only assignable when its frozen machine-family requirement matches that
+ * machine's explicit, human-qualified family.  We intentionally do not infer
+ * a family from machine type, label, or historical qualifications.
+ */
+export async function assertOperationResourceCompatible(params: {
+  tx: DbQueryer;
+  of_operation_id: string | null;
+  resource: { machine_id: string | null; poste_id: string | null };
+}): Promise<void> {
+  if (!params.of_operation_id) return;
+
+  const res = await params.tx.query<{
+    operation_id: string;
+    piece_technique_id: string;
+    required_machine_family_code: string | null;
+    machine_id: string | null;
+    machine_code: string | null;
+    machine_family_code: string | null;
+  }>(
+    `
+      SELECT
+        op.id::text AS operation_id,
+        o.piece_technique_id::text AS piece_technique_id,
+        NULLIF(btrim(op.machine_family_code), '') AS required_machine_family_code,
+        m.id::text AS machine_id,
+        m.code AS machine_code,
+        NULLIF(btrim(m.machine_family_code), '') AS machine_family_code
+      FROM public.of_operations op
+      JOIN public.ordres_fabrication o ON o.id = op.of_id
+      LEFT JOIN public.postes p ON p.id = $3::uuid
+      LEFT JOIN public.machines m ON m.id = COALESCE($2::uuid, p.machine_id)
+      WHERE op.id = $1::uuid
+      LIMIT 1
+    `,
+    [params.of_operation_id, params.resource.machine_id, params.resource.poste_id]
+  );
+  const row = res.rows[0] ?? null;
+  if (!row) throw new HttpError(404, "OF_OPERATION_NOT_FOUND", "OF operation not found");
+  if (!row.required_machine_family_code) {
+    throw new HttpError(
+      422,
+      "PLANNING_OPERATION_FAMILY_REQUIRED",
+      "L’opération n’a pas de famille machine qualifiée. Complétez la gamme avant de la planifier.",
+      {
+        operation_id: row.operation_id,
+        piece_technique_id: row.piece_technique_id,
+        remediation_path: `/pieces-techniques/${encodeURIComponent(row.piece_technique_id)}/edit`,
+        action: "Renseignez la famille requise dans la gamme validée, puis relancez la planification.",
+      }
+    );
+  }
+  if (!row.machine_id) {
+    throw new HttpError(422, "PLANNING_MACHINE_QUALIFICATION_REQUIRED", "Cette opération exige une machine qualifiée ; affectez une machine ou un poste rattaché à une machine.", {
+      operation_id: row.operation_id,
+      required_machine_family_code: row.required_machine_family_code,
+      remediation_path: "/methodes/parc-machines",
+      action: "Renseignez une ressource machine qualifiée pour la famille requise.",
+    });
+  }
+  if (!row.machine_family_code) {
+    throw new HttpError(422, "PLANNING_MACHINE_QUALIFICATION_REQUIRED", "La machine sélectionnée n'a pas de famille qualifiée. Qualifiez-la avant de planifier cette opération.", {
+      operation_id: row.operation_id,
+      machine_id: row.machine_id,
+      machine_code: row.machine_code,
+      required_machine_family_code: row.required_machine_family_code,
+      remediation_path: "/methodes/parc-machines",
+      action: "Renseignez la qualification/famille de la machine dans le référentiel Méthodes.",
+    });
+  }
+  if (row.machine_family_code.toLocaleUpperCase("fr-FR") !== row.required_machine_family_code.toLocaleUpperCase("fr-FR")) {
+    throw new HttpError(422, "PLANNING_MACHINE_FAMILY_INCOMPATIBLE", "La famille de la machine est incompatible avec l'opération à planifier.", {
+      operation_id: row.operation_id,
+      machine_id: row.machine_id,
+      machine_code: row.machine_code,
+      required_machine_family_code: row.required_machine_family_code,
+      machine_family_code: row.machine_family_code,
+      remediation_path: "/methodes/parc-machines",
+      action: "Choisissez une machine qualifiée pour la famille requise ou corrigez la gamme validée.",
+    });
+  }
+}
+
+export async function assertCommandePlanningResourcesCompatible(params: {
+  tx: DbQueryer;
+  commande_id: number;
+}): Promise<void> {
+  const events = await params.tx.query<{
+    of_operation_id: string;
+    machine_id: string | null;
+    poste_id: string | null;
+  }>(
+    `
+      SELECT
+        e.of_operation_id::text AS of_operation_id,
+        e.machine_id::text AS machine_id,
+        e.poste_id::text AS poste_id
+      FROM public.planning_events e
+      JOIN public.of_operations op ON op.id = e.of_operation_id
+      JOIN public.ordres_fabrication o ON o.id = COALESCE(e.of_id, op.of_id)
+      WHERE o.commande_id = $1::bigint
+        AND e.archived_at IS NULL
+        AND e.status <> 'CANCELLED'::planning_event_status
+      ORDER BY e.start_ts ASC, e.id ASC
+    `,
+    [params.commande_id]
+  );
+
+  for (const event of events.rows) {
+    await assertOperationResourceCompatible({
+      tx: params.tx,
+      of_operation_id: event.of_operation_id,
+      resource: { machine_id: event.machine_id, poste_id: event.poste_id },
+    });
+  }
+}
+
+async function syncPlanningCoordinates(params: {
+  tx: DbQueryer;
+  of_operation_id: string | null;
+  of_id: number | null;
+}): Promise<void> {
+  if (params.of_operation_id) {
+    await params.tx.query(
+      `
+        WITH source AS (
+          SELECT
+            (ARRAY_AGG(e.machine_id ORDER BY e.updated_at DESC, e.id DESC))[1] AS machine_id,
+            (ARRAY_AGG(e.poste_id ORDER BY e.updated_at DESC, e.id DESC))[1] AS poste_id
+          FROM public.planning_events e
+          WHERE e.of_operation_id = $1::uuid
+            AND e.archived_at IS NULL
+            AND e.status <> 'CANCELLED'::planning_event_status
+        )
+        UPDATE public.of_operations op
+        SET machine_id = source.machine_id,
+            poste_id = source.poste_id,
+            updated_at = now()
+        FROM source
+        WHERE op.id = $1::uuid
+          AND (op.machine_id, op.poste_id) IS DISTINCT FROM (source.machine_id, source.poste_id)
+      `,
+      [params.of_operation_id]
+    );
+  }
+
+  if (typeof params.of_id === "number") {
+    await params.tx.query(
+      `
+        WITH schedule AS (
+          SELECT
+            (MIN(e.start_ts) AT TIME ZONE (
+              SELECT pc.timezone
+              FROM public.programmation_calendars pc
+              WHERE pc.active
+              ORDER BY pc.updated_at DESC, pc.id
+              LIMIT 1
+            ))::date AS start_date,
+            (MAX(e.end_ts) AT TIME ZONE (
+              SELECT pc.timezone
+              FROM public.programmation_calendars pc
+              WHERE pc.active
+              ORDER BY pc.updated_at DESC, pc.id
+              LIMIT 1
+            ))::date AS end_date
+          FROM public.planning_events e
+          LEFT JOIN public.of_operations op ON op.id = e.of_operation_id
+          WHERE e.archived_at IS NULL
+            AND e.status <> 'CANCELLED'::planning_event_status
+            AND COALESCE(e.of_id, op.of_id) = $1::bigint
+        )
+        UPDATE public.ordres_fabrication o
+        SET date_lancement_prevue = schedule.start_date,
+            date_fin_prevue = schedule.end_date,
+            updated_at = now()
+        FROM schedule
+        WHERE o.id = $1::bigint
+          AND (o.date_lancement_prevue, o.date_fin_prevue) IS DISTINCT FROM (schedule.start_date, schedule.end_date)
+      `,
+      [params.of_id]
+    );
+  }
 }
 
 function mapOfOperationStatusToPlanningStatus(status: string | null | undefined): PlanningEventListItem["status"] {
@@ -1034,6 +1224,21 @@ export async function repoValidatePlanningForAr(params: {
         continue;
       }
 
+      try {
+        await assertCommandePlanningResourcesCompatible({ tx: client, commande_id: commandeId });
+      } catch (err) {
+        if (err instanceof HttpError && err.status === 422) {
+          skipped.push({
+            commande_id: commandeId,
+            numero: row.numero,
+            reason: "RESOURCE_QUALIFICATION_REQUIRED",
+            message: err.message,
+          });
+          continue;
+        }
+        throw err;
+      }
+
       await client.query("SAVEPOINT planning_validate_commande");
       let transition;
       await repoAssertPlanningCheckpointAccess({
@@ -1427,7 +1632,7 @@ export async function repoListOfOperationsForAutoplan(params: {
     of_operation_id: string;
     phase: number;
     designation: string;
-    temps_total_planned: number;
+    planned_duration_minutes: number | null;
     status: string;
     machine_id: string | null;
     poste_id: string | null;
@@ -1442,7 +1647,7 @@ export async function repoListOfOperationsForAutoplan(params: {
     of_operation_id: string;
     phase: number;
     designation: string;
-    temps_total_planned: number | string | null;
+    planned_duration_minutes: number | string | null;
     status: string;
     machine_id: string | null;
     poste_id: string | null;
@@ -1457,7 +1662,10 @@ export async function repoListOfOperationsForAutoplan(params: {
         op.id::text AS of_operation_id,
         op.phase::int AS phase,
         op.designation,
-        op.temps_total_planned::float AS temps_total_planned,
+        -- Unit times remain frozen on the OF in decimal hours.  The scheduling
+        -- charge is recomputed from those snapshots and the launched quantity,
+        -- then converted once to minutes (30 min + 12 min x 2 = 54 min).
+        ${PLANNED_OPERATION_DURATION_MINUTES_SQL} AS planned_duration_minutes,
         op.status::text AS status,
         op.machine_id::text AS machine_id,
         op.poste_id::text AS poste_id
@@ -1472,7 +1680,7 @@ export async function repoListOfOperationsForAutoplan(params: {
 
   const prioritySet = new Set(["LOW", "NORMAL", "HIGH", "CRITICAL"]);
   return res.rows.map((r) => {
-    const raw = r.temps_total_planned;
+    const raw = r.planned_duration_minutes;
     const n = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN;
     const ofPriority = typeof r.of_priority === "string" && prioritySet.has(r.of_priority) ? (r.of_priority as PlanningEventListItem["priority"]) : null;
 
@@ -1483,7 +1691,7 @@ export async function repoListOfOperationsForAutoplan(params: {
       of_operation_id: r.of_operation_id,
       phase: r.phase,
       designation: r.designation,
-      temps_total_planned: Number.isFinite(n) ? n : 0,
+      planned_duration_minutes: Number.isFinite(n) ? n : null,
       status: r.status,
       machine_id: r.machine_id,
       poste_id: r.poste_id,
@@ -1630,6 +1838,11 @@ export async function repoCreatePlanningEvent(params: {
     const resource = resolveResource({ machine_id: b.machine_id ?? null, poste_id: b.poste_id ?? null, op });
 
     await assertResourceSchedulable(client, resource);
+    await assertOperationResourceCompatible({
+      tx: client,
+      of_operation_id: b.of_operation_id ?? null,
+      resource,
+    });
 
     if (b.allow_overlap && !roleCanForcePlanningOverlap(params.audit.role)) {
       throw new HttpError(403, "PLANNING_FORCE_OVERLAP_FORBIDDEN", "Only admin or responsable atelier can force overlaps");
@@ -1711,6 +1924,7 @@ export async function repoCreatePlanningEvent(params: {
     let synchronizedOfId = finalOfId;
     let notifications: AppNotification[] = [];
     if (b.of_operation_id) {
+      await syncPlanningCoordinates({ tx: client, of_operation_id: b.of_operation_id, of_id: finalOfId });
       const sync = await syncLinkedOfOperationFromPlanning({
         tx: client,
         of_operation_id: b.of_operation_id,
@@ -1898,6 +2112,11 @@ export async function repoPatchPlanningEvent(params: {
       p.of_operation_id !== undefined;
     if (touchesSchedule) {
       await assertResourceSchedulable(client, resource);
+      await assertOperationResourceCompatible({
+        tx: client,
+        of_operation_id: nextOfOperationId,
+        resource,
+      });
     }
 
     const nextAllowOverlap = p.allow_overlap !== undefined ? p.allow_overlap : before.allow_overlap;
@@ -2020,6 +2239,11 @@ export async function repoPatchPlanningEvent(params: {
     let synchronizedOfId = nextOfId;
     let notifications: AppNotification[] = [];
     if (before.of_operation_id && before.of_operation_id !== nextOfOperationId) {
+      await syncPlanningCoordinates({
+        tx: client,
+        of_operation_id: before.of_operation_id,
+        of_id: toNullableInt(before.of_id, "planning_events.of_id"),
+      });
       const previousSync = await syncLinkedOfOperationFromPlanning({
         tx: client,
         of_operation_id: before.of_operation_id,
@@ -2030,6 +2254,7 @@ export async function repoPatchPlanningEvent(params: {
     }
 
     if (nextOfOperationId) {
+      await syncPlanningCoordinates({ tx: client, of_operation_id: nextOfOperationId, of_id: nextOfId });
       const sync = await syncLinkedOfOperationFromPlanning({
         tx: client,
         of_operation_id: nextOfOperationId,
@@ -2156,6 +2381,11 @@ export async function repoArchivePlanningEvent(params: { id: string; audit: Audi
     let synchronizedOfId = toNullableInt(before.of_id, "planning_events.of_id");
     let notifications: AppNotification[] = [];
     if (before.of_operation_id) {
+      await syncPlanningCoordinates({
+        tx: client,
+        of_operation_id: before.of_operation_id,
+        of_id: lockOfId,
+      });
       const sync = await syncLinkedOfOperationFromPlanning({
         tx: client,
         of_operation_id: before.of_operation_id,
@@ -2260,6 +2490,11 @@ export async function repoRestorePlanningEvent(params: {
 
     const resource = { machine_id: before.machine_id, poste_id: before.poste_id };
     await assertResourceSchedulable(client, resource);
+    await assertOperationResourceCompatible({
+      tx: client,
+      of_operation_id: before.of_operation_id,
+      resource,
+    });
 
     const conflicts = await selectPlanningEventConflicts(client, {
       start_ts: before.start_ts,
@@ -2296,6 +2531,11 @@ export async function repoRestorePlanningEvent(params: {
 
     let notifications: AppNotification[] = [];
     if (before.of_operation_id) {
+      await syncPlanningCoordinates({
+        tx: client,
+        of_operation_id: before.of_operation_id,
+        of_id: synchronizedOfId,
+      });
       const sync = await syncLinkedOfOperationFromPlanning({
         tx: client,
         of_operation_id: before.of_operation_id,

--- a/src/module/planning/services/planning.service.test.ts
+++ b/src/module/planning/services/planning.service.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HttpError } from "../../../utils/httpError";
+
+const mocks = vi.hoisted(() => ({
+  listOperations: vi.fn(),
+  activeEvent: vi.fn(),
+  createEvent: vi.fn(),
+}));
+
+vi.mock("../repository/planning.repository", () => ({
+  repoGetActivePlanningEventForOfOperation: mocks.activeEvent,
+  repoListOfOperationsForAutoplan: mocks.listOperations,
+  repoCreatePlanningEvent: mocks.createEvent,
+}));
+
+import { svcAutoPlanPlanning } from "./planning.service";
+
+describe("planning auto-plan remediation contract", () => {
+  beforeEach(() => {
+    mocks.listOperations.mockReset();
+    mocks.activeEvent.mockReset();
+    mocks.createEvent.mockReset();
+    mocks.listOperations.mockResolvedValue([{
+      of_id: 7,
+      of_numero: "OF-7",
+      of_priority: "NORMAL",
+      of_operation_id: "44444444-4444-4444-8444-444444444444",
+      phase: 10,
+      designation: "Usinage",
+      planned_duration_minutes: 54,
+      status: "TODO",
+      machine_id: "11111111-1111-4111-8111-111111111111",
+      poste_id: null,
+    }]);
+    mocks.activeEvent.mockResolvedValue(null);
+  });
+
+  it("preserves the actionable Methods route when a machine is not qualified", async () => {
+    mocks.createEvent.mockRejectedValue(new HttpError(
+      422,
+      "PLANNING_MACHINE_QUALIFICATION_REQUIRED",
+      "La machine sélectionnée n'a pas de famille qualifiée.",
+      {
+        remediation_path: "/methodes/parc-machines",
+        action: "Renseignez la qualification de la machine dans le référentiel Méthodes.",
+      },
+    ));
+
+    const result = await svcAutoPlanPlanning({
+      body: { of_ids: [7], step_minutes: 15, skip_planned: true, include_done: false },
+      audit: {
+        user_id: 1,
+        role: "Production",
+        ip: "127.0.0.1",
+        user_agent: "vitest",
+        device_type: null,
+        os: null,
+        browser: null,
+        path: "/api/v1/planning/autoplan",
+        page_key: "planning",
+        client_session_id: "planning-test",
+      },
+    });
+
+    expect(result.created_events).toHaveLength(0);
+    expect(result.skipped_operations).toEqual([expect.objectContaining({
+      of_id: 7,
+      reason: "RESOURCE_NOT_QUALIFIED",
+      error_code: "PLANNING_MACHINE_QUALIFICATION_REQUIRED",
+      remediation_path: "/methodes/parc-machines",
+      action: "Renseignez la qualification de la machine dans le référentiel Méthodes.",
+    })]);
+  });
+});

--- a/src/module/planning/services/planning.service.ts
+++ b/src/module/planning/services/planning.service.ts
@@ -87,12 +87,16 @@ export async function svcAutoPlanPlanning(params: {
       | "MISSING_RESOURCE"
       | "RESOURCE_BLOCKED"
       | "LOCKED_AFTER_AR"
+      | "RESOURCE_NOT_QUALIFIED"
       | "NO_OPERATIONS"
       | "DURATION_UNAVAILABLE"
       | "NO_SLOT"
       | "FAILED";
     existing_event_id?: string | null;
     message?: string;
+    error_code?: string;
+    remediation_path?: string;
+    action?: string;
   }>;
   summary: {
     requested_ofs: number;
@@ -139,12 +143,16 @@ export async function svcAutoPlanPlanning(params: {
       | "MISSING_RESOURCE"
       | "RESOURCE_BLOCKED"
       | "LOCKED_AFTER_AR"
+      | "RESOURCE_NOT_QUALIFIED"
       | "NO_OPERATIONS"
       | "DURATION_UNAVAILABLE"
       | "NO_SLOT"
       | "FAILED";
     existing_event_id?: string | null;
     message?: string;
+    error_code?: string;
+    remediation_path?: string;
+    action?: string;
   }> = [];
 
   for (const ofId of params.body.of_ids) {
@@ -229,6 +237,28 @@ export async function svcAutoPlanPlanning(params: {
           break;
         } catch (err) {
           const httpErr = err as { code?: unknown; details?: unknown; message?: unknown };
+          const errorDetails = httpErr && typeof httpErr.details === "object" && httpErr.details !== null
+            ? httpErr.details as Record<string, unknown>
+            : null;
+          const errorCode = typeof httpErr?.code === "string" ? httpErr.code : undefined;
+
+          if (errorCode && [
+            "PLANNING_OPERATION_FAMILY_REQUIRED",
+            "PLANNING_MACHINE_QUALIFICATION_REQUIRED",
+            "PLANNING_MACHINE_FAMILY_INCOMPATIBLE",
+          ].includes(errorCode)) {
+            skipped_operations.push({
+              of_id: op.of_id,
+              of_operation_id: op.of_operation_id,
+              reason: "RESOURCE_NOT_QUALIFIED",
+              message: typeof httpErr.message === "string" ? httpErr.message : undefined,
+              error_code: errorCode,
+              remediation_path: typeof errorDetails?.remediation_path === "string" ? errorDetails.remediation_path : undefined,
+              action: typeof errorDetails?.action === "string" ? errorDetails.action : undefined,
+            });
+            skipped = true;
+            break;
+          }
 
           if (httpErr && httpErr.code === "MISSING_RESOURCE") {
             if (fallbackResource && !usedFallback) {

--- a/src/module/planning/services/planning.service.ts
+++ b/src/module/planning/services/planning.service.ts
@@ -88,6 +88,7 @@ export async function svcAutoPlanPlanning(params: {
       | "RESOURCE_BLOCKED"
       | "LOCKED_AFTER_AR"
       | "NO_OPERATIONS"
+      | "DURATION_UNAVAILABLE"
       | "NO_SLOT"
       | "FAILED";
     existing_event_id?: string | null;
@@ -139,6 +140,7 @@ export async function svcAutoPlanPlanning(params: {
       | "RESOURCE_BLOCKED"
       | "LOCKED_AFTER_AR"
       | "NO_OPERATIONS"
+      | "DURATION_UNAVAILABLE"
       | "NO_SLOT"
       | "FAILED";
     existing_event_id?: string | null;
@@ -174,7 +176,17 @@ export async function svcAutoPlanPlanning(params: {
         }
       }
 
-      const durationMinutes = Math.max(15, clampPositiveInt(Math.round(op.temps_total_planned), 15));
+      const plannedDurationMinutes = op.planned_duration_minutes;
+      if (typeof plannedDurationMinutes !== "number" || !Number.isFinite(plannedDurationMinutes) || plannedDurationMinutes <= 0) {
+        skipped_operations.push({
+          of_id: op.of_id,
+          of_operation_id: op.of_operation_id,
+          reason: "DURATION_UNAVAILABLE",
+          message: "La durée planifiée est absente ou nulle. Renseignez les temps de gamme avant l’auto-planification.",
+        });
+        continue;
+      }
+      const durationMinutes = Math.max(15, Math.round(plannedDurationMinutes));
       const durationMs = durationMinutes * 60_000;
       let startMs = ceilToStepMinutes(cursorMs, stepMinutes);
       let usedFallback = false;

--- a/src/module/planning/types/planning.types.ts
+++ b/src/module/planning/types/planning.types.ts
@@ -118,7 +118,12 @@ export type PlanningValidationCommande = {
 export type PlanningValidationSkippedCommande = {
   commande_id: number;
   numero: string;
-  reason: "NO_PLANNED_OF" | "AR_ALREADY_SENT" | "ALREADY_READY" | "WORKFLOW_NOT_ADVANCED";
+  reason:
+    | "NO_PLANNED_OF"
+    | "AR_ALREADY_SENT"
+    | "ALREADY_READY"
+    | "RESOURCE_QUALIFICATION_REQUIRED"
+    | "WORKFLOW_NOT_ADVANCED";
   message: string;
 };
 

--- a/src/module/procurement-reliability/repository/procurement-reliability.repository.test.ts
+++ b/src/module/procurement-reliability/repository/procurement-reliability.repository.test.ts
@@ -66,6 +66,9 @@ describe("SOL-18 procurement write transactions", () => {
       idempotencyKey: "sol18-promise-0001",
     })).resolves.toMatchObject({ promised_date: "2026-08-25", idempotent_replay: false });
     const query = client.query as ReturnType<typeof vi.fn>;
+    const receiptRead = query.mock.calls.find(([sql]) => String(sql).includes("FROM public.procurement_command_receipts"));
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("pg_advisory_xact_lock"))).toBe(true);
+    expect(String(receiptRead?.[0] ?? "")).not.toContain("FOR SHARE");
     expect(query.mock.calls.filter(([sql]) => String(sql).includes("UPDATE public.commande_fournisseur SET date_promesse"))).toHaveLength(1);
     expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.procurement_promised_date_events"))).toHaveLength(1);
     expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.procurement_command_receipts"))).toHaveLength(1);

--- a/src/module/procurement-reliability/repository/procurement-reliability.repository.ts
+++ b/src/module/procurement-reliability/repository/procurement-reliability.repository.ts
@@ -247,9 +247,18 @@ async function readCommandReceipt<T>(
   idempotencyKey: string,
   requestHash: string,
 ): Promise<T | null> {
+  // The receipt ledger is append-only and the runtime role therefore only has
+  // SELECT + INSERT. PostgreSQL row locks require UPDATE privilege even when
+  // no mutation is performed, which made every first command fail under the
+  // production ACL. Serialise the action/key with a transaction-scoped
+  // advisory lock, then read the immutable receipt without weakening grants.
+  await tx.query(
+    "SELECT pg_advisory_xact_lock(hashtextextended($1, 20260812))",
+    [`procurement-reliability:${action}:${idempotencyKey}`],
+  );
   const result = await tx.query<{ request_hash: string; response_snapshot: T }>(
     `SELECT request_hash,response_snapshot FROM public.procurement_command_receipts
-     WHERE action=$1 AND idempotency_key=$2 FOR SHARE`,
+     WHERE action=$1 AND idempotency_key=$2`,
     [action, idempotencyKey],
   );
   const row = result.rows[0];

--- a/src/module/production/domain/planned-operation-duration.test.ts
+++ b/src/module/production/domain/planned-operation-duration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { computePlannedOperationDurationMinutes } from "./planned-operation-duration";
+
+describe("canonical planned operation duration", () => {
+  it.each([
+    { launchedQuantity: 0, expected: 30 },
+    { launchedQuantity: 1, expected: 42 },
+    { launchedQuantity: 2, expected: 54 },
+  ])("computes setup plus per-unit load for quantity $launchedQuantity", ({ launchedQuantity, expected }) => {
+    expect(computePlannedOperationDurationMinutes({
+      setupHours: 0.5,
+      unitHours: 0.2,
+      baseQuantity: 1,
+      launchedQuantity,
+      coefficient: 1,
+    })).toBe(expected);
+  });
+
+  it("applies base quantity and coefficient only to execution time", () => {
+    expect(computePlannedOperationDurationMinutes({
+      setupHours: 0.5,
+      unitHours: 0.1,
+      baseQuantity: 2,
+      launchedQuantity: 3,
+      coefficient: 1.5,
+    })).toBe(84);
+  });
+
+  it("rejects missing/invalid numeric evidence instead of fabricating a duration", () => {
+    expect(() => computePlannedOperationDurationMinutes({
+      setupHours: Number.NaN,
+      unitHours: 0.2,
+      baseQuantity: 1,
+      launchedQuantity: 2,
+      coefficient: 1,
+    })).toThrow(/setupHours/);
+  });
+});

--- a/src/module/production/domain/planned-operation-duration.ts
+++ b/src/module/production/domain/planned-operation-duration.ts
@@ -1,0 +1,39 @@
+export type PlannedOperationDurationInput = Readonly<{
+  setupHours: number;
+  unitHours: number;
+  baseQuantity: number;
+  launchedQuantity: number;
+  coefficient: number;
+}>;
+
+function finiteNonNegative(value: number, field: keyof PlannedOperationDurationInput): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${field} must be a finite non-negative number`);
+  }
+  return value;
+}
+
+/**
+ * Canonical scheduling load:
+ * setup + unit time × gamme base quantity × OF launched quantity × coefficient.
+ * Inputs are decimal hours; the output is rounded once to whole minutes.
+ */
+export function computePlannedOperationDurationMinutes(input: PlannedOperationDurationInput): number {
+  const setupHours = finiteNonNegative(input.setupHours, "setupHours");
+  const unitHours = finiteNonNegative(input.unitHours, "unitHours");
+  const baseQuantity = finiteNonNegative(input.baseQuantity, "baseQuantity");
+  const launchedQuantity = finiteNonNegative(input.launchedQuantity, "launchedQuantity");
+  const coefficient = finiteNonNegative(input.coefficient, "coefficient");
+  return Math.round((setupHours + unitHours * baseQuantity * launchedQuantity * coefficient) * 60);
+}
+
+/** Same canonical formula for PostgreSQL reads. Aliases are fixed by repository code. */
+export const PLANNED_OPERATION_DURATION_MINUTES_SQL = `
+  ROUND(GREATEST(0,
+    op.tp
+    + op.tf_unit
+      * op.qte
+      * o.quantite_lancee
+      * op.coef
+  ) * 60)::int
+`;

--- a/src/module/production/repository/production-receipts.repository.ts
+++ b/src/module/production/repository/production-receipts.repository.ts
@@ -653,12 +653,12 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
     `
       SELECT
         m.id::text AS id,
-        COALESCE(m.code, m.code_magasin) AS code,
-        COALESCE(m.name, m.libelle) AS name,
+        m.code,
+        m.name,
         m.is_active
       FROM public.magasins m
       WHERE m.is_active = true
-      ORDER BY COALESCE(m.name, m.libelle) ASC, COALESCE(m.code, m.code_magasin) ASC
+      ORDER BY m.name ASC, m.code ASC
     `
   );
 
@@ -1299,8 +1299,8 @@ export async function repoGetOfTraceability(params: { of_id: number }): Promise<
         ml.lot_id::text AS lot_id,
         l.lot_code,
         ml.dst_magasin_id::text AS magasin_id,
-        COALESCE(mag.code, mag.code_magasin) AS magasin_code,
-        COALESCE(mag.name, mag.libelle) AS magasin_name,
+        mag.code AS magasin_code,
+        mag.name AS magasin_name,
         ml.dst_emplacement_id::bigint AS emplacement_id,
         e.code AS emplacement_code,
         e.location_id::text AS location_id

--- a/src/module/production/repository/production.repository.ts
+++ b/src/module/production/repository/production.repository.ts
@@ -3409,6 +3409,7 @@ export async function repoUpdateOrdreFabrication(params: {
       id: string;
       commande_id: string | null;
       statut: string;
+      quantite_bonne: number;
       updated_at: string | null;
     }>(
       `
@@ -3416,6 +3417,7 @@ export async function repoUpdateOrdreFabrication(params: {
           id::text AS id,
           commande_id::text AS commande_id,
           statut::text AS statut,
+          quantite_bonne::float8 AS quantite_bonne,
           to_char(
             updated_at AT TIME ZONE 'UTC',
             'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
@@ -3464,6 +3466,76 @@ export async function repoUpdateOrdreFabrication(params: {
         throw new HttpError(403, "OF_TRANSITION_FORBIDDEN", "Votre rôle ne permet pas cette transition d'OF.", {
           capability,
         });
+      }
+    }
+
+    // A completed OF may only be archived once every declared good part is
+    // backed by the immutable receipt ledger and its posted stock movement.
+    // The receipt remains a separate, explicit command because its location
+    // and quality decision cannot be inferred safely at closure time.
+    if (statutChanges && currentStatut === "TERMINE" && requestedStatut === "CLOTURE") {
+      const receiptStateRes = await client.query<{
+        received_qty_ok: number;
+        invalid_receipt_count: number;
+      }>(
+        `
+          SELECT
+            COALESCE(
+              SUM(r.qty_ok) FILTER (
+                WHERE m.status = 'POSTED'
+                  AND m.movement_type = 'IN'::public.movement_type
+                  AND m.source_document_type = 'OF'
+                  AND m.source_document_id = $1::text
+                  AND m.qty = r.qty_ok
+                  AND EXISTS (
+                    SELECT 1
+                    FROM public.of_output_lots ool
+                    WHERE ool.of_id = r.of_id
+                      AND ool.lot_id = r.lot_id
+                  )
+              ),
+              0
+            )::float8 AS received_qty_ok,
+            COUNT(*) FILTER (
+              WHERE r.id IS NOT NULL
+                AND NOT COALESCE(
+                  m.status = 'POSTED'
+                    AND m.movement_type = 'IN'::public.movement_type
+                    AND m.source_document_type = 'OF'
+                    AND m.source_document_id = $1::text
+                    AND m.qty = r.qty_ok
+                    AND EXISTS (
+                      SELECT 1
+                      FROM public.of_output_lots ool
+                      WHERE ool.of_id = r.of_id
+                        AND ool.lot_id = r.lot_id
+                    ),
+                  false
+                )
+            )::int AS invalid_receipt_count
+          FROM public.of_receipts r
+          LEFT JOIN public.stock_movements m ON m.id = r.stock_movement_id
+          WHERE r.of_id = $1::bigint
+        `,
+        [params.id]
+      );
+      const receivedQtyOk = Number(receiptStateRes.rows[0]?.received_qty_ok ?? 0);
+      const invalidReceiptCount = Number(receiptStateRes.rows[0]?.invalid_receipt_count ?? 0);
+      const declaredQtyOk = Number(ofRow.quantite_bonne);
+      const remainingQtyOk = Math.max(0, declaredQtyOk - receivedQtyOk);
+
+      if (invalidReceiptCount > 0 || remainingQtyOk > 1e-9) {
+        throw new HttpError(
+          409,
+          "OF_RECEIPT_INCOMPLETE",
+          "Reception stock incomplete : enregistrez les pieces bonnes avant de cloturer l'OF.",
+          {
+            declared_qty_ok: declaredQtyOk,
+            received_qty_ok: receivedQtyOk,
+            remaining_qty_ok: remainingQtyOk,
+            invalid_receipt_count: invalidReceiptCount,
+          }
+        );
       }
     }
 

--- a/src/module/production/repository/production.repository.ts
+++ b/src/module/production/repository/production.repository.ts
@@ -54,6 +54,7 @@ import {
 } from "../domain/of-status";
 import { capabilityForOfTransition, roleHasOfCapability } from "../domain/of-rbac";
 import { copyPieceOperationsToOf, loadApplicableTechnicalSnapshot } from "../domain/of-generation";
+import { PLANNED_OPERATION_DURATION_MINUTES_SQL } from "../domain/planned-operation-duration";
 import { enqueueProductionOfChanged, productionRealtimeActionFromAudit } from "./production-realtime.repository";
 
 export type AuditContext = {
@@ -2636,6 +2637,7 @@ async function selectOfOperation(q: DbQueryer, params: {
     qte: number;
     coef: number;
     temps_total_planned: number;
+    planned_duration_minutes: number;
     temps_total_real: number;
     status: OfOperation["status"];
     started_at: string | null;
@@ -2676,6 +2678,7 @@ async function selectOfOperation(q: DbQueryer, params: {
         op.qte::float8 AS qte,
         op.coef::float8 AS coef,
         op.temps_total_planned::float8 AS temps_total_planned,
+        ${PLANNED_OPERATION_DURATION_MINUTES_SQL} AS planned_duration_minutes,
         op.temps_total_real::float8 AS temps_total_real,
         op.status::text AS status,
         op.started_at::text AS started_at,
@@ -2693,6 +2696,7 @@ async function selectOfOperation(q: DbQueryer, params: {
         open_log.comment AS open_log_comment,
         open_log.created_at::text AS open_log_created_at
       FROM of_operations op
+      JOIN ordres_fabrication o ON o.id = op.of_id
       LEFT JOIN postes p ON p.id = op.poste_id
       LEFT JOIN machines m ON m.id = op.machine_id
       LEFT JOIN LATERAL (
@@ -2739,6 +2743,7 @@ async function selectOfOperation(q: DbQueryer, params: {
     qte: Number(row.qte),
     coef: Number(row.coef),
     temps_total_planned: Number(row.temps_total_planned),
+    planned_duration_minutes: Number(row.planned_duration_minutes),
     temps_total_real: Number(row.temps_total_real),
     status: row.status,
     started_at: row.started_at,
@@ -2768,6 +2773,7 @@ async function selectOfOperations(q: DbQueryer, params: { of_id: number; user_id
     qte: number;
     coef: number;
     temps_total_planned: number;
+    planned_duration_minutes: number;
     temps_total_real: number;
     status: OfOperation["status"];
     started_at: string | null;
@@ -2808,6 +2814,7 @@ async function selectOfOperations(q: DbQueryer, params: { of_id: number; user_id
         op.qte::float8 AS qte,
         op.coef::float8 AS coef,
         op.temps_total_planned::float8 AS temps_total_planned,
+        ${PLANNED_OPERATION_DURATION_MINUTES_SQL} AS planned_duration_minutes,
         op.temps_total_real::float8 AS temps_total_real,
         op.status::text AS status,
         op.started_at::text AS started_at,
@@ -2825,6 +2832,7 @@ async function selectOfOperations(q: DbQueryer, params: { of_id: number; user_id
         open_log.comment AS open_log_comment,
         open_log.created_at::text AS open_log_created_at
       FROM of_operations op
+      JOIN ordres_fabrication o ON o.id = op.of_id
       LEFT JOIN postes p ON p.id = op.poste_id
       LEFT JOIN machines m ON m.id = op.machine_id
       LEFT JOIN LATERAL (
@@ -2868,6 +2876,7 @@ async function selectOfOperations(q: DbQueryer, params: { of_id: number; user_id
     qte: Number(row.qte),
     coef: Number(row.coef),
     temps_total_planned: Number(row.temps_total_planned),
+    planned_duration_minutes: Number(row.planned_duration_minutes),
     temps_total_real: Number(row.temps_total_real),
     status: row.status,
     started_at: row.started_at,

--- a/src/module/production/types/production.types.ts
+++ b/src/module/production/types/production.types.ts
@@ -147,6 +147,7 @@ export type OfOperation = {
   qte: number;
   coef: number;
   temps_total_planned: number;
+  planned_duration_minutes: number;
   temps_total_real: number;
   status: OfOperationStatusDTO;
   started_at: string | null;

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -69,6 +69,7 @@ import importAssistantRoutes from "../module/import-assistant/routes/import-assi
 import accessControlRoutes from "../module/access-control/routes/access-control.routes"
 import dashboardGovernanceRoutes from "../module/dashboard-governance/routes/dashboard-governance.routes"
 import referenceDataRoutes from "../module/reference-data/routes/reference-data.routes"
+import commercialReferencesRoutes from "../module/commercial-references/routes/commercial-references.routes"
 import { moduleAccessGate } from "../module/access-control/middlewares/module-access-gate"
 import { runWithAccountModuleAccessScope } from "../module/access-control/context/account-module-access.context"
 const router = Router()
@@ -125,6 +126,7 @@ router.use("/admin/reference-data", referenceDataRoutes);
 router.use("/admin", adminRoutes);
 router.use("/affaires", affaireRoutes);
 router.use("/devis", devisRoutes);
+router.use(commercialReferencesRoutes);
 router.use("/factures", facturesRoutes);
 router.use("/avoirs", avoirsRoutes);
 router.use("/paiements", paiementsRoutes);

--- a/src/shared/uploads/upload-scanner.ts
+++ b/src/shared/uploads/upload-scanner.ts
@@ -333,7 +333,10 @@ export async function probeUploadScannerHealth(
   startup = getUploadScannerStartupConfiguration()
 ): Promise<UploadScannerStartupConfiguration> {
   if (!startup.ready || startup.provider !== "clamdscan" || !startup.command) return startup;
-  if (process.env.NODE_ENV === "test") return startup;
+  // Unit tests do not require a host ClamAV daemon, but the managed E2E image
+  // is a real runtime even though NODE_ENV=test. It must exercise the live
+  // daemon probe so readiness cannot report a dead scanner as healthy.
+  if (process.env.NODE_ENV === "test" && process.env.CERP_E2E_CONTAINER !== "1") return startup;
 
   return await new Promise((resolve) => {
     const child = spawn(startup.command as string, ["--ping=1:1"], {

--- a/src/swagger/generated-route-inventory.ts
+++ b/src/swagger/generated-route-inventory.ts
@@ -8,7 +8,7 @@ export type GeneratedRouteContract = {
   rbac: readonly string[];
 };
 
-export const GENERATED_ROUTE_SOURCE_SHA256 = "0a9bf864dfa4af98d8173ae7baed0be83600634922eaa3996b9955c579022ed3";
+export const GENERATED_ROUTE_SOURCE_SHA256 = "d8680eee125fbc1b1f1230e14b3294af0f44c59e8ab02a285e3512d89386f536";
 export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
@@ -3504,6 +3504,40 @@ export const GENERATED_ROUTE_INVENTORY = [
     "authenticated": true,
     "rbac": [
       "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/compte-vente",
+    "source": "src/module/commercial-references/routes/commercial-references.routes.ts:20",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireDevisRead",
+      "listComptesVente"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireDevisRead"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/conditions-paiement",
+    "source": "src/module/commercial-references/routes/commercial-references.routes.ts:19",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireDevisRead",
+      "listConditionsPaiement"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireDevisRead"
     ]
   },
   {


### PR DESCRIPTION
## Promotion backend dev → main

Contrôle de release bloquant réussi avant promotion :
- release : `20260820T071034Z-test-decd72b2-265a6309`
- backend : `265a63090f1ea54cd098c7200a8a2164c01892da`
- frontend associé : `decd72b2693f7340685842b8ed7196c5ba9bc583`
- 4 848 tests backend ; OpenAPI 1 079/1 079
- Playwright : 154 réussis, 4 opt-in ignorés, 0 échec, 0 flaky
- migrations isolées : apply/replay/rollback/restore réussis
- artefact : 1 392 fichiers, intégrité SHA-256 vérifiée

Cette PR promeut l'arbre exact validé. Les trois patchs 20260819 restent à appliquer avec sauvegarde et preflight sur cerp_test puis cerp_prod, après le gate `production` sur `main`.

## Summary by Sourcery

Promote the validated backend release by hardening production closure, planning qualification, quote idempotency, least-privilege operations, GED fail-closed behavior, and isolated release verification.

New Features:
- Expose governed compatibility endpoints for payment terms and sales accounts while clearly reporting that the underlying references are not configured.

Bug Fixes:
- Require complete, valid stock receipt evidence before allowing a completed manufacturing order to be closed.
- Prevent planning with unqualified or incompatible machine families and preserve actionable remediation details.
- Use the canonical operation duration for planning and skip auto-planning when duration evidence is unavailable.
- Enforce idempotency for quote creation and fail closed when the idempotency ledger or commercial schema is unavailable.
- Keep append-only command receipt workflows compatible with least-privilege runtime permissions.
- Keep the API available while GED scanner processes fail, while quarantining uploads and restricting exposed scan-failure details.
- Correct warehouse field usage and improve isolated E2E container networking and scanner health behavior.

Enhancements:
- Synchronize planning assignments and calculated manufacturing-order dates back to their source records.
- Expand release preflight and immutable migration tracking for corrective runtime grants.
- Add explicit machine qualification, commercial reference, receipt, isolation, error-handling, scanner, and migration guard coverage.

CI:
- Update generated route inventory and OpenAPI route coverage for the added commercial reference endpoints.

Deployment:
- Add guarded, least-privilege migration patches with preflight, verification, and backup-based rollback procedures for quote preparation, portal authentication attempts, and MFA cleanup.

Documentation:
- Document the validated release execution and promotion controls, including isolated test evidence, migration procedures, rollback guidance, and remaining operational prerequisites.
- Document the new planning auto-plan duration outcome.

Tests:
- Expand production, planning, quote, portal, GED, scanner, E2E isolation, reliability, and migration tests to cover the new validation and failure-handling contracts.

Chores:
- Stabilize multipart quote tests by using in-memory upload data to avoid asynchronous file-descriptor races.