### PR TITLE
feat(pdf): authoritative archive and automatic GED creation snapshots

### DIFF
--- a/db/patches/20260823_authoritative_pdf_archive_612.sql
+++ b/db/patches/20260823_authoritative_pdf_archive_612.sql
@@ -1,0 +1,213 @@
+-- #612 — Archivage autoritatif des PDF sortants dans la GED.
+--
+-- Additif et reversible : ce patch ne rebascule aucun producteur existant.
+-- Il fournit le contrat commun utilise par les commandes, fiches, OF et pieces
+-- techniques : un instantane fige, un PDF adresse par empreinte et une file
+-- transactionnelle pour le versement GED apres la creation de l'entite.
+
+BEGIN;
+
+-- This one-shot migration owns the class it creates. Refuse any existing key
+-- rather than silently adopting operator configuration that rollback could
+-- later delete.
+DO $$
+BEGIN
+  IF to_regclass('public.ged_document_classes') IS NULL
+     OR to_regclass('public.ged_documents') IS NULL
+     OR to_regclass('public.ged_document_versions') IS NULL
+     OR to_regclass('public.ged_document_links') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_PREREQUISITE_MISSING';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_APP_ROLE_MISSING';
+  END IF;
+  IF to_regprocedure('gen_random_uuid()') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_UUID_GENERATOR_MISSING';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.ged_document_classes WHERE class_key IN ('CERP_AUTHORITATIVE_PDF', 'CERP_SYSTEM_SNAPSHOT')) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_CLASS_ALREADY_EXISTS';
+  END IF;
+
+  IF to_regclass('public.authoritative_pdf_archives') IS NOT NULL
+     OR to_regclass('public.authoritative_pdf_archive_outbox') IS NOT NULL
+     OR to_regclass('public.authoritative_pdf_archive_snapshot_lookup_idx') IS NOT NULL
+     OR to_regclass('public.authoritative_pdf_archive_outbox_ready_idx') IS NOT NULL
+     OR to_regclass('public.authoritative_pdf_archive_outbox_stale_idx') IS NOT NULL
+     OR to_regprocedure('public.fn_authoritative_pdf_archive_immutable_612()') IS NOT NULL
+     OR to_regprocedure('public.fn_authoritative_pdf_archive_outbox_stamp_612()') IS NOT NULL
+     OR to_regprocedure('public.fn_authoritative_pdf_archive_outbox_complete_612()') IS NOT NULL
+     OR EXISTS (
+       SELECT 1 FROM pg_trigger
+        WHERE NOT tgisinternal
+          AND tgname IN ('trg_authoritative_pdf_archive_immutable_612', 'trg_authoritative_pdf_archive_outbox_stamp_612', 'trg_authoritative_pdf_archive_outbox_complete_612')
+     ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_TARGET_NAMESPACE_ALREADY_EXISTS';
+  END IF;
+END;
+$$;
+
+INSERT INTO public.ged_document_classes
+  (class_key, domain, label, nature, allowed_mime_types, allowed_extensions,
+   max_size_bytes, approvals_required, retention_months, hold_on_publish, is_active)
+VALUES
+  ('CERP_AUTHORITATIVE_PDF', 'CERP', 'PDF sortant autoritatif', 'GENERATED',
+   ARRAY['application/pdf'], ARRAY['pdf'], 52428800, 0, 120, false, true),
+  ('CERP_SYSTEM_SNAPSHOT', 'CERP', 'Instantané interne de création', 'GENERATED',
+   ARRAY['application/pdf'], ARRAY['pdf'], 52428800, 0, 120, false, true);
+
+CREATE TABLE public.authoritative_pdf_archives (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_type        text NOT NULL CHECK (entity_type ~ '^[a-z][a-z0-9_-]{1,63}$'),
+  entity_id          text NOT NULL CHECK (length(btrim(entity_id)) BETWEEN 1 AND 160),
+  document_kind      text NOT NULL CHECK (document_kind ~ '^[A-Z][A-Z0-9_]{1,63}$'),
+  document_version   integer NOT NULL CHECK (document_version >= 1),
+  render_version     text NOT NULL CHECK (length(btrim(render_version)) BETWEEN 1 AND 64),
+  idempotency_key    text NOT NULL CHECK (length(btrim(idempotency_key)) BETWEEN 1 AND 240),
+  title              text NOT NULL CHECK (length(btrim(title)) BETWEEN 1 AND 300),
+  original_name      text NOT NULL CHECK (original_name ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,180}\.pdf$'),
+  source_snapshot    jsonb NOT NULL,
+  source_revision    text NOT NULL CHECK (length(btrim(source_revision)) BETWEEN 1 AND 160),
+  snapshot_sha256    text NOT NULL CHECK (snapshot_sha256 ~ '^[a-f0-9]{64}$'),
+  pdf_sha256         text NULL CHECK (pdf_sha256 IS NULL OR pdf_sha256 ~ '^[a-f0-9]{64}$'),
+  pdf_size_bytes     bigint NULL,
+  ged_document_id    uuid NULL REFERENCES public.ged_documents(id) ON DELETE RESTRICT,
+  ged_version_id     uuid NULL REFERENCES public.ged_document_versions(id) ON DELETE RESTRICT,
+  archived_at        timestamptz NULL,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  created_by         integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT authoritative_pdf_archive_document_version_uq
+    UNIQUE (entity_type, entity_id, document_kind, document_version),
+  CONSTRAINT authoritative_pdf_archive_idempotency_uq UNIQUE (idempotency_key),
+  CONSTRAINT authoritative_pdf_archive_pdf_size_ck CHECK (
+    pdf_size_bytes IS NULL OR (pdf_size_bytes > 0 AND pdf_size_bytes <= 52428800)
+  ),
+  CONSTRAINT authoritative_pdf_archive_complete_ck CHECK (
+    (archived_at IS NULL AND pdf_sha256 IS NULL AND pdf_size_bytes IS NULL AND ged_document_id IS NULL AND ged_version_id IS NULL)
+    OR
+    (archived_at IS NOT NULL AND pdf_sha256 IS NOT NULL AND pdf_size_bytes IS NOT NULL AND ged_document_id IS NOT NULL AND ged_version_id IS NOT NULL)
+  )
+);
+
+-- A deliberate reissue can preserve exactly the same business snapshot while
+-- creating a new, human-visible edition.  The snapshot is immutable per row,
+-- but must not be a uniqueness key across editions.
+CREATE INDEX authoritative_pdf_archive_snapshot_lookup_idx
+  ON public.authoritative_pdf_archives(entity_type, entity_id, document_kind, snapshot_sha256);
+
+COMMENT ON TABLE public.authoritative_pdf_archives IS
+  'Registre immuable des PDF sortants : instantane source, edition et empreinte; inclut les instantanes internes de creation.';
+
+CREATE TABLE public.authoritative_pdf_archive_outbox (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  archive_id         uuid NOT NULL REFERENCES public.authoritative_pdf_archives(id) ON DELETE RESTRICT,
+  event_key          text NOT NULL UNIQUE,
+  status             text NOT NULL DEFAULT 'PENDING'
+                     CHECK (status IN ('PENDING', 'PROCESSING', 'ARCHIVED', 'FAILED')),
+  attempt_count      integer NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  available_at       timestamptz NOT NULL DEFAULT now(),
+  locked_at          timestamptz NULL,
+  locked_by          text NULL,
+  claim_token        uuid NULL,
+  archived_at        timestamptz NULL,
+  last_error         text NULL,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT authoritative_pdf_archive_outbox_archive_uq UNIQUE (archive_id),
+  CONSTRAINT authoritative_pdf_archive_outbox_lifecycle_ck CHECK (
+    (status = 'ARCHIVED') = (archived_at IS NOT NULL)
+    AND (
+      (status = 'PROCESSING' AND locked_at IS NOT NULL AND locked_by IS NOT NULL AND length(btrim(locked_by)) > 0 AND claim_token IS NOT NULL)
+      OR (status <> 'PROCESSING' AND locked_at IS NULL AND locked_by IS NULL AND claim_token IS NULL)
+    )
+  )
+);
+
+CREATE INDEX authoritative_pdf_archive_outbox_ready_idx
+  ON public.authoritative_pdf_archive_outbox(status, available_at, created_at)
+  WHERE status IN ('PENDING', 'FAILED');
+
+-- A worker lease is deliberately finite. A process crash must never strand a
+-- creation snapshot forever; a later worker may safely reclaim it because the
+-- archive registry and its GED links are idempotent.
+CREATE INDEX authoritative_pdf_archive_outbox_stale_idx
+  ON public.authoritative_pdf_archive_outbox(locked_at)
+  WHERE status = 'PROCESSING';
+
+CREATE FUNCTION public.fn_authoritative_pdf_archive_immutable_612()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.entity_type IS DISTINCT FROM OLD.entity_type
+     OR NEW.entity_id IS DISTINCT FROM OLD.entity_id
+     OR NEW.document_kind IS DISTINCT FROM OLD.document_kind
+     OR NEW.document_version IS DISTINCT FROM OLD.document_version
+     OR NEW.render_version IS DISTINCT FROM OLD.render_version
+     OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+     OR NEW.title IS DISTINCT FROM OLD.title
+     OR NEW.original_name IS DISTINCT FROM OLD.original_name
+     OR NEW.source_snapshot IS DISTINCT FROM OLD.source_snapshot
+     OR NEW.source_revision IS DISTINCT FROM OLD.source_revision
+     OR NEW.snapshot_sha256 IS DISTINCT FROM OLD.snapshot_sha256
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at
+     OR NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_ARCHIVE_IMMUTABLE: archive source identity cannot change (id=%)', OLD.id
+      USING ERRCODE = 'check_violation';
+  END IF;
+  IF OLD.archived_at IS NOT NULL AND (
+       NEW.pdf_sha256 IS DISTINCT FROM OLD.pdf_sha256
+       OR NEW.pdf_size_bytes IS DISTINCT FROM OLD.pdf_size_bytes
+       OR NEW.ged_document_id IS DISTINCT FROM OLD.ged_document_id
+       OR NEW.ged_version_id IS DISTINCT FROM OLD.ged_version_id
+       OR NEW.archived_at IS DISTINCT FROM OLD.archived_at) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_ARCHIVE_IMMUTABLE: archived bytes cannot change (id=%)', OLD.id
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_authoritative_pdf_archive_immutable_612
+  BEFORE UPDATE ON public.authoritative_pdf_archives
+  FOR EACH ROW EXECUTE FUNCTION public.fn_authoritative_pdf_archive_immutable_612();
+
+CREATE FUNCTION public.fn_authoritative_pdf_archive_outbox_stamp_612()
+RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN NEW.updated_at := now(); RETURN NEW; END; $$;
+CREATE TRIGGER trg_authoritative_pdf_archive_outbox_stamp_612
+  BEFORE UPDATE ON public.authoritative_pdf_archive_outbox
+  FOR EACH ROW EXECUTE FUNCTION public.fn_authoritative_pdf_archive_outbox_stamp_612();
+
+-- An outbox row may become ARCHIVED only after the matching immutable archive
+-- has all exact-byte/GED evidence. This cross-table guard complements the
+-- local lifecycle CHECK and matches the worker's archive-then-outbox order.
+CREATE FUNCTION public.fn_authoritative_pdf_archive_outbox_complete_612()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.status = 'ARCHIVED' AND NOT EXISTS (
+    SELECT 1
+      FROM public.authoritative_pdf_archives a
+     WHERE a.id = NEW.archive_id
+       AND a.archived_at IS NOT NULL
+       AND a.pdf_sha256 IS NOT NULL
+       AND a.pdf_size_bytes IS NOT NULL
+       AND a.ged_document_id IS NOT NULL
+       AND a.ged_version_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_OUTBOX_ARCHIVED_WITHOUT_COMPLETE_ARCHIVE'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_authoritative_pdf_archive_outbox_complete_612
+  BEFORE INSERT OR UPDATE OF status, archive_id ON public.authoritative_pdf_archive_outbox
+  FOR EACH ROW EXECUTE FUNCTION public.fn_authoritative_pdf_archive_outbox_complete_612();
+
+GRANT SELECT, INSERT, UPDATE ON TABLE public.authoritative_pdf_archives TO cerp_app;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.authoritative_pdf_archive_outbox TO cerp_app;
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_archive_612.preflight.sql
+++ b/db/patches/support/20260823_authoritative_pdf_archive_612.preflight.sql
@@ -1,0 +1,47 @@
+-- #612 preflight — read-only and deliberately fail-closed.
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+BEGIN
+  IF to_regclass('public.ged_document_classes') IS NULL
+     OR to_regclass('public.ged_documents') IS NULL
+     OR to_regclass('public.ged_document_versions') IS NULL
+     OR to_regclass('public.ged_document_links') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_PREFLIGHT_GED_PREREQUISITE_MISSING';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_PREFLIGHT_APP_ROLE_MISSING';
+  END IF;
+  IF to_regprocedure('gen_random_uuid()') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_PREFLIGHT_UUID_GENERATOR_MISSING';
+  END IF;
+  IF to_regclass('public.authoritative_pdf_archives') IS NOT NULL
+     OR to_regclass('public.authoritative_pdf_archive_outbox') IS NOT NULL
+     OR to_regclass('public.authoritative_pdf_archive_snapshot_lookup_idx') IS NOT NULL
+     OR to_regclass('public.authoritative_pdf_archive_outbox_ready_idx') IS NOT NULL
+     OR to_regclass('public.authoritative_pdf_archive_outbox_stale_idx') IS NOT NULL
+     OR to_regprocedure('public.fn_authoritative_pdf_archive_immutable_612()') IS NOT NULL
+     OR to_regprocedure('public.fn_authoritative_pdf_archive_outbox_stamp_612()') IS NOT NULL
+     OR to_regprocedure('public.fn_authoritative_pdf_archive_outbox_complete_612()') IS NOT NULL
+     OR EXISTS (
+       SELECT 1 FROM pg_trigger
+        WHERE NOT tgisinternal
+          AND tgname IN ('trg_authoritative_pdf_archive_immutable_612', 'trg_authoritative_pdf_archive_outbox_stamp_612', 'trg_authoritative_pdf_archive_outbox_complete_612')
+     ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_PREFLIGHT_TARGET_ALREADY_EXISTS';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.ged_document_classes WHERE class_key IN ('CERP_AUTHORITATIVE_PDF', 'CERP_SYSTEM_SNAPSHOT')) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_PREFLIGHT_GED_CLASS_ALREADY_EXISTS';
+  END IF;
+END;
+$$;
+
+SELECT
+  to_regclass('public.authoritative_pdf_archives') IS NULL AS archive_registry_absent,
+  to_regclass('public.authoritative_pdf_archive_outbox') IS NULL AS archive_outbox_absent,
+  NOT EXISTS (SELECT 1 FROM public.ged_document_classes WHERE class_key = 'CERP_AUTHORITATIVE_PDF') AS generated_pdf_class_absent,
+  NOT EXISTS (SELECT 1 FROM public.ged_document_classes WHERE class_key = 'CERP_SYSTEM_SNAPSHOT') AS system_snapshot_class_absent,
+  EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') AS app_role_present,
+  to_regprocedure('gen_random_uuid()') IS NOT NULL AS uuid_generator_present;
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_archive_612.rollback.sql
+++ b/db/patches/support/20260823_authoritative_pdf_archive_612.rollback.sql
@@ -1,0 +1,115 @@
+-- #612 rollback — only safe before a producer has written archive records.
+-- It is a no-op on an entirely unapplied schema. If similarly named artifacts
+-- exist without the canonical migration-ledger record, it refuses rather than
+-- guessing ownership or deleting operator configuration.
+BEGIN;
+DO $$
+DECLARE
+  has_rows boolean;
+  patch_recorded boolean := false;
+  target_exists boolean;
+  class_owned boolean := false;
+  snapshot_class_owned boolean := false;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    EXECUTE 'SELECT EXISTS (SELECT 1 FROM public.cerp_schema_migrations WHERE filename = $1)'
+      INTO patch_recorded
+      USING '20260823_authoritative_pdf_archive_612.sql';
+  END IF;
+
+  target_exists := to_regclass('public.authoritative_pdf_archives') IS NOT NULL
+    OR to_regclass('public.authoritative_pdf_archive_outbox') IS NOT NULL
+    OR to_regclass('public.authoritative_pdf_archive_snapshot_lookup_idx') IS NOT NULL
+    OR to_regclass('public.authoritative_pdf_archive_outbox_ready_idx') IS NOT NULL
+    OR to_regclass('public.authoritative_pdf_archive_outbox_stale_idx') IS NOT NULL
+    OR to_regprocedure('public.fn_authoritative_pdf_archive_immutable_612()') IS NOT NULL
+    OR to_regprocedure('public.fn_authoritative_pdf_archive_outbox_stamp_612()') IS NOT NULL
+    OR to_regprocedure('public.fn_authoritative_pdf_archive_outbox_complete_612()') IS NOT NULL
+    OR EXISTS (
+      SELECT 1 FROM pg_trigger
+       WHERE NOT tgisinternal
+         AND tgname IN ('trg_authoritative_pdf_archive_immutable_612', 'trg_authoritative_pdf_archive_outbox_stamp_612', 'trg_authoritative_pdf_archive_outbox_complete_612')
+    );
+  IF NOT patch_recorded THEN
+    IF target_exists THEN
+      RAISE EXCEPTION 'Rollback refused: #612 artifacts exist without canonical migration-ledger ownership.';
+    END IF;
+    RETURN;
+  END IF;
+  IF to_regclass('public.authoritative_pdf_archives') IS NULL
+     OR to_regclass('public.authoritative_pdf_archive_outbox') IS NULL THEN
+    RAISE EXCEPTION 'Rollback refused: #612 migration ledger is present but archive artifacts are incomplete.';
+  END IF;
+  IF to_regclass('public.ged_document_classes') IS NULL THEN
+    RAISE EXCEPTION 'Rollback refused: GED class registry is missing.';
+  END IF;
+  EXECUTE $ownership$
+    SELECT EXISTS (
+      SELECT 1 FROM public.ged_document_classes c
+       WHERE c.class_key = 'CERP_AUTHORITATIVE_PDF'
+         AND c.domain = 'CERP'
+         AND c.label = 'PDF sortant autoritatif'
+         AND c.nature = 'GENERATED'
+         AND c.allowed_mime_types = ARRAY['application/pdf']::text[]
+         AND c.allowed_extensions = ARRAY['pdf']::text[]
+         AND c.max_size_bytes = 52428800::bigint
+         AND c.approvals_required = 0::smallint
+         AND c.retention_months = 120
+         AND c.hold_on_publish = false
+         AND c.is_active = true
+    )
+  $ownership$ INTO class_owned;
+  IF NOT class_owned THEN
+    RAISE EXCEPTION 'Rollback refused: #612 GED class is missing or its policy changed.';
+  END IF;
+  EXECUTE $snapshot_ownership$
+    SELECT EXISTS (
+      SELECT 1 FROM public.ged_document_classes c
+       WHERE c.class_key = 'CERP_SYSTEM_SNAPSHOT' AND c.domain = 'CERP'
+         AND c.label = 'Instantané interne de création' AND c.nature = 'GENERATED'
+         AND c.allowed_mime_types = ARRAY['application/pdf']::text[] AND c.allowed_extensions = ARRAY['pdf']::text[]
+         AND c.max_size_bytes = 52428800::bigint AND c.approvals_required = 0::smallint
+         AND c.retention_months = 120 AND c.hold_on_publish = false AND c.is_active = true
+    )
+  $snapshot_ownership$ INTO snapshot_class_owned;
+  IF NOT snapshot_class_owned THEN
+    RAISE EXCEPTION 'Rollback refused: #612 system snapshot GED class is missing or its policy changed.';
+  END IF;
+
+  -- Dynamic SQL is intentional: PL/pgSQL may resolve a static table reference
+  -- before the IF guard runs, which would make an unapplied schema fail here.
+  EXECUTE 'SELECT EXISTS (SELECT 1 FROM public.authoritative_pdf_archives)' INTO has_rows;
+  IF has_rows THEN
+    RAISE EXCEPTION 'Rollback refused: authoritative PDF archive records exist.';
+  END IF;
+
+  IF to_regclass('public.ged_documents') IS NOT NULL THEN
+    EXECUTE 'SELECT EXISTS (SELECT 1 FROM public.ged_documents WHERE class_key = ''CERP_AUTHORITATIVE_PDF'')' INTO has_rows;
+    IF has_rows THEN
+      RAISE EXCEPTION 'Rollback refused: authoritative PDF GED documents exist.';
+    END IF;
+  END IF;
+  IF to_regclass('public.ged_documents') IS NOT NULL THEN
+    EXECUTE 'SELECT EXISTS (SELECT 1 FROM public.ged_documents WHERE class_key = ''CERP_SYSTEM_SNAPSHOT'')' INTO has_rows;
+    IF has_rows THEN RAISE EXCEPTION 'Rollback refused: system snapshot GED documents exist.'; END IF;
+  END IF;
+
+  -- The ledger proves ownership; if a referenced operator configuration exists
+  -- without it, the function returned above without touching the class.
+  EXECUTE 'DELETE FROM public.ged_document_classes WHERE class_key = ''CERP_AUTHORITATIVE_PDF''';
+  EXECUTE 'DELETE FROM public.ged_document_classes WHERE class_key = ''CERP_SYSTEM_SNAPSHOT''';
+END $$;
+
+DROP TABLE IF EXISTS public.authoritative_pdf_archive_outbox;
+DROP TABLE IF EXISTS public.authoritative_pdf_archives;
+DROP FUNCTION IF EXISTS public.fn_authoritative_pdf_archive_outbox_stamp_612();
+DROP FUNCTION IF EXISTS public.fn_authoritative_pdf_archive_outbox_complete_612();
+DROP FUNCTION IF EXISTS public.fn_authoritative_pdf_archive_immutable_612();
+DO $$
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    EXECUTE 'DELETE FROM public.cerp_schema_migrations WHERE filename = $1'
+      USING '20260823_authoritative_pdf_archive_612.sql';
+  END IF;
+END $$;
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_archive_612.verify.sql
+++ b/db/patches/support/20260823_authoritative_pdf_archive_612.verify.sql
@@ -1,0 +1,164 @@
+-- #612 verification — read-only and fail-closed on an incomplete runtime contract.
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+BEGIN
+  IF to_regclass('public.authoritative_pdf_archives') IS NULL
+     OR to_regclass('public.authoritative_pdf_archive_outbox') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_VERIFY_TABLE_MISSING';
+  END IF;
+  IF to_regclass('public.ged_document_classes') IS NULL
+     OR to_regclass('public.ged_documents') IS NULL
+     OR to_regclass('public.ged_document_versions') IS NULL
+     OR to_regclass('public.ged_document_links') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_VERIFY_GED_PREREQUISITE_MISSING';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_VERIFY_APP_ROLE_MISSING';
+  END IF;
+  IF to_regprocedure('gen_random_uuid()') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_VERIFY_UUID_GENERATOR_MISSING';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'authoritative_pdf_archive_outbox'
+       AND column_name = 'claim_token' AND data_type = 'uuid'
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_VERIFY_LEASE_TOKEN_MISSING';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.ged_document_classes c
+     WHERE c.class_key = 'CERP_AUTHORITATIVE_PDF'
+       AND c.domain = 'CERP'
+       AND c.label = 'PDF sortant autoritatif'
+       AND c.nature = 'GENERATED'
+       AND c.allowed_mime_types = ARRAY['application/pdf']::text[]
+       AND c.allowed_extensions = ARRAY['pdf']::text[]
+       AND c.max_size_bytes = 52428800::bigint
+       AND c.approvals_required = 0::smallint
+       AND c.retention_months = 120
+       AND c.hold_on_publish = false
+       AND c.is_active = true
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_VERIFY_GED_CLASS_INCOMPATIBLE';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.ged_document_classes c
+     WHERE c.class_key = 'CERP_SYSTEM_SNAPSHOT' AND c.domain = 'CERP'
+       AND c.label = 'Instantané interne de création' AND c.nature = 'GENERATED'
+       AND c.allowed_mime_types = ARRAY['application/pdf']::text[] AND c.allowed_extensions = ARRAY['pdf']::text[]
+       AND c.max_size_bytes = 52428800::bigint AND c.approvals_required = 0::smallint
+       AND c.retention_months = 120 AND c.hold_on_publish = false AND c.is_active = true
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_VERIFY_SYSTEM_SNAPSHOT_CLASS_INCOMPATIBLE';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.authoritative_pdf_archives'::regclass
+       AND conname = 'authoritative_pdf_archive_document_version_uq'
+       AND contype = 'u'
+       AND regexp_replace(upper(pg_get_constraintdef(oid)), '\s+', ' ', 'g') LIKE '%UNIQUE (ENTITY_TYPE, ENTITY_ID, DOCUMENT_KIND, DOCUMENT_VERSION)%'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.authoritative_pdf_archives'::regclass
+       AND conname = 'authoritative_pdf_archive_idempotency_uq'
+       AND contype = 'u'
+       AND regexp_replace(upper(pg_get_constraintdef(oid)), '\s+', ' ', 'g') LIKE '%UNIQUE (IDEMPOTENCY_KEY)%'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.authoritative_pdf_archives'::regclass
+       AND conname = 'authoritative_pdf_archive_complete_ck'
+       AND contype = 'c'
+       AND upper(pg_get_constraintdef(oid)) LIKE '%ARCHIVED_AT IS NULL%'
+       AND upper(pg_get_constraintdef(oid)) LIKE '%PDF_SHA256 IS NOT NULL%'
+       AND upper(pg_get_constraintdef(oid)) LIKE '%GED_DOCUMENT_ID IS NOT NULL%'
+       AND upper(pg_get_constraintdef(oid)) LIKE '%GED_VERSION_ID IS NOT NULL%'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.authoritative_pdf_archives'::regclass
+       AND conname = 'authoritative_pdf_archive_pdf_size_ck'
+       AND contype = 'c'
+       AND upper(pg_get_constraintdef(oid)) LIKE '%PDF_SIZE_BYTES <= 52428800%'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+     WHERE schemaname = 'public' AND indexname = 'authoritative_pdf_archive_snapshot_lookup_idx'
+       AND upper(indexdef) LIKE '%(ENTITY_TYPE, ENTITY_ID, DOCUMENT_KIND, SNAPSHOT_SHA256)%'
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_VERIFY_ARCHIVE_VERSIONING_MISSING';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.authoritative_pdf_archive_outbox'::regclass
+       AND conname = 'authoritative_pdf_archive_outbox_archive_uq'
+       AND contype = 'u'
+       AND regexp_replace(upper(pg_get_constraintdef(oid)), '\s+', ' ', 'g') LIKE '%UNIQUE (ARCHIVE_ID)%'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.authoritative_pdf_archive_outbox'::regclass
+       AND conname = 'authoritative_pdf_archive_outbox_lifecycle_ck'
+       AND contype = 'c'
+       AND upper(pg_get_constraintdef(oid)) LIKE '%STATUS = ''ARCHIVED''%'
+       AND upper(pg_get_constraintdef(oid)) LIKE '%ARCHIVED_AT IS NOT NULL%'
+       AND upper(pg_get_constraintdef(oid)) LIKE '%LOCKED_AT IS NOT NULL%'
+       AND upper(pg_get_constraintdef(oid)) LIKE '%LOCKED_BY IS NOT NULL%'
+       AND upper(pg_get_constraintdef(oid)) LIKE '%CLAIM_TOKEN IS NOT NULL%'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.authoritative_pdf_archive_outbox'::regclass
+       AND contype = 'c'
+       AND pg_get_constraintdef(oid) LIKE '%PENDING%'
+       AND pg_get_constraintdef(oid) LIKE '%PROCESSING%'
+       AND pg_get_constraintdef(oid) LIKE '%ARCHIVED%'
+       AND pg_get_constraintdef(oid) LIKE '%FAILED%'
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_VERIFY_OUTBOX_STATUS_CONSTRAINT_MISSING';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+     WHERE tgname = 'trg_authoritative_pdf_archive_immutable_612'
+       AND tgrelid = 'public.authoritative_pdf_archives'::regclass
+       AND tgfoid = to_regprocedure('public.fn_authoritative_pdf_archive_immutable_612()')
+       AND NOT tgisinternal
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+     WHERE tgname = 'trg_authoritative_pdf_archive_outbox_stamp_612'
+       AND tgrelid = 'public.authoritative_pdf_archive_outbox'::regclass
+       AND tgfoid = to_regprocedure('public.fn_authoritative_pdf_archive_outbox_stamp_612()')
+       AND NOT tgisinternal
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+     WHERE tgname = 'trg_authoritative_pdf_archive_outbox_complete_612'
+       AND tgrelid = 'public.authoritative_pdf_archive_outbox'::regclass
+       AND tgfoid = to_regprocedure('public.fn_authoritative_pdf_archive_outbox_complete_612()')
+       AND NOT tgisinternal
+  ) OR to_regprocedure('public.fn_authoritative_pdf_archive_immutable_612()') IS NULL
+     OR to_regprocedure('public.fn_authoritative_pdf_archive_outbox_stamp_612()') IS NULL
+     OR to_regprocedure('public.fn_authoritative_pdf_archive_outbox_complete_612()') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_VERIFY_IMMUTABILITY_MISSING';
+  END IF;
+END;
+$$;
+
+SELECT
+  EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'authoritative_pdf_archives'
+      AND column_name = 'document_version' AND data_type = 'integer'
+  ) AS archive_document_version_present,
+  EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'authoritative_pdf_archives'
+      AND column_name = 'source_revision'
+  ) AS archive_source_revision_present,
+  EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'authoritative_pdf_archive_outbox'
+      AND column_name = 'claim_token' AND data_type = 'uuid'
+  ) AS outbox_claim_token_present,
+  EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'authoritative_pdf_archive_outbox_ready_idx') AS outbox_ready_index_present,
+  EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'authoritative_pdf_archive_outbox_stale_idx') AS outbox_stale_lease_index_present,
+  EXISTS (SELECT 1 FROM public.ged_document_classes WHERE class_key = 'CERP_SYSTEM_SNAPSHOT') AS system_snapshot_class_present,
+  has_table_privilege('cerp_app', 'public.authoritative_pdf_archives', 'SELECT,INSERT,UPDATE') AS app_archive_privileges,
+  has_table_privilege('cerp_app', 'public.authoritative_pdf_archive_outbox', 'SELECT,INSERT,UPDATE') AS app_outbox_privileges;
+
+COMMIT;

--- a/docs/adr/ADR-0081-authoritative-pdf-archive.md
+++ b/docs/adr/ADR-0081-authoritative-pdf-archive.md
@@ -1,0 +1,145 @@
+# ADR-0081 — PDF sortants autoritatifs et versement GED automatique
+
+Chaque PDF sortant, officiel ou instantané interne de création, est produit
+depuis un instantané serveur figé, jamais depuis les données envoyées par le
+navigateur. La création de l'entité écrit dans la
+même transaction un registre `authoritative_pdf_archives` et une ligne d'outbox.
+Le worker rend ensuite le document, vérifie son SHA-256, l'insère dans le coffre
+GED adressé par contenu, le lie à l'entité et écrit l'audit GED.
+
+Une création répétée avec la même clé d'idempotence ne crée ni second registre ni
+second travail. Les octets, l'empreinte, les liens GED et l'instantané deviennent
+immuables une fois archivés. L'absence du coffre ne fait pas perdre la création :
+le travail reste `FAILED`, durable et réessayable après correction de l'infrastructure.
+
+Les modules conservent leur autorisation métier avant d'appeler
+`queueCreationPdfArchive`; le registre n'ajoute aucune route publique et ne peut
+donc pas élargir l'accès à une entité. Chaque producteur serveur explicite est
+enregistré dans `AuthoritativePdfProducerRegistry` par le couple
+`(entity_type, document_kind)`, afin qu'une même entité puisse porter plusieurs
+familles documentaires sans ambiguïté.
+
+Le worker réclame le travail puis exécute le rendu et le versement dans sa propre
+transaction GED. En cas d'échec, il termine cette transaction (rollback confirmé)
+avant d'ouvrir une transaction fraîche pour appeler `recordAuthoritativePdfItemFailure`.
+Chaque réclamation porte un jeton UUID éphémère : une ancienne exécution dont le
+lease a été récupéré ne peut ni finaliser ni faire échouer la réclamation plus récente.
+
+La migration de fondation est une création stricte et ponctuelle : elle refuse
+une classe GED ou des artefacts #612 préexistants. Son rollback s'appuie sur la
+preuve de propriété du registre canonique `cerp_schema_migrations`; un schéma
+entièrement non appliqué est un no-op, tandis qu'un artefact sans provenance est
+refusé plutôt que supprimé par supposition.
+
+## Contrat HTTP Wave 1
+
+Les collections officielles sont :
+
+- `POST|GET /commandes-fournisseurs/:id/official-documents`
+- `POST|GET /devis/:id/official-documents`
+- `POST|GET /commandes/:id/acknowledgements`
+
+Chaque collection expose aussi `/:documentId`, `preview`, `download` et
+`print-intents`; l'accusé de réception expose en plus `send`. Toutes sont
+protégées par l'authentification globale, le contrôle d'accès de module et une
+capacité d'export explicite. Les routes ne retournent jamais de chemin physique,
+de clé coffre ou d'erreur de rendu brute.
+
+Un `POST` porte `Idempotency-Key` et le corps strict
+`{ source_revision, reissue_reason? }`. Il renvoie exactement
+`{ state, latest_document, retryable, failure_code }`; l'état de génération UI
+est `NOT_GENERATED | PENDING | PROCESSING | READY | FAILED`.
+`NOT_GENERATED` signifie strictement qu'aucune tentative durable n'existe;
+`PENDING` signifie qu'une ligne outbox durable est bien en attente. Un état
+`FAILED` reste la même tentative durable et est repris par le worker, sans
+forcer le navigateur à créer une nouvelle édition. `latest_document`, lorsqu'il est
+disponible, contient exactement `id`, `kind`, `version` (entier métier),
+`state` (`ISSUED | SUPERSEDED | REVOKED`), `safe_filename`,
+`byte_sha256`, `byte_length`, `mime_type`, `issued_at`, `source_revision` et
+les URL preview/download sûres. Aucun chemin physique, localisateur GED ou
+détail d'erreur de rendu ne traverse ce contrat.
+
+Pour les trois familles Wave 1, `source_revision` est le jeton serveur
+persisté `updated_at` de l'agrégat. Il est présenté dans le document archivé
+pour pouvoir être renvoyé par le navigateur, puis revérifié sous verrou
+transactionnel avant toute nouvelle émission. Le SHA-256 de l'instantané est
+un champ d'intégrité séparé et ne sert jamais de jeton UI. Une reprise avec la
+même clé d'idempotence renvoie toujours l'exemplaire immuable déjà accepté,
+même si l'entité a changé entre-temps.
+
+`document_version` est une édition numérique monotone, indépendante de
+`render_version` (version interne du modèle PDF). Un même instantané peut être
+réémis intentionnellement avec une édition différente; l'unicité est donc
+portée par `(entity_type, entity_id, document_kind, document_version)`, tandis
+que chaque ligne conserve son instantané, son empreinte et ses octets exacts.
+
+Les accusés de réception sont archivés sous le parent
+`commande-client:<commande_id>`, jamais sous l'identifiant transitoire de
+l'accusé. Cet identifiant reste figé dans l'instantané pour la traçabilité; la
+chronologie et les versions affichées dans la commande sont ainsi continues.
+
+## Automatisation de création et classement GED
+
+Deux politiques documentaires sont volontairement distinctes :
+
+- les documents externes opposables (`CUSTOMER_QUOTE`,
+  `SUPPLIER_PURCHASE_ORDER`, accusés de réception) utilisent la classe GED
+  `CERP_AUTHORITATIVE_PDF` et le rôle de lien `AUTHORITATIVE_PDF` ;
+- les fiches de création internes utilisent la classe
+  `CERP_SYSTEM_SNAPSHOT` et le rôle `CREATION_SNAPSHOT`. Elles portent le
+  filigrane permanent `INTERNE / BROUILLON` et la mention « non opposable ».
+
+Pour toute nouvelle racine couverte, le registre et l'outbox sont écrits après
+la matérialisation de ses dépendances mais avant le `COMMIT` métier. Une erreur
+de mise en file annule donc aussi la création. Une erreur ultérieure du worker
+GED ne réécrit pas le métier : elle conserve un travail durable et réessayable.
+
+Le périmètre transactionnel couvre les chemins directs et alternatifs suivants :
+
+- client et fournisseur : création directe ;
+- commande client : création, conversion d'un devis et duplication ;
+- commande fournisseur : création directe, confirmation de propositions,
+  conversion de réapprovisionnement et duplication ;
+- devis : création directe et nouvelle révision ;
+- OF : création manuelle, génération et lancement depuis commande ; seul l'OF
+  racine reçoit la fiche, jamais ses enfants ;
+- pièce technique : création directe, duplication complète et promotion d'un
+  dossier préparatoire ;
+- affaire : création directe et tous les parcours de génération métier, sans
+  doublon lors d'un replay ;
+- article de stock : création directe, promotion préparatoire et les deux
+  parcours de création d'article de finition.
+
+Les reprises historiques `OLD` sont explicitement exclues : elles matérialisent
+en masse des données antérieures et ne constituent pas une création métier
+courante. Aucun backfill implicite n'est exécuté par la migration. Les objets
+créés avant cette mise en service peuvent donc répondre `NOT_GENERATED` jusqu'à
+une opération de reprise contrôlée distincte.
+
+Les instantanés sont composés par le serveur depuis des colonnes persistées et
+une grammaire bornée. Les chemins physiques, octets de pièces jointes, notes
+sensibles et clés supplémentaires non déclarées sont rejetés ou omis. Les noms
+de fichier sont normalisés et la même clé d'entité `:creation:v1` garantit une
+seule fiche initiale, y compris après rejeu idempotent.
+
+## Contrat HTTP des fiches de création
+
+Les sept racines exposées en lecture sont :
+
+- `/clients/:id/creation-snapshot`
+- `/fournisseurs/:id/creation-snapshot`
+- `/commandes/:id/creation-snapshot`
+- `/production/ofs/:id/creation-snapshot`
+- `/pieces-techniques/:id/creation-snapshot`
+- `/affaires/:id/creation-snapshot`
+- `/stock/articles/:id/creation-snapshot`
+
+Pour chacune, `GET` sur la racine retourne la métadonnée ;
+`GET /:documentId/preview`, `GET /:documentId/download` et
+`POST /:documentId/print-intents` servent exactement l'archive immuable et
+journalisent l'acteur. Il n'existe aucun `POST` d'émission ou de réémission pour
+une fiche interne. L'existence et le périmètre de la racine sont vérifiés avant
+la recherche d'archive, puis les gardes de module existantes restent appliquées.
+Les octets sont servis avec `private, no-store`, `nosniff`, une politique
+cross-origin restrictive et un `Content-Disposition` sûr ; l'aperçu ajoute un
+bac à sable CSP.

--- a/docs/http/openapi-route-coverage.json
+++ b/docs/http/openapi-route-coverage.json
@@ -1,9 +1,9 @@
 {
   "scope": "/api/v1",
-  "source_sha256": "b3b69bab92eec4e2f23670abaa0a2202e8337d3268429e92e945a267e9ba7107",
-  "discovered_operations": 1081,
-  "documented_operations": 1081,
+  "source_sha256": "f7ef2c7fd490b1828a5cd8a0c34e09ebbaa631784f0ff2ce7b3620014756af96",
+  "discovered_operations": 1128,
+  "documented_operations": 1128,
   "coverage_percent": 100,
-  "authenticated_operations": 1061,
+  "authenticated_operations": 1108,
   "public_operations": 20
 }

--- a/docs/release/MIGRATION_INVENTORY_SOL_06.json
+++ b/docs/release/MIGRATION_INVENTORY_SOL_06.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-08-23T09:59:43.470Z",
+  "generated_at": "2026-08-23T12:35:34.241Z",
   "source": "filesystem scan of db/patches and db/patches/support",
-  "patch_count": 170,
-  "support_file_count": 302,
-  "recent_patch_count": 112,
+  "patch_count": 171,
+  "support_file_count": 305,
+  "recent_patch_count": 113,
   "recent_support_gaps": [
     {
       "filename": "20260706_affaire_allow_projet.sql",
@@ -209,9 +209,9 @@
   "risk_totals": {
     "destructive_ddl": 2,
     "destructive_dml": 9,
-    "data_rewrite": 103,
+    "data_rewrite": 104,
     "table_lock": 130,
-    "blocking_index": 126,
+    "blocking_index": 127,
     "enum_change": 1
   },
   "patches": [
@@ -3113,6 +3113,23 @@
     },
     {
       "order": 170,
+      "filename": "20260823_authoritative_pdf_archive_612.sql",
+      "sha256": "776abd77520868b535de280d14ff61c71177b8cf131192f8b76ff836fec254d1",
+      "bytes": 10756,
+      "transaction_wrapped": true,
+      "replay_markers": true,
+      "support": {
+        "preflight": true,
+        "verify": true,
+        "rollback": true
+      },
+      "risks": [
+        "data-rewrite",
+        "blocking-index"
+      ]
+    },
+    {
+      "order": 171,
       "filename": "20260823_operational_media_access_611.sql",
       "sha256": "cad0368b00c3bff67a9390a0e1e9669bca37d0fa8bd4f89b4854aef5a1505415",
       "bytes": 11961,

--- a/docs/release/MIGRATION_INVENTORY_SOL_06.md
+++ b/docs/release/MIGRATION_INVENTORY_SOL_06.md
@@ -1,10 +1,10 @@
 # Inventaire des migrations — SOL-06
 
-- Généré : 2026-08-23T09:59:43.470Z
+- Généré : 2026-08-23T12:35:34.241Z
 - Source : filesystem scan of db/patches and db/patches/support
-- Patches exécutables : 170
-- Scripts auxiliaires : 302
-- Patches depuis 2026-07-01 : 112
+- Patches exécutables : 171
+- Scripts auxiliaires : 305
+- Patches depuis 2026-07-01 : 113
 
 ## Risques statiques à examiner
 
@@ -12,9 +12,9 @@
 |---|---:|
 | DDL destructif | 2 |
 | DML destructif | 9 |
-| Réécriture de données | 103 |
+| Réécriture de données | 104 |
 | Verrou de table possible | 130 |
-| Index non concurrent | 126 |
+| Index non concurrent | 127 |
 | Évolution d'enum | 1 |
 
 Ces détections sont volontairement conservatrices : elles servent de file de revue, pas de preuve de danger. Les durées réelles sont capturées par la répétition isolée.

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-23T10:02:10.720Z",
+  "started_at": "2026-08-23T13:58:32.612Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 19427,
-    "source_seed": 200,
-    "backup": 736,
-    "preflight": 157,
-    "integrity_before": 596,
-    "migration": 953,
-    "verify": 329,
-    "replay": 142,
-    "integrity_after": 1650,
-    "negative_gate": 46,
-    "rollback": 485,
-    "restore": 4076
+    "source_migration": 19137,
+    "source_seed": 211,
+    "backup": 767,
+    "preflight": 161,
+    "integrity_before": 576,
+    "migration": 1001,
+    "verify": 337,
+    "replay": 126,
+    "integrity_after": 1551,
+    "negative_gate": 40,
+    "rollback": 470,
+    "restore": 4079
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-23T10:02:33.655Z",
-    "duration_ms": 108,
+    "checked_at": "2026-08-23T13:58:55.488Z",
+    "duration_ms": 112,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36363287"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-8bRdiE\\cerp-test-before-sol06.dump",
-      "bytes": 1968536,
-      "sha256": "7bd25c74d6ccad6c35d710670d59a38a42243f339312c9fa50c6529a1206b5af",
-      "free_bytes": 373328035840
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-oGODNy\\cerp-test-before-sol06.dump",
+      "bytes": 1968552,
+      "sha256": "91762b69aa2bde844338da441dab92b6ff8c3f18c77198f511d9c30fd5c5fc5d",
+      "free_bytes": 371293040640
     },
     "ledger": {
       "applied": 140,
@@ -70,6 +70,7 @@
         "20260819_client_portal_auth_attempt_update_grant_004.sql",
         "20260819_devis_preparation_idempotency_grants_002_003.sql",
         "20260819_mfa_expired_artifact_cleanup_delete_grant.sql",
+        "20260823_authoritative_pdf_archive_612.sql",
         "20260823_operational_media_access_611.sql"
       ],
       "checksum_mismatches": [],
@@ -482,13 +483,14 @@
         "20260819_client_portal_auth_attempt_update_grant_004.sql",
         "20260819_devis_preparation_idempotency_grants_002_003.sql",
         "20260819_mfa_expired_artifact_cleanup_delete_grant.sql",
+        "20260823_authoritative_pdf_archive_612.sql",
         "20260823_operational_media_access_611.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "d5b753c1cb7873471cd22a411d06836cd840f96a36d714d74136f0b99d5671be"
+    "fingerprint": "2ab61304f8c151509f23cf9a7a9f006178a71ac6759b8dd48082c1ce75dbf680"
   },
   "replay": {
     "applied_zero": true,
@@ -496,8 +498,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-23T10:02:37.332Z",
-    "duration_ms": 1636,
+    "checked_at": "2026-08-23T13:58:59.084Z",
+    "duration_ms": 1536,
     "table_counts": {
       "accounting_export_batch_sources": "0",
       "accounting_export_batches": "0",
@@ -561,6 +563,8 @@
       "auth_login_logs": "0",
       "auth_mfa_challenges": "0",
       "auth_rate_limit_buckets": "0",
+      "authoritative_pdf_archive_outbox": "0",
+      "authoritative_pdf_archives": "0",
       "avoir": "0",
       "avoir_ligne": "0",
       "avoir_source_allocations": "0",
@@ -577,7 +581,7 @@
       "cerp_migration_supersessions": "5",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "170",
+      "cerp_schema_migrations": "171",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -672,7 +676,7 @@
       "ged_approvals": "0",
       "ged_blobs": "0",
       "ged_checkouts": "0",
-      "ged_document_classes": "21",
+      "ged_document_classes": "23",
       "ged_document_links": "0",
       "ged_document_relations": "0",
       "ged_document_versions": "0",
@@ -941,7 +945,7 @@
       "users": "8",
       "warehouses": "4"
     },
-    "table_count": 441,
+    "table_count": 443,
     "unvalidated_constraints": [
       {
         "table_name": "avoir",
@@ -1018,7 +1022,7 @@
         "groups": 0
       }
     ],
-    "foreign_key_count": 1226,
+    "foreign_key_count": 1230,
     "orphans": [],
     "readiness": [
       {
@@ -1030,7 +1034,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1047,7 +1051,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1065,7 +1069,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1091,7 +1095,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1108,7 +1112,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1126,7 +1130,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1146,7 +1150,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1164,7 +1168,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1190,7 +1194,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1208,7 +1212,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1227,7 +1231,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1265,7 +1269,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-23T10:02:35.696Z",
+        "freshness_at": "2026-08-23T13:58:57.549Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1284,13 +1288,13 @@
       }
     ],
     "ledger": {
-      "applied": 170,
+      "applied": 171,
       "pending": [],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "b3d931b3b854209fc0ca58cc7b31cf5711c78e0424a319e6eb10fc3e62166f43"
+    "fingerprint": "f24ac611f0bb05457a546060715e1306acee24b6faa44000d17684291a63330e"
   },
   "negative_gate": {
     "status": "passed",
@@ -1334,7 +1338,7 @@
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "d5b753c1cb7873471cd22a411d06836cd840f96a36d714d74136f0b99d5671be",
+    "fingerprint": "2ab61304f8c151509f23cf9a7a9f006178a71ac6759b8dd48082c1ce75dbf680",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1368,6 +1372,7 @@
         "20260819_client_portal_auth_attempt_update_grant_004.sql",
         "20260819_devis_preparation_idempotency_grants_002_003.sql",
         "20260819_mfa_expired_artifact_cleanup_delete_grant.sql",
+        "20260823_authoritative_pdf_archive_612.sql",
         "20260823_operational_media_access_611.sql"
       ],
       "checksum_mismatches": [],
@@ -1375,5 +1380,5 @@
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-23T10:02:42.142Z"
+  "completed_at": "2026-08-23T13:59:03.843Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-23T10:02:42.142Z
+- Exécutée : 2026-08-23T13:59:03.843Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36363287 octets
-- Sauvegarde : 1968536 octets, SHA-256 `7bd25c74d6ccad6c35d710670d59a38a42243f339312c9fa50c6529a1206b5af`
-- Patches avant/après : 140 / 170
+- Sauvegarde : 1968552 octets, SHA-256 `91762b69aa2bde844338da441dab92b6ff8c3f18c77198f511d9c30fd5c5fc5d`
+- Patches avant/après : 140 / 171
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `d5b753c1cb7873471cd22a411d06836cd840f96a36d714d74136f0b99d5671be` / `d5b753c1cb7873471cd22a411d06836cd840f96a36d714d74136f0b99d5671be`
+- Empreinte source/restaurée : `2ab61304f8c151509f23cf9a7a9f006178a71ac6759b8dd48082c1ce75dbf680` / `2ab61304f8c151509f23cf9a7a9f006178a71ac6759b8dd48082c1ce75dbf680`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 19427 |
-| source_seed | 200 |
-| backup | 736 |
-| preflight | 157 |
-| integrity_before | 596 |
-| migration | 953 |
-| verify | 329 |
-| replay | 142 |
-| integrity_after | 1650 |
-| negative_gate | 46 |
-| rollback | 485 |
-| restore | 4076 |
+| source_migration | 19137 |
+| source_seed | 211 |
+| backup | 767 |
+| preflight | 161 |
+| integrity_before | 576 |
+| migration | 1001 |
+| verify | 337 |
+| replay | 126 |
+| integrity_after | 1551 |
+| negative_gate | 40 |
+| rollback | 470 |
+| restore | 4079 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/src/__tests__/affaires.routes.test.ts
+++ b/src/__tests__/affaires.routes.test.ts
@@ -33,6 +33,11 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }));
 
+vi.mock("../shared/authoritative-documents/authoritative-document.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../shared/authoritative-documents/authoritative-document.service")>()),
+  queueCreationPdfArchive: vi.fn(),
+}));
+
 // Auth mock : rôle injecté via l'en-tête `x-test-role` (défaut administrateur) pour tester le RBAC.
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authenticateToken: (
@@ -60,6 +65,7 @@ vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
 }));
 
 import app from "../config/app";
+import { queueCreationPdfArchive } from "../shared/authoritative-documents/authoritative-document.service";
 import { withRealtimeOutboxDbMock } from "./helpers/realtime-outbox-db-mock";
 
 beforeEach(() => {
@@ -67,6 +73,7 @@ beforeEach(() => {
   mocks.poolConnect.mockReset();
   mocks.clientQuery.mockReset();
   mocks.clientRelease.mockReset();
+  vi.mocked(queueCreationPdfArchive).mockReset();
 
   mocks.poolConnect.mockResolvedValue({
     query: withRealtimeOutboxDbMock(mocks.clientQuery),
@@ -370,6 +377,18 @@ describe("/api/v1/affaires", () => {
     expect(params[0]).toBe(7);
     expect(String(params[1])).toMatch(/^AFF-\d{4}-0001$/);
     expect(params[1]).not.toBe("HACK-1"); // le code client est ignoré
+    expect(queueCreationPdfArchive).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        entityType: "affaire",
+        entityId: "7",
+        documentKind: "AFFAIR_CREATION_SNAPSHOT",
+        documentVersion: 1,
+        idempotencyKey: "affaire:7:creation:v1",
+        sourceRevision: "2026-02-02T10:00:00.000Z",
+      })
+    );
+    expect(vi.mocked(queueCreationPdfArchive).mock.calls[0]?.[1]?.sourceSnapshot).toMatchObject({ type: "INTERNAL_CREATION_SNAPSHOT" });
   });
 
   it("POST /api/v1/affaires rejects a livraison without client_id (400 VALIDATION_ERROR)", async () => {

--- a/src/__tests__/article-unit-stock-contract.test.ts
+++ b/src/__tests__/article-unit-stock-contract.test.ts
@@ -22,6 +22,11 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }));
 
+vi.mock("../shared/authoritative-documents/authoritative-document.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../shared/authoritative-documents/authoritative-document.service")>()),
+  queueCreationPdfArchive: vi.fn(),
+}));
+
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authenticateToken: (
     req: { user?: { id: number; role: string } },
@@ -179,7 +184,10 @@ describe("#475 article/stock unit contract", () => {
           is_active: Boolean(values[18]),
           status: String(values[14]),
         };
-        return { rows: [{ id: state.article.id }], rowCount: 1 };
+        return { rows: [{ id: state.article.id, updated_at: "2026-08-04T10:00:00.000Z" }], rowCount: 1 };
+      }
+      if (text.includes("SELECT updated_at::text AS updated_at FROM public.articles")) {
+        return state.article ? { rows: [{ updated_at: "2026-08-04T10:00:00.000Z" }], rowCount: 1 } : { rows: [], rowCount: 0 };
       }
       if (text.includes("SELECT stock_managed, lot_tracking FROM public.articles")) {
         return state.article

--- a/src/__tests__/authoritative-document.domain.test.ts
+++ b/src/__tests__/authoritative-document.domain.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+
+import { authoritativePdfFilename, assertAuthoritativePdfFilename } from "../shared/authoritative-documents/authoritative-document.filename";
+import { repoAssertAuthoritativePdfClaim, repoClaimAuthoritativePdfWork, repoFindLatestAuthoritativePdfForEntity, repoGetAuthoritativePdf, repoListAuthoritativePdfs, repoMarkAuthoritativePdfArchived, repoMarkAuthoritativePdfFailure } from "../shared/authoritative-documents/authoritative-document.repository";
+import { archiveClaimedAuthoritativePdf, AuthoritativePdfProducerRegistry, authoritativePdfGedPolicy, canonicalJson, officialDocumentGenerationEnvelope, queueCreationPdfArchive, sha256Text } from "../shared/authoritative-documents/authoritative-document.service";
+import type { ArchiveQueueItem } from "../shared/authoritative-documents/authoritative-document.types";
+
+function archiveItem(overrides: Partial<ArchiveQueueItem["archive"]> = {}): ArchiveQueueItem {
+  return {
+    outboxId: "22222222-2222-4222-8222-222222222222",
+    claimToken: "33333333-3333-4333-8333-333333333333",
+    archive: {
+      id: "11111111-1111-4111-8111-111111111111",
+      entityType: "devis",
+      entityId: "1",
+      documentKind: "CUSTOMER_QUOTE",
+      documentVersion: 1,
+      renderVersion: "renderer-v7",
+      idempotencyKey: "devis:1:creation:v1",
+      title: "Devis DV-2026-001",
+      originalName: "DEVIS-DV-2026-001-v1.pdf",
+      sourceRevision: "2026-08-23 10:00:00+00",
+      sourceSnapshot: {},
+      actorUserId: 1,
+      createdAt: "2026-08-23T10:00:00.000Z",
+      snapshotSha256: "a".repeat(64),
+      pdfSha256: null,
+      pdfSizeBytes: null,
+      gedDocumentId: null,
+      gedVersionId: null,
+      archivedAt: null,
+      ...overrides,
+    },
+  };
+}
+
+describe("authoritative PDF archive foundation (#612)", () => {
+  it("uses the dedicated GED class only for explicitly allowlisted internal creation snapshots", () => {
+    expect(authoritativePdfGedPolicy("CLIENT_CREATION_SNAPSHOT")).toEqual({ classKey: "CERP_SYSTEM_SNAPSHOT", linkRole: "CREATION_SNAPSHOT", eventType: "CREATION_SNAPSHOT_ARCHIVED" });
+    expect(authoritativePdfGedPolicy("CUSTOMER_QUOTE")).toEqual({ classKey: "CERP_AUTHORITATIVE_PDF", linkRole: "AUTHORITATIVE_PDF", eventType: "AUTHORITATIVE_PDF_ARCHIVED" });
+    expect(authoritativePdfGedPolicy("INVENTED_CREATION_SNAPSHOT").classKey).toBe("CERP_AUTHORITATIVE_PDF");
+  });
+  it("canonicalizes a creation snapshot independently of source key order", () => {
+    const left = { entity: { id: "42", lines: [{ quantity: 2, ref: "P-01" }] }, created: "2026-08-23T10:00:00Z" };
+    const right = { created: "2026-08-23T10:00:00Z", entity: { lines: [{ ref: "P-01", quantity: 2 }], id: "42" } };
+    expect(canonicalJson(left)).toBe(canonicalJson(right));
+    expect(sha256Text(canonicalJson(left))).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("creates portable deterministic PDF filenames and rejects unsafe names", () => {
+    expect(authoritativePdfFilename(["Commande client", "BC/2026:001", "épreuve"])).toBe("Commande-client-BC-2026-001-epreuve.pdf");
+    expect(() => assertAuthoritativePdfFilename("../../secret.pdf")).toThrow("AUTHORITATIVE_PDF_FILENAME_INVALID");
+  });
+
+  it("rejects overlong queue identifiers before a database error can leak", async () => {
+    const tx = { query: async () => ({ rows: [] }) };
+    await expect(queueCreationPdfArchive(tx, {
+      entityType: "devis",
+      entityId: "x".repeat(161),
+      documentKind: "CUSTOMER_QUOTE",
+      documentVersion: 1,
+      renderVersion: "creation-v1",
+      idempotencyKey: "queue-input-test",
+      title: "Devis",
+      originalName: "DEVIS-TEST.pdf",
+      sourceRevision: "2026-08-23 10:00:00+00",
+      sourceSnapshot: {},
+      actorUserId: 1,
+    })).rejects.toThrow("AUTHORITATIVE_PDF_IDENTITY_INVALID");
+  });
+
+  it("turns a residual business-edition uniqueness race into a safe conflict", async () => {
+    const duplicate = Object.assign(new Error("duplicate"), {
+      code: "23505",
+      constraint: "authoritative_pdf_archive_document_version_uq",
+    });
+    const tx = { query: async () => { throw duplicate; } };
+    await expect(queueCreationPdfArchive(tx, {
+      entityType: "devis",
+      entityId: "42",
+      documentKind: "CUSTOMER_QUOTE",
+      documentVersion: 2,
+      renderVersion: "devis-pdf-v1",
+      idempotencyKey: "quote:42:reissue:2",
+      title: "Devis",
+      originalName: "DEVIS-42-v2.pdf",
+      sourceRevision: "2026-08-23 10:00:00+00",
+      sourceSnapshot: { id: 42 },
+      actorUserId: 1,
+    })).rejects.toMatchObject({ status: 409, code: "OFFICIAL_DOCUMENT_VERSION_CONFLICT" });
+  });
+
+  it("rejects an idempotency key replay whose frozen request differs", async () => {
+    let calls = 0;
+    const tx = {
+      query: async () => {
+        calls += 1;
+        if (calls === 1) return { rows: [] };
+        return { rows: [{
+          id: "11111111-1111-4111-8111-111111111111", entity_type: "devis", entity_id: "42", document_kind: "CUSTOMER_QUOTE",
+          document_version: 1, render_version: "devis-pdf-v1", idempotency_key: "quote:42:creation:v1", title: "Devis", original_name: "DEVIS-42-v1.pdf",
+          source_snapshot: { id: 42 }, source_revision: "2026-08-22 10:00:00+00", snapshot_sha256: "b".repeat(64), pdf_sha256: null,
+          pdf_size_bytes: null, ged_document_id: null, ged_version_id: null, archived_at: null, created_at: "2026-08-23T10:00:00.000Z", created_by: 1,
+        }] };
+      },
+    };
+    await expect(queueCreationPdfArchive(tx, {
+      entityType: "devis", entityId: "42", documentKind: "CUSTOMER_QUOTE", documentVersion: 1, renderVersion: "devis-pdf-v1",
+      idempotencyKey: "quote:42:creation:v1", title: "Devis", originalName: "DEVIS-42-v1.pdf",
+      sourceRevision: "2026-08-23 10:00:00+00", sourceSnapshot: { id: 42 }, actorUserId: 1,
+    })).rejects.toMatchObject({ status: 409, code: "OFFICIAL_DOCUMENT_IDEMPOTENCY_CONFLICT" });
+  });
+
+  it("keeps the renderer revision stable across deliberate same-source business editions", () => {
+    const first = archiveItem({ documentVersion: 1, renderVersion: "devis-pdf-v1", sourceSnapshot: { id: 42, total: "100.00" } }).archive;
+    const reissue = archiveItem({ documentVersion: 2, renderVersion: "devis-pdf-v1", sourceSnapshot: { total: "100.00", id: 42 } }).archive;
+    expect(canonicalJson(first.sourceSnapshot)).toBe(canonicalJson(reissue.sourceSnapshot));
+    expect(first.renderVersion).toBe(reissue.renderVersion);
+    expect(reissue.documentVersion).toBe(first.documentVersion + 1);
+  });
+
+  it("keys server-only renderers by entity family and document kind", () => {
+    const registry = new AuthoritativePdfProducerRegistry();
+    registry.register("commande-client", "CUSTOMER_ORDER_ACKNOWLEDGEMENT", async () => Buffer.from("%PDF-1.7"));
+    registry.register("commande-client", "CUSTOMER_ORDER_CERTIFICATE", async () => Buffer.from("%PDF-1.7"));
+    expect(registry.get("commande-client", "CUSTOMER_ORDER_ACKNOWLEDGEMENT")).not.toBeNull();
+    expect(registry.get("commande-client", "CUSTOMER_ORDER_CERTIFICATE")).not.toBeNull();
+    expect(registry.get("commande-client", "UNREGISTERED_KIND")).toBeNull();
+    expect(() => registry.register("commande-client", "CUSTOMER_ORDER_ACKNOWLEDGEMENT", async () => Buffer.alloc(0))).toThrow("AUTHORITATIVE_PDF_PRODUCER_ALREADY_REGISTERED");
+  });
+
+  it("binds every shared archive lookup to its exact document kind", async () => {
+    const calls: Array<[string, unknown[]]> = [];
+    const spyTx = {
+      query: async (sql: string, params: unknown[]) => {
+        calls.push([sql, params]);
+        return { rows: [] };
+      },
+    };
+    await repoListAuthoritativePdfs(spyTx, "commande-client", "123", "CUSTOMER_ORDER_ACKNOWLEDGEMENT");
+    await repoGetAuthoritativePdf(spyTx, "commande-client", "123", "11111111-1111-4111-8111-111111111111", "CUSTOMER_ORDER_ACKNOWLEDGEMENT");
+    await repoFindLatestAuthoritativePdfForEntity(spyTx, "commande-client", "123", "CUSTOMER_ORDER_ACKNOWLEDGEMENT");
+    expect(calls[0]?.[0]).toContain("a.document_kind = $3");
+    expect(calls[0]?.[1]).toEqual(["commande-client", "123", "CUSTOMER_ORDER_ACKNOWLEDGEMENT"]);
+    expect(calls[1]?.[0]).toContain("a.document_kind = $4");
+    expect(calls[1]?.[1]).toEqual(["11111111-1111-4111-8111-111111111111", "commande-client", "123", "CUSTOMER_ORDER_ACKNOWLEDGEMENT"]);
+    expect(calls[2]?.[0]).toContain("a.document_kind = $3");
+    expect(calls[2]?.[0]).not.toContain("$3::text IS NULL");
+    expect(calls[2]?.[1]).toEqual(["commande-client", "123", "CUSTOMER_ORDER_ACKNOWLEDGEMENT"]);
+  });
+
+  it("carries the exact fresh claim token from the outbox claim into the worker item", async () => {
+    const claimToken = "33333333-3333-4333-8333-333333333333";
+    const tx = {
+      query: async () => ({ rows: [{
+        outbox_id: "22222222-2222-4222-8222-222222222222", claim_token: claimToken,
+        id: "11111111-1111-4111-8111-111111111111", entity_type: "devis", entity_id: "42", document_kind: "CUSTOMER_QUOTE",
+        document_version: 1, render_version: "devis-pdf-v1", idempotency_key: "devis:42:creation:v1", title: "Devis", original_name: "DEVIS-42-v1.pdf",
+        source_snapshot: {}, source_revision: "2026-08-23 10:00:00+00", snapshot_sha256: "a".repeat(64), pdf_sha256: null,
+        pdf_size_bytes: null, ged_document_id: null, ged_version_id: null, archived_at: null, created_at: "2026-08-23T10:00:00.000Z", created_by: 1,
+      }] }),
+    };
+    const claimed = await repoClaimAuthoritativePdfWork(tx, "worker-1", 8);
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0]?.claimToken).toBe(claimToken);
+  });
+
+  it("closes the outbox lease when an archive becomes durable", async () => {
+    const calls: string[] = [];
+    const tx = {
+      query: async (sql: string) => {
+        calls.push(sql);
+        return { rows: [], rowCount: 1 };
+      },
+    };
+    await repoMarkAuthoritativePdfArchived(tx, {
+      archiveId: "11111111-1111-4111-8111-111111111111",
+      outboxId: "22222222-2222-4222-8222-222222222222",
+      claimToken: "33333333-3333-4333-8333-333333333333",
+      pdfSha256: "a".repeat(64), pdfSizeBytes: 1,
+      gedDocumentId: "33333333-3333-4333-8333-333333333333",
+      gedVersionId: "44444444-4444-4444-8444-444444444444",
+      actorUserId: 1,
+    });
+    expect(calls[1]).toContain("locked_at = NULL, locked_by = NULL");
+    expect(calls[1]).toContain("claim_token = $3::uuid");
+  });
+
+  it("refuses a reclaimed worker lease from completing or failing the newer claim", async () => {
+    let completionCalls = 0;
+    const archiveThenMissingOutbox = {
+      query: async (_sql: string) => ({ rows: [], rowCount: ++completionCalls === 1 ? 1 : 0 }),
+    };
+    await expect(repoMarkAuthoritativePdfArchived(archiveThenMissingOutbox, {
+      archiveId: "11111111-1111-4111-8111-111111111111", outboxId: "22222222-2222-4222-8222-222222222222",
+      claimToken: "33333333-3333-4333-8333-333333333333", pdfSha256: "a".repeat(64), pdfSizeBytes: 1, gedDocumentId: "33333333-3333-4333-8333-333333333333",
+      gedVersionId: "44444444-4444-4444-8444-444444444444", actorUserId: 1,
+    })).rejects.toThrow("AUTHORITATIVE_PDF_OUTBOX_ARCHIVE_TRANSITION_FAILED");
+
+    const outboxMissing = { query: async () => ({ rows: [], rowCount: 0 }) };
+    await expect(repoMarkAuthoritativePdfFailure(outboxMissing, { outboxId: "22222222-2222-4222-8222-222222222222", claimToken: "33333333-3333-4333-8333-333333333333", message: "AUTHORITATIVE_PDF_NOT_PDF" }))
+      .rejects.toThrow("AUTHORITATIVE_PDF_OUTBOX_FAILURE_TRANSITION_FAILED");
+
+    const staleClaimQueries: string[] = [];
+    await expect(repoAssertAuthoritativePdfClaim({ query: async (sql: string) => {
+      staleClaimQueries.push(sql);
+      return { rows: [] };
+    } }, {
+      archiveId: "11111111-1111-4111-8111-111111111111", outboxId: "22222222-2222-4222-8222-222222222222", claimToken: "33333333-3333-4333-8333-333333333333",
+    })).rejects.toThrow("AUTHORITATIVE_PDF_CLAIM_STALE");
+    expect(staleClaimQueries[0]).toContain("FOR UPDATE");
+  });
+
+  it("exposes a browser-safe envelope while a newer attempt is still pending", () => {
+    const issued = archiveItem({
+      pdfSha256: "b".repeat(64), pdfSizeBytes: 1234, gedDocumentId: "33333333-3333-4333-8333-333333333333",
+      gedVersionId: "44444444-4444-4444-8444-444444444444", archivedAt: "2026-08-23T10:01:00.000Z",
+    }).archive;
+    const pending = archiveItem({
+      id: "55555555-5555-4555-8555-555555555555", documentVersion: 2, renderVersion: "renderer-v8",
+      createdAt: "2026-08-23T10:02:00.000Z", idempotencyKey: "devis:1:reissue:v2",
+    }).archive;
+    expect(officialDocumentGenerationEnvelope([
+      { ...issued, state: "ARCHIVED" as const },
+      { ...pending, state: "PENDING" as const },
+    ], "/devis/1/official-documents")).toEqual({
+      state: "PENDING",
+      latest_document: expect.objectContaining({
+        id: issued.id,
+        version: 1,
+        state: "ISSUED",
+        byte_sha256: "b".repeat(64),
+        byte_length: 1234,
+        source_revision: "2026-08-23 10:00:00+00",
+      }),
+      retryable: false,
+      failure_code: null,
+    });
+    expect(officialDocumentGenerationEnvelope([{ ...issued, state: "ARCHIVED" as const }], "/devis/1/official-documents")).toMatchObject({
+      state: "READY",
+      retryable: false,
+      failure_code: null,
+    });
+    expect(officialDocumentGenerationEnvelope([], "/devis/1/official-documents")).toEqual({
+      state: "NOT_GENERATED",
+      latest_document: null,
+      retryable: false,
+      failure_code: null,
+    });
+  });
+
+  it("orders offset-form archive timestamps by instant rather than lexicographically", () => {
+    const olderIssued = archiveItem({
+      id: "11111111-1111-4111-8111-111111111111", createdAt: "2026-08-23T10:00:00+02:00",
+      pdfSha256: "b".repeat(64), pdfSizeBytes: 1234, gedDocumentId: "33333333-3333-4333-8333-333333333333",
+      gedVersionId: "44444444-4444-4444-8444-444444444444", archivedAt: "2026-08-23T08:01:00.000Z",
+    }).archive;
+    const newerPending = archiveItem({
+      id: "55555555-5555-4555-8555-555555555555", createdAt: "2026-08-23T09:00:00Z",
+      // Same version isolates timestamp ordering; the persistence constraint
+      // prevents this shape in production.
+      documentVersion: 1,
+    }).archive;
+    expect(officialDocumentGenerationEnvelope([
+      { ...olderIssued, state: "ARCHIVED" as const },
+      { ...newerPending, state: "PENDING" as const },
+    ], "/devis/42/official-documents").state).toBe("PENDING");
+  });
+
+  it("rejects invalid PDFs before vault or GED writes", async () => {
+    const tx = { query: async () => { throw new Error("GED_WRITE_MUST_NOT_RUN"); } };
+    await expect(archiveClaimedAuthoritativePdf(tx, archiveItem(), Buffer.alloc(0))).rejects.toThrow("AUTHORITATIVE_PDF_EMPTY");
+    await expect(archiveClaimedAuthoritativePdf(tx, archiveItem(), Buffer.from("not a pdf"))).rejects.toThrow("AUTHORITATIVE_PDF_NOT_PDF");
+    await expect(archiveClaimedAuthoritativePdf(tx, archiveItem(), Buffer.concat([Buffer.from("%PDF-"), Buffer.alloc(52_428_800)]))).rejects.toThrow("AUTHORITATIVE_PDF_SIZE_EXCEEDED");
+  });
+});

--- a/src/__tests__/authoritative-pdf-renderers.test.ts
+++ b/src/__tests__/authoritative-pdf-renderers.test.ts
@@ -1,0 +1,218 @@
+import { inflateSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+
+import { renderSupplierPurchaseOrderOfficialPdf } from "../module/commande-fournisseur/services/commande-fournisseur-official-pdf";
+import { renderDevisOfficialPdf } from "../module/devis/services/devis-official-pdf";
+import { renderCommandeArOfficialPdf } from "../module/commande-client/services/commande-ar.service";
+import { renderCerpDocument } from "../shared/pdf/cerp-document";
+import { parseInternalCreationSnapshot, renderInternalCreationSnapshotPdf } from "../shared/authoritative-documents/internal-creation-snapshot-pdf";
+import { buildInternalCreationSnapshot } from "../shared/authoritative-documents/internal-creation-snapshot";
+
+const archive = (sourceSnapshot: Record<string, unknown>) => ({
+  id: "11111111-1111-4111-8111-111111111111", entityType: "fixture", entityId: "42", documentKind: "FIXTURE",
+  documentVersion: 7, renderVersion: "qa-render-v1", idempotencyKey: "fixture:42:creation:v1", title: "Fixture", originalName: "fixture.pdf",
+  sourceRevision: "2026-08-23 10:00:00+00", createdAt: "2026-08-23T10:00:00.000Z",
+  sourceSnapshot, snapshotSha256: "a".repeat(64), pdfSha256: null, pdfSizeBytes: null, gedDocumentId: null,
+  gedVersionId: null, archivedAt: null, actorUserId: 1,
+});
+
+const issuer = { company_name: "CROIX ROUSSE PRECISION", legal_form: "SARL", siret: "38056901200020" };
+
+function pageTexts(bytes: Buffer): string[] {
+  const pages: string[] = [];
+  let cursor = 0;
+  for (;;) {
+    const start = bytes.indexOf("stream", cursor);
+    if (start < 0) break;
+    let from = start + "stream".length;
+    if (bytes[from] === 0x0d) from += 1;
+    if (bytes[from] === 0x0a) from += 1;
+    const end = bytes.indexOf("endstream", from);
+    if (end < 0) break;
+    cursor = end + "endstream".length;
+    let stream: string;
+    try { stream = inflateSync(bytes.subarray(from, end)).toString("latin1"); }
+    catch { continue; }
+    pages.push([...stream.matchAll(/\((?:\\.|[^\\)])*\)|<[0-9a-fA-F\s]+>/g)]
+      .map((match) => {
+        const value = match[0];
+        if (value.startsWith("<")) return Buffer.from(value.slice(1, -1).replace(/\s+/g, ""), "hex").toString("latin1");
+        return value.slice(1, -1).replace(/\\([()\\])/g, "$1");
+      })
+      .join(" "));
+  }
+  return pages;
+}
+
+// PDFKit can split one visual word across several text-showing operations.  The
+// layout assertion therefore compares a compact form rather than assuming the
+// internal PDF text operators retain visual word boundaries.
+function compactPdfText(value: string): string {
+  return value.replace(/\s+/g, "").toUpperCase();
+}
+
+describe("Wave-1 official PDF renderers", () => {
+  it("renders a long internal creation snapshot as visibly non-opposable", async () => {
+    const bytes = await renderInternalCreationSnapshotPdf({ archive: archive(buildInternalCreationSnapshot({
+      entityLabel: "Fiche client", reference: "CLI-0042", issuer,
+      summary: [{ label: "Client", value: "Client Test" }],
+      sections: [{ title: "Données", rows: Array.from({ length: 50 }, (_, index) => ({ label: `Champ ${index}`, value: `Valeur ${index}` })) }],
+    })) });
+    const text = compactPdfText(pageTexts(bytes).join(" "));
+    expect(bytes.subarray(0, 5).toString("ascii")).toBe("%PDF-");
+    expect(text).toContain("INTERNE/BROUILLON");
+    expect(text).toContain("NONOPPOSABLE");
+    expect(text).toContain("VALEUR49");
+  });
+
+  it("sanitizes creation-table columns and persists only declared bounded cells", () => {
+    const snapshot = buildInternalCreationSnapshot({
+      entityLabel: "Article", reference: "ART-42",
+      sections: [{
+        title: "Données",
+        table: {
+          columns: [
+            { key: "reference", label: "Référence" },
+            { key: "reference", label: "Doublon" },
+            { key: "../secret", label: "Invalide" },
+          ],
+          rows: [{ reference: "ART-42", unexpected: "must-not-enter-the-archive" }],
+        },
+      }],
+    });
+    const table = snapshot.sections[0]?.table;
+    expect(table?.columns).toEqual([{ key: "reference", label: "Référence" }]);
+    expect(table?.rows).toEqual([{ reference: "ART-42" }]);
+  });
+
+  it.each([
+    { reference: "ART-42", unexpected: "extra" },
+    { reference: 42 },
+    ["ART-42"],
+  ])("rejects a malformed immutable creation-table row %#", (row) => {
+    const source = buildInternalCreationSnapshot({
+      entityLabel: "Article", reference: "ART-42",
+      sections: [{ title: "Données", table: { columns: [{ key: "reference", label: "Référence" }], rows: [{ reference: "ART-42" }] } }],
+    });
+    const malformed = { ...source, sections: [{ ...source.sections[0], table: { ...source.sections[0]!.table!, rows: [row] } }] };
+    expect(() => parseInternalCreationSnapshot(archive(malformed))).toThrow("INTERNAL_CREATION_SNAPSHOT_INVALID");
+  });
+
+  it("renders a supplier PO only from its frozen external-safe snapshot", async () => {
+    const bytes = await renderSupplierPurchaseOrderOfficialPdf({ archive: archive({
+      type: "SUPPLIER_PURCHASE_ORDER", code: "BCF-2026-0042", status: "BROUILLON", issued_at: "2026-08-23T10:00:00Z",
+      supplier: { code: "SUP-42", name: "Fournisseur Test", address: { street: "Rue des Forges", house_number: "12", postal_code: "69007", city: "Lyon", country: "France" } }, currency: "EUR", need_date: null, incoterm: null,
+      payment_terms: null, transport_mode: null, public_comment: "Livrer avec certificat.", delivery_address: null,
+      lines: [{ position: 1, reference: "MAT-01", designation: "Matière", unit: "kg", quantity: "12.500", unit_price_ht: "10.00", discount_pct: "0", vat_pct: "20", net_ht: "125.00", need_date: null }],
+      totals: { total_ht: "125.00", total_discount: "0.00", total_vat: "25.00", freight_ht: "17.00", total_ttc: "167.00" }, issuer,
+    }) });
+    expect(bytes.subarray(0, 5).toString("ascii")).toBe("%PDF-");
+    expect(bytes.byteLength).toBeGreaterThan(1000);
+    const text = compactPdfText(pageTexts(bytes).join(" "));
+    expect(text).toContain("INTERNE/BROUILLON");
+    expect(text).toContain("FRAISDEPORTHT");
+    expect(text).toContain("RUEDESFORGES");
+    expect(text).toContain("VERSION7");
+    expect(text).not.toContain("QARENDERV1");
+    expect(text).not.toContain("ORIGINALGED");
+  });
+
+  it("renders a quote from precise decimal-string totals", async () => {
+    const bytes = await renderDevisOfficialPdf({ archive: archive({
+      type: "CUSTOMER_QUOTE", number: "DEV-2026-0042", status: "BROUILLON", issued_at: "2026-08-23T10:00:00Z", valid_until: "2026-09-22", version: "1",
+      customer: { code: "CLI-042", name: "Client Test", address: { name: "Client Test", street: "Avenue des Alpes", house_number: "4", postal_code: "74000", city: "Annecy", country: "France" } }, currency: "EUR", public_comment: null,
+      lines: [{ position: 1, reference: "PT-42", designation: "Pièce usinée", quantity: "2.000", unit: "pce", unit_price_ht: "1200.50", discount_pct: "2.50", vat_pct: "20.00", total_ht: "2340.975", total_ttc: "2809.170" }],
+      totals: { total_ht: "2340.975", total_ttc: "2809.170", global_discount_pct: "0.00" }, issuer,
+    }) });
+    expect(bytes.subarray(0, 5).toString("ascii")).toBe("%PDF-");
+    expect(bytes.byteLength).toBeGreaterThan(1000);
+    const text = compactPdfText(pageTexts(bytes).join(" "));
+    expect(text).toContain("INTERNE/BROUILLON");
+    expect(text).toContain("CLI-042");
+    expect(text).toContain("AVENUEDESALPES");
+    expect(text).toContain("VERSION7");
+    // PDF text streams encode the Euro glyph as a legacy single-byte code;
+    // assert the canonical rendered amount rather than that extractor detail.
+    expect(text).toContain("2340,98");
+    expect(text).not.toContain("2340,975");
+    expect(text).not.toContain("QARENDERV1");
+  });
+
+  it("repeats the table header instead of letting PDFKit split a discounted row", async () => {
+    const lines = Array.from({ length: 42 }, (_, index) => ({
+      position: index + 1,
+      reference: `PT-${String(index + 1).padStart(3, "0")}`,
+      designation: `Pièce usinée aéronautique ${index + 1} — contrôle dimensionnel et traçabilité lot exigée`,
+      quantity: String(index + 1),
+      unit: "pce",
+      unit_price_ht: "1234.56",
+      discount_pct: index % 3 === 0 ? "2.50" : null,
+      vat_pct: "20.00",
+      total_ht: String((index + 1) * 1234.56),
+      total_ttc: String((index + 1) * 1481.472),
+    }));
+    const bytes = await renderDevisOfficialPdf({ archive: archive({
+      type: "CUSTOMER_QUOTE", number: "DEV-LONG-42", status: "BROUILLON", issued_at: "2026-08-23T10:00:00Z",
+      valid_until: "2026-09-22", version: "1", customer: { code: "CLI-042", name: "Client Test" },
+      currency: "EUR", public_comment: null, lines,
+      totals: { total_ht: "111111.11", total_ttc: "133333.33", global_discount_pct: "2.50" }, issuer,
+    }) });
+    const text = compactPdfText(pageTexts(bytes).join(" "));
+    const pdfPageCount = bytes.toString("latin1").match(/\/Type \/Page\b/g)?.length ?? 0;
+    const repeatedHeaders = text.match(/RÉFÉRENCE/g)?.length ?? 0;
+
+    expect(pdfPageCount).toBeGreaterThan(1);
+    expect(repeatedHeaders).toBe(pdfPageCount);
+    for (let index = 1; index <= 42; index += 1) {
+      expect(text).toContain(`PT-${String(index).padStart(3, "0")}`);
+    }
+  });
+
+  it("keeps the source issue date visible while stamping a reissue with its immutable archive time", async () => {
+    const bytes = await renderDevisOfficialPdf({ archive: {
+      ...archive({
+        type: "CUSTOMER_QUOTE", number: "DEV-2025-0007", status: "ENVOYE", issued_at: "2025-01-02T09:00:00Z", valid_until: null, version: "1",
+        customer: { code: "CLI-007", name: "Client Test" }, currency: "EUR", public_comment: null,
+        lines: [{ position: 1, reference: null, designation: "Prestation", quantity: "1", unit: "u", unit_price_ht: "100.00", discount_pct: null, vat_pct: "20", total_ht: "100.00", total_ttc: "120.00" }],
+        totals: { total_ht: "100.00", total_ttc: "120.00", global_discount_pct: null }, issuer,
+      }),
+      documentVersion: 2,
+      createdAt: "2026-08-23T10:00:00.000Z",
+    } });
+    const compact = compactPdfText(pageTexts(bytes).join(" "));
+    expect(compact).toContain("VERSION2");
+    expect(compact).toContain("ÉMISLE02/01/2025");
+    expect(compact).toContain("GÉNÉRÉLE23/08/2026");
+    expect(bytes.toString("latin1")).toContain("/CreationDate");
+  });
+
+  it("marks a draft customer acknowledgement as internal rather than an issued original", async () => {
+    const bytes = await renderCommandeArOfficialPdf({ archive: archive({
+      type: "CUSTOMER_ORDER_ACKNOWLEDGEMENT", acknowledgement_id: "11111111-1111-4111-8111-111111111112",
+      acknowledgement_number: "AR-CC-2026-0042", order_number: "CC-2026-0042", generated_at: "2026-08-23T10:00:00Z",
+      status: "BROUILLON", customer_name: "Client Test", date_commande: "2026-08-20", total_ht: "125.00", total_ttc: "150.00",
+      public_comment: null, bill_address: {}, delivery_address: {},
+      lines: [{ designation: "Pièce usinée", code_piece: "PT-42", quantite: "1", unite: "pce", prix_unitaire_ht: "125.00", taux_tva: "20", total_ttc: "150.00" }],
+      issuer,
+    }) });
+    const text = compactPdfText(pageTexts(bytes).join(" "));
+    expect(text).toContain("INTERNE/BROUILLON");
+    expect(text).toContain("VERSION7");
+    expect(text).toContain("AR-CC-2026-0042");
+    expect(text).toContain("COMMANDECC-2026-0042");
+    expect(text).not.toContain("ORIGINALGED");
+    expect(text).not.toContain("QARENDERV1");
+  });
+
+  it("paginates a long note in bounded blocks above the legal footer", async () => {
+    const note = Array.from({ length: 450 }, (_, index) => `Instruction-${index} de production et de conformité.`).join(" ");
+    const bytes = await renderCerpDocument({
+      documentType: "Test", name: "Note longue", code: "TEST-1", status: "BROUILLON", monogramName: "Test",
+      generatedAt: "23/08/2026", title: "Test notes", subject: "Test", creationDate: new Date("2026-08-23T10:00:00Z"),
+      legalIdentity: "CERP", legalMentions: ["Mention légale de test"],
+    }, (ctx) => ctx.notesSection("Notes", note));
+    const pages = pageTexts(bytes);
+    expect(pages.length).toBeGreaterThan(1);
+    expect(compactPdfText(pages.join(" "))).toContain("INSTRUCTION-449");
+  });
+});

--- a/src/__tests__/authoritative-pdf.cache-headers.controller.test.ts
+++ b/src/__tests__/authoritative-pdf.cache-headers.controller.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const supplier = vi.hoisted(() => ({ read: vi.fn() }));
+const quote = vi.hoisted(() => ({ read: vi.fn() }));
+const acknowledgement = vi.hoisted(() => ({ read: vi.fn() }));
+
+vi.mock("../module/commande-fournisseur/services/commande-fournisseur.service", () => ({
+  readSupplierPoOfficialDocumentSVC: supplier.read,
+}));
+vi.mock("../module/devis/services/devis.service", () => ({
+  svcReadDevisOfficialDocument: quote.read,
+}));
+vi.mock("../module/commande-client/services/commande-ar.service", () => ({
+  svcReadCommandeArOfficialDocument: acknowledgement.read,
+}));
+
+import { downloadOfficialDocument, previewOfficialDocument } from "../module/commande-fournisseur/controllers/commande-fournisseur.controller";
+import { downloadDevisOfficialDocument, previewDevisOfficialDocument } from "../module/devis/controllers/devis.controller";
+import { downloadAcknowledgement, previewAcknowledgement } from "../module/commande-client/controllers/commande-ar.controller";
+
+const DOCUMENT_ID = "11111111-1111-4111-8111-111111111111";
+const SUPPLIER_ID = "22222222-2222-4222-8222-222222222222";
+const bytes = Buffer.from("%PDF-1.7 authoritative");
+
+function responseDouble() {
+  const headers = new Map<string, string>();
+  return {
+    headers,
+    setHeader(name: string, value: string) { headers.set(name.toLowerCase(), value); },
+    send: vi.fn(),
+  };
+}
+
+const endpoints = [
+  { label: "supplier PO preview", handler: previewOfficialDocument, params: { id: SUPPLIER_ID, documentId: DOCUMENT_ID }, reader: supplier.read, disposition: "inline" },
+  { label: "supplier PO download", handler: downloadOfficialDocument, params: { id: SUPPLIER_ID, documentId: DOCUMENT_ID }, reader: supplier.read, disposition: "attachment" },
+  { label: "quote preview", handler: previewDevisOfficialDocument, params: { id: "42", documentId: DOCUMENT_ID }, reader: quote.read, disposition: "inline" },
+  { label: "quote download", handler: downloadDevisOfficialDocument, params: { id: "42", documentId: DOCUMENT_ID }, reader: quote.read, disposition: "attachment" },
+  { label: "acknowledgement preview", handler: previewAcknowledgement, params: { id: "42", documentId: DOCUMENT_ID }, reader: acknowledgement.read, disposition: "inline" },
+  { label: "acknowledgement download", handler: downloadAcknowledgement, params: { id: "42", documentId: DOCUMENT_ID }, reader: acknowledgement.read, disposition: "attachment" },
+] as const;
+
+describe("authoritative PDF delivery cache policy", () => {
+  beforeEach(() => {
+    supplier.read.mockReset().mockResolvedValue({ bytes, filename: "supplier-po.pdf" });
+    quote.read.mockReset().mockResolvedValue({ bytes, filename: "quote.pdf" });
+    acknowledgement.read.mockReset().mockResolvedValue({ bytes, filename: "acknowledgement.pdf" });
+  });
+
+  it.each(endpoints)("sets private no-store while preserving PDF delivery headers for $label", async ({ handler, params, disposition }) => {
+    const res = responseDouble();
+    const next = vi.fn();
+    const req = {
+      params,
+      headers: {},
+      user: { id: 7, role: "Administrateur" },
+      ip: "127.0.0.1",
+      originalUrl: "/authoritative-pdf-test",
+    };
+
+    await (handler as unknown as (req: typeof req, res: typeof res, next: typeof next) => Promise<void>)(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    expect(res.headers.get("content-length")).toBe(String(bytes.byteLength));
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("content-disposition")).toContain(disposition);
+    expect(res.send).toHaveBeenCalledWith(bytes);
+  });
+});

--- a/src/__tests__/authoritative-pdf.migration.test.ts
+++ b/src/__tests__/authoritative-pdf.migration.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const patch = fs.readFileSync(path.join(root, "db/patches/20260823_authoritative_pdf_archive_612.sql"), "utf8");
+const preflight = fs.readFileSync(path.join(root, "db/patches/support/20260823_authoritative_pdf_archive_612.preflight.sql"), "utf8");
+const verify = fs.readFileSync(path.join(root, "db/patches/support/20260823_authoritative_pdf_archive_612.verify.sql"), "utf8");
+const rollback = fs.readFileSync(path.join(root, "db/patches/support/20260823_authoritative_pdf_archive_612.rollback.sql"), "utf8");
+
+describe("#612 authoritative PDF archive migration guards", () => {
+  it("requires an absent GED class so the migration owns what rollback removes", () => {
+    expect(patch).toContain("AUTHORITATIVE_PDF_GED_CLASS_ALREADY_EXISTS");
+    expect(preflight).toContain("AUTHORITATIVE_PDF_PREFLIGHT_GED_CLASS_ALREADY_EXISTS");
+    expect(preflight).toContain("generated_pdf_class_absent");
+    expect(patch).toContain("'PDF sortant autoritatif'");
+    expect(patch).not.toContain("ON CONFLICT (class_key) DO NOTHING");
+    expect(patch).toContain("AUTHORITATIVE_PDF_TARGET_NAMESPACE_ALREADY_EXISTS");
+    expect(patch).not.toContain("CREATE TABLE IF NOT EXISTS public.authoritative_pdf_archives");
+    expect(patch).toContain("{0,180}\\.pdf$");
+    expect(patch).not.toContain("{0,180}\\\\.pdf$");
+  });
+
+  it("keeps human document version separate from renderer revision and permits same-source reissues", () => {
+    expect(patch).toContain("authoritative_pdf_archive_document_version_uq");
+    expect(patch).toContain("authoritative_pdf_archive_snapshot_lookup_idx");
+    expect(patch).not.toContain("authoritative_pdf_archive_identity_uq");
+  });
+
+  it("ships read-only preflight and verification gates for runtime invariants", () => {
+    for (const script of [preflight, verify]) {
+      expect(script).toContain("BEGIN TRANSACTION READ ONLY");
+      expect(script).toContain("CERP_AUTHORITATIVE_PDF");
+      expect(script).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE|GRANT|REVOKE)\b/im);
+    }
+    expect(preflight).toContain("generated_pdf_class_absent");
+    expect(verify).toContain("52428800");
+    expect(preflight).toContain("AUTHORITATIVE_PDF_PREFLIGHT_GED_CLASS_ALREADY_EXISTS");
+    expect(verify).toContain("AUTHORITATIVE_PDF_VERIFY_OUTBOX_STATUS_CONSTRAINT_MISSING");
+    expect(verify).toContain("authoritative_pdf_archive_pdf_size_ck");
+    expect(verify).toContain("authoritative_pdf_archive_outbox_lifecycle_ck");
+    expect(verify).toContain("AUTHORITATIVE_PDF_VERIFY_GED_PREREQUISITE_MISSING");
+    expect(verify).toContain("AUTHORITATIVE_PDF_VERIFY_APP_ROLE_MISSING");
+    expect(verify).toContain("AUTHORITATIVE_PDF_VERIFY_LEASE_TOKEN_MISSING");
+    expect(verify).toContain("tgrelid = 'public.authoritative_pdf_archives'::regclass");
+    expect(verify).toContain("tgfoid = to_regprocedure('public.fn_authoritative_pdf_archive_immutable_612()')");
+    expect(verify).toContain("pg_get_constraintdef(oid)");
+    expect(verify).toContain("authoritative_pdf_archive_outbox_complete_612");
+    expect(patch).toContain("pdf_size_bytes <= 52428800");
+    expect(patch).toContain("(status = 'ARCHIVED') = (archived_at IS NOT NULL)");
+    expect(patch).toContain("status = 'PROCESSING' AND locked_at IS NOT NULL AND locked_by IS NOT NULL");
+    expect(patch).toContain("claim_token IS NOT NULL");
+    expect(patch).toContain("AUTHORITATIVE_PDF_OUTBOX_ARCHIVED_WITHOUT_COMPLETE_ARCHIVE");
+    expect(verify).toContain("trg_authoritative_pdf_archive_immutable_612");
+    expect(verify).toContain("authoritative_pdf_archive_outbox_stale_idx");
+  });
+
+  it("makes rollback ledger-owned, empty-install safe, and removes every owned function", () => {
+    expect(rollback).toContain("to_regclass('public.authoritative_pdf_archives') IS NOT NULL");
+    expect(rollback).toContain("EXECUTE 'SELECT EXISTS (SELECT 1 FROM public.authoritative_pdf_archives)' INTO has_rows");
+    expect(rollback).toContain("EXECUTE 'SELECT EXISTS (SELECT 1 FROM public.ged_documents WHERE class_key = ''CERP_AUTHORITATIVE_PDF'')' INTO has_rows");
+    expect(rollback).toContain("Rollback refused: #612 artifacts exist without canonical migration-ledger ownership.");
+    expect(rollback).toContain("Rollback refused: #612 GED class is missing or its policy changed.");
+    expect(rollback).toContain("20260823_authoritative_pdf_archive_612.sql");
+    expect(rollback).toContain("DROP FUNCTION IF EXISTS public.fn_authoritative_pdf_archive_immutable_612()");
+    expect(rollback).toContain("DROP FUNCTION IF EXISTS public.fn_authoritative_pdf_archive_outbox_stamp_612()");
+    expect(rollback).toContain("DROP FUNCTION IF EXISTS public.fn_authoritative_pdf_archive_outbox_complete_612()");
+    expect(rollback).toContain("authoritative PDF GED documents exist");
+    expect(rollback).toContain("target_exists := to_regclass('public.authoritative_pdf_archives') IS NOT NULL");
+    expect(rollback).toContain("DELETE FROM public.ged_document_classes WHERE class_key = ''CERP_AUTHORITATIVE_PDF''");
+  });
+});

--- a/src/__tests__/authoritative-pdf.routes.test.ts
+++ b/src/__tests__/authoritative-pdf.routes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { GENERATED_ROUTE_INVENTORY } from "../swagger/generated-route-inventory";
+
+type ExpectedRoute = readonly [method: string, path: string];
+
+function expectAuthoritativeRouteSet(expected: readonly ExpectedRoute[], capability: string): void {
+  const actual = GENERATED_ROUTE_INVENTORY.filter((route) =>
+    expected.some(([method, path]) => route.method === method && route.path === path)
+  );
+  expect(actual).toHaveLength(expected.length);
+  for (const route of actual) {
+    expect(route.authenticated).toBe(true);
+    expect(route.rbac).toContain("moduleAccessGate");
+    expect(route.rbac).toContain(capability);
+  }
+}
+
+describe("authoritative PDF route contract (#612)", () => {
+  it("keeps supplier purchase-order PDFs behind explicit export capability", () => {
+    const root = "/commandes-fournisseurs/{id}/official-documents";
+    expectAuthoritativeRouteSet([
+      ["get", root], ["post", root], ["get", `${root}/{documentId}`],
+      ["get", `${root}/{documentId}/preview`], ["get", `${root}/{documentId}/download`],
+      ["post", `${root}/{documentId}/print-intents`],
+    ], "requireCapability(export)");
+  });
+
+  it("keeps customer quote PDFs behind explicit export capability", () => {
+    const root = "/devis/{id}/official-documents";
+    expectAuthoritativeRouteSet([
+      ["get", root], ["post", root], ["get", `${root}/{documentId}`],
+      ["get", `${root}/{documentId}/preview`], ["get", `${root}/{documentId}/download`],
+      ["post", `${root}/{documentId}/print-intents`],
+    ], "requireCapability(export)");
+  });
+
+  it("keeps customer acknowledgements entity-scoped, including exact-byte send", () => {
+    const root = "/commandes/{id}/acknowledgements";
+    expectAuthoritativeRouteSet([
+      ["get", root], ["post", root], ["get", `${root}/{documentId}`],
+      ["get", `${root}/{documentId}/preview`], ["get", `${root}/{documentId}/download`],
+      ["post", `${root}/{documentId}/print-intents`], ["post", `${root}/{documentId}/send`],
+    ], "requireAcknowledgementExport");
+  });
+});

--- a/src/__tests__/authoritative-pdf.worker.test.ts
+++ b/src/__tests__/authoritative-pdf.worker.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  claim: vi.fn(),
+  runClaimed: vi.fn(),
+}));
+
+vi.mock("../config/database", () => ({ default: { connect: mocks.connect } }));
+vi.mock("../shared/authoritative-documents/authoritative-document.repository", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../shared/authoritative-documents/authoritative-document.repository")>()),
+  repoClaimAuthoritativePdfWork: mocks.claim,
+}));
+vi.mock("../shared/authoritative-documents/authoritative-document.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../shared/authoritative-documents/authoritative-document.service")>()),
+  runClaimedAuthoritativePdfArchive: mocks.runClaimed,
+}));
+
+import { AuthoritativePdfProducerRegistry } from "../shared/authoritative-documents/authoritative-document.service";
+import { runAuthoritativePdfArchiveWorkerOnce } from "../shared/authoritative-documents/authoritative-document.worker";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("authoritative PDF archive worker", () => {
+  it("continues to the next claimed job when one producer/archive job fails", async () => {
+    const client = { query: vi.fn().mockResolvedValue({ rows: [] }), release: vi.fn() };
+    const first = { outboxId: "11111111-1111-4111-8111-111111111111", archive: { id: "a" } };
+    const second = { outboxId: "22222222-2222-4222-8222-222222222222", archive: { id: "b" } };
+    mocks.connect.mockResolvedValue(client);
+    mocks.claim.mockResolvedValue([first, second]);
+    mocks.runClaimed.mockRejectedValueOnce(new Error("AUTHORITATIVE_PDF_NOT_PDF")).mockResolvedValueOnce(undefined);
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(runAuthoritativePdfArchiveWorkerOnce(new AuthoritativePdfProducerRegistry(), "test-worker")).resolves.toBe(2);
+
+    expect(mocks.runClaimed).toHaveBeenCalledTimes(2);
+    expect(mocks.runClaimed).toHaveBeenNthCalledWith(1, first, expect.any(AuthoritativePdfProducerRegistry));
+    expect(mocks.runClaimed).toHaveBeenNthCalledWith(2, second, expect.any(AuthoritativePdfProducerRegistry));
+    expect(client.query).toHaveBeenNthCalledWith(1, "BEGIN");
+    expect(client.query).toHaveBeenNthCalledWith(2, "COMMIT");
+    expect(client.release).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('"failed":1'));
+  });
+});

--- a/src/__tests__/automatic-creation-pdf-alternate-paths.contract.test.ts
+++ b/src/__tests__/automatic-creation-pdf-alternate-paths.contract.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (...parts: string[]) => fs.readFileSync(path.resolve(process.cwd(), ...parts), "utf8");
+const body = (source: string, marker: string) => {
+  const start = source.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const next = source.indexOf("\nexport ", start + marker.length);
+  return source.slice(start, next === -1 ? source.length : next);
+};
+const beforeCommit = (source: string, queue: string) => {
+  expect(source.indexOf(queue)).toBeGreaterThan(-1);
+  expect(source.lastIndexOf("COMMIT")).toBeGreaterThan(source.indexOf(queue));
+};
+
+describe("automatic creation PDFs: alternate transaction paths", () => {
+  const supplier = read("src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts");
+  const replenishment = read("src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts");
+  const stock = read("src/module/stock/repository/stock.repository.ts");
+  const quotes = read("src/module/devis/repository/devis.repository.ts");
+
+  it("queues the supplier PO snapshot after lines/totals/transition and before commit for normal, proposal-confirm and duplicate draft creates", () => {
+    for (const marker of ["export async function repoCreateCommandeFournisseur", "export async function repoConfirmPropositions", "export async function repoDuplicateAsDraft"]) {
+      const slice = body(supplier, marker);
+      const queue = slice.indexOf("queueSupplierPurchaseOrderCreationPdfTx");
+      expect(queue).toBeGreaterThan(slice.indexOf("recomputeTotauxTx"));
+      expect(queue).toBeGreaterThan(slice.indexOf("insertTransitionRow"));
+      expect(slice.lastIndexOf('client.query("COMMIT")')).toBeGreaterThan(queue);
+    }
+  });
+
+  it("queues the replenishment conversion snapshot after its transition and before commit", () => {
+    const slice = body(replenishment, "export async function repoValidateReplenishmentProposal");
+    const queue = slice.indexOf("queueSupplierPurchaseOrderCreationPdfTx");
+    expect(queue).toBeGreaterThan(slice.indexOf("commande_fournisseur_transition"));
+    expect(slice.lastIndexOf('client.query("COMMIT")')).toBeGreaterThan(queue);
+  });
+
+  it("keeps stock creation snapshots on explicit article creation only, excluding OLD historical import", () => {
+    const createStart = stock.indexOf("export async function repoCreateArticle");
+    const create = stock.slice(createStart, stock.indexOf("export async function repoCreateHistoricalImport", createStart));
+    beforeCommit(create, "queueStockArticleCreationSnapshotTx");
+    const historical = body(stock, "export async function repoCreateHistoricalImport");
+    expect(historical).not.toContain("queueStockArticleCreationSnapshotTx");
+    const finish = read("src/module/surface-finish/repository/surface-finish-resolution.repository.ts");
+    for (const marker of ["export async function repoConfirmStockFinishArticle", "export async function repoConfirmOperationFinish"]) {
+      beforeCommit(body(finish, marker), "queueStockArticleCreationSnapshotTx");
+    }
+  });
+
+  it("uses the quote creation helper for normal creates and queues revisions after materialized lines/documents/audit/idempotency", () => {
+    const normal = body(quotes, "export async function repoCreateDevis");
+    expect(normal).toContain("queueDevisCreationPdfTx");
+    const revision = body(quotes, "export async function repoReviseDevis");
+    const queue = revision.indexOf("queueDevisCreationPdfTx");
+    expect(queue).toBeGreaterThan(revision.indexOf("insertDevisDocuments"));
+    expect(queue).toBeGreaterThan(revision.indexOf("insertDevisAuditLog"));
+    expect(queue).toBeGreaterThan(revision.indexOf("recordDevisIdempotence"));
+    expect(queue).toBeLessThan(revision.indexOf("return { ...resultat"));
+  });
+});

--- a/src/__tests__/clients-360-hardening.routes.test.ts
+++ b/src/__tests__/clients-360-hardening.routes.test.ts
@@ -58,6 +58,7 @@ vi.mock("../module/auth/middlewares/auth.middleware", async (importOriginal) => 
 
 import app from "../config/app";
 import { withRealtimeOutboxDbMock } from "./helpers/realtime-outbox-db-mock";
+import { authoritativePdfQueueDbMock } from "./helpers/authoritative-pdf-queue-db-mock";
 import { stripQueryFromUrl } from "../utils/logPath";
 import { maskIban } from "../module/client/client.permissions";
 import { setLogSinkForTests } from "../shared/observability/logger";
@@ -86,8 +87,13 @@ beforeEach(() => {
     query: withRealtimeOutboxDbMock(mocks.clientQuery),
     release: mocks.clientRelease,
   });
-  mocks.clientQuery.mockImplementation((sql: unknown) => {
+  mocks.clientQuery.mockImplementation((sql: unknown, params?: unknown[]) => {
     const s = String(sql);
+    const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+    if (authoritativePdf) return Promise.resolve(authoritativePdf);
+    if (s.includes("SELECT updated_at::text AS updated_at FROM clients")) {
+      return Promise.resolve({ rows: [{ updated_at: "2026-08-23T12:00:00.000Z" }] });
+    }
     if (s.includes("fn_next_issued_code_value")) return Promise.resolve({ rows: [{ v: "7" }] });
     if (s.includes("INSERT INTO adresse_facturation")) return Promise.resolve({ rows: [{ bill_address_id: "b1" }] });
     if (s.includes("INSERT INTO adresse_livraison")) return Promise.resolve({ rows: [{ delivery_address_id: "d1" }] });

--- a/src/__tests__/commande-ar.routes.test.ts
+++ b/src/__tests__/commande-ar.routes.test.ts
@@ -10,6 +10,12 @@ const mocks = vi.hoisted(() => ({
   clientRelease: vi.fn(),
   generateAr: vi.fn(),
   sendAr: vi.fn(),
+  createOfficial: vi.fn(),
+  listOfficial: vi.fn(),
+  getOfficial: vi.fn(),
+  readOfficial: vi.fn(),
+  printOfficial: vi.fn(),
+  sendOfficial: vi.fn(),
 }));
 
 vi.mock("pg", () => {
@@ -63,6 +69,12 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
 vi.mock("../module/commande-client/services/commande-ar.service", () => ({
   svcGenerateCommandeAr: mocks.generateAr,
   svcSendCommandeAr: mocks.sendAr,
+  svcCreateCommandeArOfficial: mocks.createOfficial,
+  svcListCommandeArOfficialDocuments: mocks.listOfficial,
+  svcGetCommandeArOfficialDocument: mocks.getOfficial,
+  svcReadCommandeArOfficialDocument: mocks.readOfficial,
+  svcRecordCommandeArOfficialPrint: mocks.printOfficial,
+  svcSendCommandeArOfficial: mocks.sendOfficial,
 }));
 
 // Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
@@ -81,10 +93,137 @@ beforeEach(() => {
   mocks.clientRelease.mockReset();
   mocks.generateAr.mockReset();
   mocks.sendAr.mockReset();
+  mocks.createOfficial.mockReset();
+  mocks.listOfficial.mockReset();
+  mocks.getOfficial.mockReset();
+  mocks.readOfficial.mockReset();
+  mocks.printOfficial.mockReset();
+  mocks.sendOfficial.mockReset();
 
   mocks.poolConnect.mockResolvedValue({
     query: mocks.clientQuery,
     release: mocks.clientRelease,
+  });
+});
+
+const OFFICIAL_ID = "33333333-3333-4333-8333-333333333333";
+const OFFICIAL_DOCUMENT = {
+  id: OFFICIAL_ID,
+  kind: "CUSTOMER_ORDER_ACKNOWLEDGEMENT",
+  version: 2,
+  state: "ISSUED",
+  safe_filename: "AR-123-v2.pdf",
+  byte_sha256: "a".repeat(64),
+  byte_length: 1234,
+  mime_type: "application/pdf",
+  issued_at: "2026-08-23T10:01:00.000Z",
+  source_revision: "2026-08-23 10:00:00+00",
+  preview_url: `/commandes/123/acknowledgements/${OFFICIAL_ID}/preview`,
+  download_url: `/commandes/123/acknowledgements/${OFFICIAL_ID}/download`,
+};
+const OFFICIAL_ENVELOPE = {
+  state: "READY",
+  latest_document: OFFICIAL_DOCUMENT,
+  retryable: false,
+  failure_code: null,
+};
+
+describe("/api/v1/commandes/:id/acknowledgements", () => {
+  it("uses the exact safe generation envelope for the collection POST and GET", async () => {
+    mocks.listOfficial.mockResolvedValue(OFFICIAL_ENVELOPE);
+    mocks.createOfficial.mockResolvedValue({ ...OFFICIAL_ENVELOPE, state: "PENDING" });
+
+    const listed = await request(app)
+      .get("/api/v1/commandes/123/acknowledgements")
+      .set("Authorization", "Bearer fake");
+    expect(listed.status).toBe(200);
+    expect(listed.body).toEqual(OFFICIAL_ENVELOPE);
+    expect(mocks.listOfficial).toHaveBeenCalledWith(123);
+
+    const created = await request(app)
+      .post("/api/v1/commandes/123/acknowledgements")
+      .set("Authorization", "Bearer fake")
+      .set("Idempotency-Key", "acknowledgement-attempt-001")
+      .send({ source_revision: "2026-08-23 10:00:00+00", reissue_reason: "Client requested revised delivery date" });
+    expect(created.status).toBe(201);
+    expect(created.body).toEqual({ ...OFFICIAL_ENVELOPE, state: "PENDING" });
+    expect(mocks.createOfficial).toHaveBeenCalledWith({
+      commande_id: 123,
+      user_id: 7,
+      user_role: "Secretaire",
+      source_revision: "2026-08-23 10:00:00+00",
+      reissue_reason: "Client requested revised delivery date",
+      idempotency_key: "acknowledgement-attempt-001",
+    });
+    expect(Object.keys(created.body.latest_document)).toEqual([
+      "id", "kind", "version", "state", "safe_filename", "byte_sha256", "byte_length", "mime_type",
+      "issued_at", "source_revision", "preview_url", "download_url",
+    ]);
+  });
+
+  it("requires a per-attempt idempotency key before invoking the generator", async () => {
+    const response = await request(app)
+      .post("/api/v1/commandes/123/acknowledgements")
+      .set("Authorization", "Bearer fake")
+      .send({ source_revision: "2026-08-23 10:00:00+00" });
+    expect(response.status).toBe(400);
+    expect(mocks.createOfficial).not.toHaveBeenCalled();
+  });
+
+  it("keeps detail, exact-byte delivery, print intent, and send scoped to the parent order", async () => {
+    mocks.getOfficial.mockResolvedValue(OFFICIAL_DOCUMENT);
+    mocks.readOfficial.mockResolvedValue({ bytes: Buffer.from("%PDF-1.7 official"), filename: OFFICIAL_DOCUMENT.safe_filename, sha256: OFFICIAL_DOCUMENT.byte_sha256 });
+    mocks.printOfficial.mockResolvedValue(undefined);
+    mocks.sendOfficial.mockResolvedValue({ commande_id: 123, status: "AR_ENVOYE" });
+
+    const detail = await request(app)
+      .get(`/api/v1/commandes/123/acknowledgements/${OFFICIAL_ID}`)
+      .set("Authorization", "Bearer fake");
+    expect(detail.status).toBe(200);
+    expect(detail.body).toEqual(OFFICIAL_DOCUMENT);
+
+    const preview = await request(app)
+      .get(`/api/v1/commandes/123/acknowledgements/${OFFICIAL_ID}/preview`)
+      .set("Authorization", "Bearer fake");
+    expect(preview.status).toBe(200);
+    expect(preview.headers["content-type"]).toContain("application/pdf");
+
+    const download = await request(app)
+      .get(`/api/v1/commandes/123/acknowledgements/${OFFICIAL_ID}/download`)
+      .set("Authorization", "Bearer fake");
+    expect(download.status).toBe(200);
+    expect(download.headers["content-disposition"]).toContain("attachment");
+
+    const printed = await request(app)
+      .post(`/api/v1/commandes/123/acknowledgements/${OFFICIAL_ID}/print-intents`)
+      .set("Authorization", "Bearer fake");
+    expect(printed.status).toBe(204);
+
+    const sent = await request(app)
+      .post(`/api/v1/commandes/123/acknowledgements/${OFFICIAL_ID}/send`)
+      .set("Authorization", "Bearer fake")
+      .send({ recipient_emails: ["client@example.test"], recipient_contact_ids: [] });
+    expect(sent.status).toBe(200);
+    expect(mocks.getOfficial).toHaveBeenCalledWith(123, OFFICIAL_ID);
+    expect(mocks.readOfficial).toHaveBeenNthCalledWith(1, 123, OFFICIAL_ID, 7, "AUTHORITATIVE_PDF_PREVIEWED");
+    expect(mocks.readOfficial).toHaveBeenNthCalledWith(2, 123, OFFICIAL_ID, 7, "AUTHORITATIVE_PDF_DOWNLOADED");
+    expect(mocks.printOfficial).toHaveBeenCalledWith(123, OFFICIAL_ID, 7);
+    expect(mocks.sendOfficial).toHaveBeenCalledWith({
+      commande_id: 123,
+      archive_id: OFFICIAL_ID,
+      user_id: 7,
+      user_role: "Secretaire",
+      body: { recipient_emails: ["client@example.test"], recipient_contact_ids: [] },
+    });
+  });
+
+  it("default-denies acknowledgement export for a role without the explicit capability", async () => {
+    const response = await request(app)
+      .get("/api/v1/commandes/123/acknowledgements")
+      .set("Authorization", "Bearer fake")
+      .set("x-test-role", "Employee");
+    expect(response.status).toBe(403);
+    expect(mocks.listOfficial).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/commande-article-eligibility.routes.test.ts
+++ b/src/__tests__/commande-article-eligibility.routes.test.ts
@@ -40,6 +40,7 @@ vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
 }));
 
 import app from "../config/app";
+import { authoritativePdfQueueDbMock } from "./helpers/authoritative-pdf-queue-db-mock";
 
 const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
 const PIECE_ID = "22222222-2222-4222-8222-222222222222";
@@ -244,6 +245,8 @@ describe("BUG-CERP-0015 - validation serveur POST/PATCH commandes", () => {
     let promotedArticleId: string | null = null;
     mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const query = String(sql);
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+      if (authoritativePdf) return authoritativePdf;
       if (query.includes("FROM commande_client") && query.includes("FOR UPDATE")) {
         return {
           rows: [{
@@ -266,7 +269,10 @@ describe("BUG-CERP-0015 - validation serveur POST/PATCH commandes", () => {
       if (query.includes("FROM public.article_devis_promotion")) return { rows: [] };
       if (query.includes("INSERT INTO public.articles (")) {
         promotedArticleId = String(params?.[0] ?? "");
-        return { rows: [] };
+        return { rows: [{ id: promotedArticleId, updated_at: "2026-08-23T12:00:00.000Z" }] };
+      }
+      if (query.includes("UPDATE public.articles") && query.includes("RETURNING updated_at")) {
+        return { rows: [{ updated_at: "2026-08-23T12:00:00.000Z" }] };
       }
       if (
         query.includes("FROM public.articles a") &&
@@ -348,8 +354,13 @@ describe("BUG-CERP-0015 - validation serveur POST/PATCH commandes", () => {
       commande_client_eligible: true,
       commande_client_ineligibility_code: null,
     };
-    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const query = String(sql);
+      if (query.includes("FROM public.commande_client cc") && query.includes("FOR UPDATE")) {
+        return { rows: [{ id: "315", numero: "CC-315", client_id: "001", client_name: "ACME", billing_address_id: null, billing_address_name: null, billing_street: null, billing_house_number: null, billing_postal_code: null, billing_city: null, billing_country: null, date_commande: "2026-08-04", order_type: "FERME", total_ht: 19.5, total_ttc: 23.4, remise_globale: 0, commentaire: null, updated_at: "2026-08-23T12:00:00.000Z" }] };
+      }
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+      if (authoritativePdf) return authoritativePdf;
       if (query.includes("nextval('public.commande_client_id_seq')")) return { rows: [{ id: "315" }] };
       if (query.includes("public.fn_next_issued_code_value")) return { rows: [{ v: "1" }] };
       if (query.includes("INSERT INTO commande_client")) return { rows: [{ id: "315" }] };

--- a/src/__tests__/commande-fournisseur.routes.test.ts
+++ b/src/__tests__/commande-fournisseur.routes.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   clientQuery: vi.fn(),
   clientRelease: vi.fn(),
 }));
+const officialArchive = vi.hoisted(() => ({ queue: vi.fn() }));
 
 vi.mock("pg", () => {
   const emitter = new EventEmitter();
@@ -22,6 +23,16 @@ vi.mock("pg", () => {
 
 vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+// Route tests keep the archive worker/storage boundary isolated. The persisted
+// source snapshot is still built by the real repository below.
+vi.mock("../shared/authoritative-documents/authoritative-document.service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../shared/authoritative-documents/authoritative-document.service")>();
+  return { ...actual, queueCreationPdfArchive: officialArchive.queue };
+});
+vi.mock("../shared/documents/issuer-identity.repository", () => ({
+  readIssuerParty: vi.fn().mockResolvedValue({ company_name: "CERP Test" }),
 }));
 
 vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
@@ -69,6 +80,19 @@ const state = {
 function dispatch(sqlRaw: unknown): { rows: unknown[]; rowCount?: number } {
   const sql = String(sqlRaw);
   if (/fn_next_issued_code_value/.test(sql)) return { rows: [{ v: "7" }] };
+  if (/SELECT updated_at::text AS source_revision\s+FROM public\.commande_fournisseur/.test(sql)) {
+    return { rows: [{ source_revision: state.header.updated_at_token }] };
+  }
+  if (/FROM public\.commande_fournisseur cf\s+JOIN public\.fournisseurs f/.test(sql)) {
+    return { rows: [{
+      code: state.header.code, statut: state.header.statut, issued_at: "2026-07-21T10:00:00.000Z",
+      devise: state.header.devise, need_date: null, incoterm: null, payment_terms: null,
+      transport_mode: null, public_comment: null, delivery_address: null,
+      supplier_code: state.fournisseur.code, supplier_name: state.fournisseur.nom,
+      total_ht: "120", total_remise: "0", total_tva: "24", freight_ht: "0", total_ttc: "144",
+    }] };
+  }
+  if (/FROM public\.commande_fournisseur_ligne\s+WHERE commande_id/.test(sql)) return { rows: [] };
   if (/FROM public\.commande_fournisseur_idempotence WHERE cle/.test(sql)) {
     return { rows: state.idemRow ? [state.idemRow] : [] };
   }
@@ -101,6 +125,8 @@ beforeEach(() => {
   mocks.poolConnect.mockReset();
   mocks.clientQuery.mockReset();
   mocks.clientRelease.mockReset();
+  officialArchive.queue.mockReset();
+  officialArchive.queue.mockResolvedValue(undefined);
   mocks.poolConnect.mockResolvedValue({
     query: withRealtimeOutboxDbMock(mocks.clientQuery),
     release: mocks.clientRelease,
@@ -169,6 +195,12 @@ describe("/api/v1/commandes-fournisseurs — création", () => {
     expect(res.status).toBe(201);
     expect(res.body.code).toMatch(/^BCF-\d{4}-0007$/);
     expect(res.body.idempotent_replay).toBe(false);
+    expect(officialArchive.queue).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      entityType: "commande-fournisseur",
+      entityId: UUID,
+      documentKind: "SUPPLIER_PURCHASE_ORDER",
+      renderVersion: "supplier-po-pdf-v1",
+    }));
 
     const forbidden = await request(app)
       .post("/api/v1/commandes-fournisseurs")

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -73,6 +73,7 @@ vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
 
 import app from "../config/app";
 import { withRealtimeOutboxDbMock } from "./helpers/realtime-outbox-db-mock";
+import { authoritativePdfQueueDbMock } from "./helpers/authoritative-pdf-queue-db-mock";
 
 beforeEach(() => {
   mocks.poolQuery.mockReset();
@@ -323,6 +324,20 @@ describe("/api/v1/commandes", () => {
       .mockResolvedValueOnce({ rows: [] }) // INSERT commande_documents
       .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
+    // The create path now queues a durable creation snapshot before COMMIT.
+    // Keep this fixture query-aware rather than relying on an obsolete call order.
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
+      const query = String(sql);
+      if (query.includes("nextval('public.commande_client_id_seq')")) return { rows: [{ id: "123" }] };
+      if (query.includes("public.fn_next_issued_code_value")) return { rows: [{ v: "1" }] };
+      if (query.includes("INSERT INTO commande_client (")) return { rows: [{ id: "123" }] };
+      if (query.includes("FROM public.articles a")) return { rows: [{ article_id: ARTICLE_ID, article_code: "ART-001", article_designation: "Article test", article_category: "fabrique", family_code: "PT", article_unite: "u", piece_technique_id: PIECE_ID, piece_code: "PT-001", piece_designation: "Pièce test", stock_managed: true, is_active: true }] };
+      if (query.includes("FROM public.commande_client cc") && query.includes("FOR UPDATE")) return { rows: [{ id: "123", numero: "CC-123", client_id: "001", client_name: "ACME", billing_address_id: null, billing_address_name: null, billing_street: null, billing_house_number: null, billing_postal_code: null, billing_city: null, billing_country: null, date_commande: "2026-02-01", order_type: "FERME", total_ht: 100, total_ttc: 120, remise_globale: 0, commentaire: null, updated_at: "2026-08-23T12:00:00.000Z" }] };
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+      if (authoritativePdf) return authoritativePdf;
+      return { rows: [] };
+    });
+
     const payload = {
       numero: "CC-123",
       client_id: "001",
@@ -399,6 +414,11 @@ describe("/api/v1/commandes", () => {
 
     mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const q = String(sql);
+      if (q.includes("FROM public.commande_client cc") && q.includes("FOR UPDATE")) {
+        return { rows: [{ id: String(seq), numero: `CC-${seq}`, client_id: "001", client_name: "ACME", billing_address_id: null, billing_address_name: null, billing_street: null, billing_house_number: null, billing_postal_code: null, billing_city: null, billing_country: null, date_commande: "2026-03-26", order_type: "FERME", total_ht: 100, total_ttc: 120, remise_globale: 0, commentaire: null, updated_at: "2026-08-23T12:00:00.000Z" }] };
+      }
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+      if (authoritativePdf) return authoritativePdf;
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
 
       if (q.includes("nextval('public.commande_client_id_seq')")) {
@@ -442,7 +462,7 @@ describe("/api/v1/commandes", () => {
       }
       if (q.includes("INSERT INTO public.pieces_techniques")) {
         piecePromoted = true;
-        return { rows: [] };
+        return { rows: [{ id: "99999999-9999-9999-9999-999999999999", updated_at: "2026-08-23T12:00:00.000Z" }] };
       }
       if (q.includes("INSERT INTO public.dossier_technique_piece_devis_promotion")) {
         piecePromoted = true;
@@ -454,7 +474,7 @@ describe("/api/v1/commandes", () => {
       }
       if (q.includes("INSERT INTO public.articles (") && q.includes("status")) {
         articlePromoted = true;
-        return { rows: [] };
+        return { rows: [{ id: "88888888-8888-8888-8888-888888888888", updated_at: "2026-08-23T12:00:00.000Z" }] };
       }
       if (q.includes("INSERT INTO public.article_devis_promotion")) {
         articlePromoted = true;
@@ -483,6 +503,7 @@ describe("/api/v1/commandes", () => {
       if (q.includes("INSERT INTO commande_ligne")) return { rows: [{ id: "1" }] };
       if (q.includes("UPDATE public.article_devis_promotion")) return { rows: [] };
       if (q.includes("UPDATE public.dossier_technique_piece_devis_promotion")) return { rows: [] };
+      if (q.includes("UPDATE public.articles\n        SET status = 'VALIDE'")) return { rows: [{ updated_at: "2026-08-23T12:00:01.000Z" }] };
       if (q.includes("UPDATE public.articles a") || q.includes("UPDATE public.articles SET status = 'VALIDE'")) return { rows: [] };
       if (q.includes("INSERT INTO commande_historique")) return { rows: [] };
       if (q.includes("DELETE FROM public.article_category_link")) return { rows: [] };
@@ -664,8 +685,10 @@ describe("/api/v1/commandes", () => {
       },
     ];
 
-    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const q = String(sql);
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+      if (authoritativePdf) return authoritativePdf;
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
       if (q.includes("FROM commande_client cc")) {
         return {
@@ -1354,6 +1377,10 @@ describe("/api/v1/commandes", () => {
       .mockResolvedValueOnce({ rows: [] }) // insert historique
       .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) =>
+      authoritativePdfQueueDbMock(sql, params) ?? { rows: [] }
+    );
+
     const res = await request(app).post("/api/v1/commandes/123/duplicate");
 
     expect(res.status).toBe(201);
@@ -1377,6 +1404,8 @@ describe("/api/v1/commandes", () => {
     mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const q = String(sql);
       const p0 = Array.isArray(params) ? params[0] : undefined;
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+      if (authoritativePdf) return authoritativePdf;
 
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
 
@@ -1651,6 +1680,8 @@ describe("/api/v1/commandes", () => {
     mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const q = String(sql);
       const p0 = Array.isArray(params) ? params[0] : undefined;
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+      if (authoritativePdf) return authoritativePdf;
 
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
 
@@ -1849,6 +1880,9 @@ describe("/api/v1/commandes", () => {
       const q = String(sql);
       const p0 = Array.isArray(params) ? params[0] : undefined;
 
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+      if (authoritativePdf) return authoritativePdf;
+
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
 
       // The recursive OF scenario starts after a successful stock-control checkpoint.
@@ -2025,8 +2059,10 @@ describe("/api/v1/commandes", () => {
   });
 
   it("POST /api/v1/commandes/:id/generate-affaires protects internal-order launch and single-affair invariant", async () => {
-    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const q = String(sql);
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+      if (authoritativePdf) return authoritativePdf;
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
       if (q.includes("FROM commande_client") && q.includes("FOR UPDATE") && q.includes("order_type")) {
         return {
@@ -2162,8 +2198,10 @@ describe("/api/v1/commandes", () => {
     const BOM_LINE_ID = "44444444-4444-4444-4444-444444444444";
     let ofSeq = 8;
 
-    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const q = String(sql);
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+      if (authoritativePdf) return authoritativePdf;
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
       if (q.includes("FROM commande_client") && q.includes("FOR UPDATE") && q.includes("order_type")) {
         return {

--- a/src/__tests__/creation-snapshot-http.test.ts
+++ b/src/__tests__/creation-snapshot-http.test.ts
@@ -1,0 +1,172 @@
+import express, { type ErrorRequestHandler } from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HttpError } from "../utils/httpError";
+
+const authoritative = vi.hoisted(() => ({
+  envelope: vi.fn(),
+  read: vi.fn(),
+  print: vi.fn(),
+}));
+
+vi.mock("../config/database", () => ({ default: { query: vi.fn() } }));
+vi.mock("../shared/authoritative-documents/authoritative-document.service", () => ({
+  getOfficialDocumentGenerationEnvelope: authoritative.envelope,
+  readOfficialPdfBytes: authoritative.read,
+  recordOfficialPdfPrintIntent: authoritative.print,
+}));
+
+import { createCreationSnapshotHandlers } from "../shared/authoritative-documents/creation-snapshot-http";
+
+const ROOT_ID = "visible-root";
+const ARCHIVE_ID = "11111111-1111-4111-8111-111111111111";
+const exactBytes = Buffer.from("%PDF-1.7 immutable creation snapshot\n%%EOF\n", "utf8");
+
+function binaryParser(response: NodeJS.ReadableStream, callback: (error: Error | null, value?: Buffer) => void): void {
+  const chunks: Buffer[] = [];
+  response.on("data", (chunk: Buffer | string) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+  response.on("error", (error: Error) => callback(error));
+  response.on("end", () => callback(null, Buffer.concat(chunks)));
+}
+
+function buildApp() {
+  const app = express();
+  app.use((req, _res, next) => {
+    if (req.header("x-test-anonymous") !== "true") req.user = { id: 7, role: "Administrateur" };
+    next();
+  });
+
+  const handlers = createCreationSnapshotHandlers({
+    entityType: "client",
+    documentKind: "CLIENT_CREATION_SNAPSHOT",
+    parseEntityId: (req) => req.params.id,
+    canReadEntity: async (id) => id === ROOT_ID,
+    baseUrl: (id) => `/clients/${encodeURIComponent(id)}/creation-snapshot`,
+  });
+
+  app.get("/:id/creation-snapshot", handlers.metadata);
+  app.get("/:id/creation-snapshot/:documentId/preview", handlers.preview);
+  app.get("/:id/creation-snapshot/:documentId/download", handlers.download);
+  app.post("/:id/creation-snapshot/:documentId/print-intents", handlers.printIntent);
+
+  const errors: ErrorRequestHandler = (error, _req, res, _next) => {
+    const status = error instanceof HttpError ? error.status : 500;
+    const code = error instanceof HttpError ? error.code : "INTERNAL_ERROR";
+    res.status(status).json({ code });
+  };
+  app.use(errors);
+  return app;
+}
+
+describe("creation snapshot HTTP adapter", () => {
+  beforeEach(() => {
+    authoritative.envelope.mockReset().mockResolvedValue({
+      state: "READY",
+      latest_document: { id: ARCHIVE_ID },
+      retryable: false,
+      failure_code: null,
+    });
+    authoritative.read.mockReset().mockResolvedValue({
+      bytes: exactBytes,
+      filename: "client-creation-snapshot.pdf",
+      sha256: "a".repeat(64),
+    });
+    authoritative.print.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("returns metadata only after the aggregate scope check, with no-store links", async () => {
+    const response = await request(buildApp()).get(`/${ROOT_ID}/creation-snapshot`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers["cache-control"]).toBe("private, no-store, max-age=0");
+    expect(response.headers.pragma).toBe("no-cache");
+    expect(response.body).toMatchObject({ state: "READY", latest_document: { id: ARCHIVE_ID } });
+    expect(authoritative.envelope).toHaveBeenCalledWith({
+      tx: expect.any(Object),
+      entityType: "client",
+      entityId: ROOT_ID,
+      documentKind: "CLIENT_CREATION_SNAPSHOT",
+      baseUrl: `/clients/${ROOT_ID}/creation-snapshot`,
+    });
+  });
+
+  it("returns the exact archived bytes with secure preview/download cache and disposition headers", async () => {
+    const app = buildApp();
+    const preview = await request(app)
+      .get(`/${ROOT_ID}/creation-snapshot/${ARCHIVE_ID}/preview`)
+      .buffer(true)
+      .parse(binaryParser);
+    const download = await request(app)
+      .get(`/${ROOT_ID}/creation-snapshot/${ARCHIVE_ID}/download`)
+      .buffer(true)
+      .parse(binaryParser);
+
+    expect(preview.status).toBe(200);
+    expect(preview.body).toEqual(exactBytes);
+    expect(preview.headers["content-type"]).toMatch(/^application\/pdf/);
+    expect(preview.headers["content-length"]).toBe(String(exactBytes.byteLength));
+    expect(preview.headers["cache-control"]).toBe("private, no-store, max-age=0");
+    expect(preview.headers["x-content-type-options"]).toBe("nosniff");
+    expect(preview.headers["content-disposition"]).toContain('inline; filename="client-creation-snapshot.pdf"');
+
+    expect(download.status).toBe(200);
+    expect(download.body).toEqual(exactBytes);
+    expect(download.headers["content-disposition"]).toContain('attachment; filename="client-creation-snapshot.pdf"');
+    expect(authoritative.read).toHaveBeenNthCalledWith(1, {
+      entityType: "client",
+      entityId: ROOT_ID,
+      documentKind: "CLIENT_CREATION_SNAPSHOT",
+      archiveId: ARCHIVE_ID,
+      actorUserId: 7,
+      eventType: "AUTHORITATIVE_PDF_PREVIEWED",
+    });
+    expect(authoritative.read).toHaveBeenNthCalledWith(2, {
+      entityType: "client",
+      entityId: ROOT_ID,
+      documentKind: "CLIENT_CREATION_SNAPSHOT",
+      archiveId: ARCHIVE_ID,
+      actorUserId: 7,
+      eventType: "AUTHORITATIVE_PDF_DOWNLOADED",
+    });
+  });
+
+  it("denies unknown roots before archive access and rejects unauthenticated metadata/byte reads", async () => {
+    const app = buildApp();
+    const hidden = await request(app).get(`/hidden-root/creation-snapshot/${ARCHIVE_ID}/preview`);
+    const anonymousMetadata = await request(app)
+      .get(`/${ROOT_ID}/creation-snapshot`)
+      .set("x-test-anonymous", "true");
+    const anonymous = await request(app)
+      .get(`/${ROOT_ID}/creation-snapshot/${ARCHIVE_ID}/preview`)
+      .set("x-test-anonymous", "true");
+
+    expect(hidden.status).toBe(404);
+    expect(hidden.body).toEqual({ code: "CREATION_SNAPSHOT_ENTITY_NOT_FOUND" });
+    expect(anonymousMetadata.status).toBe(401);
+    expect(anonymousMetadata.body).toEqual({ code: "UNAUTHORIZED" });
+    expect(anonymous.status).toBe(401);
+    expect(anonymous.body).toEqual({ code: "UNAUTHORIZED" });
+    expect(authoritative.read).not.toHaveBeenCalled();
+    expect(authoritative.envelope).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed archive ids and records a byte-free print intent for an exact archive", async () => {
+    const app = buildApp();
+    const malformed = await request(app).get(`/${ROOT_ID}/creation-snapshot/not-a-uuid/download`);
+    const printed = await request(app).post(`/${ROOT_ID}/creation-snapshot/${ARCHIVE_ID}/print-intents`);
+
+    expect(malformed.status).toBe(400);
+    expect(malformed.body).toEqual({ code: "INVALID_ROUTE_PARAM" });
+    expect(printed.status).toBe(204);
+    expect(printed.headers["cache-control"]).toBe("private, no-store, max-age=0");
+    expect(authoritative.read).not.toHaveBeenCalled();
+    expect(authoritative.print).toHaveBeenCalledWith({
+      entityType: "client",
+      entityId: ROOT_ID,
+      documentKind: "CLIENT_CREATION_SNAPSHOT",
+      archiveId: ARCHIVE_ID,
+      actorUserId: 7,
+    });
+  });
+});

--- a/src/__tests__/creation-snapshot-transactional.repository.test.ts
+++ b/src/__tests__/creation-snapshot-transactional.repository.test.ts
@@ -1,0 +1,342 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolConnect: vi.fn(),
+  poolQuery: vi.fn(),
+  clientRelease: vi.fn(),
+  generateCommandeCode: vi.fn(),
+  generateSupplierCode: vi.fn(),
+  insertAudit: vi.fn(),
+  issuer: vi.fn(),
+}));
+
+vi.mock("../config/database", () => ({
+  default: { connect: mocks.poolConnect, query: mocks.poolQuery },
+}));
+
+vi.mock("../shared/codes/code-generator.service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../shared/codes/code-generator.service")>();
+  return {
+    ...actual,
+    generateCommandeCode: mocks.generateCommandeCode,
+    generateCommandeFournisseurCode: mocks.generateSupplierCode,
+  };
+});
+
+vi.mock("../module/audit-logs/repository/audit-logs.repository", () => ({
+  repoInsertAuditLog: mocks.insertAudit,
+}));
+
+vi.mock("../shared/documents/issuer-identity.repository", () => ({
+  readIssuerParty: mocks.issuer,
+}));
+
+import { repoDuplicateCommande } from "../module/commande-client/repository/commande-client.repository";
+import { repoConfirmPropositions } from "../module/commande-fournisseur/repository/commande-fournisseur.repository";
+import { authoritativePdfQueueDbMock } from "./helpers/authoritative-pdf-queue-db-mock";
+
+type QueryResult = { rows: Record<string, unknown>[]; rowCount?: number };
+
+const CUSTOMER_ORDER_ID = "456";
+const SUPPLIER_ID = "11111111-1111-4111-8111-111111111111";
+const SUPPLIER_ORDER_ID = "22222222-2222-4222-8222-222222222222";
+const SUPPLIER_LINE_ID = "33333333-3333-4333-8333-333333333333";
+
+/**
+ * Extends the shared authoritative queue fixture with transaction-local state.
+ * An archive insert is deliberately kept pending until COMMIT, so an outbox
+ * failure proves that the business caller's rollback discards it.
+ */
+function transactionalAuthoritativeQueue(options: { failOutbox?: boolean } = {}) {
+  const calls: Array<{ statement: string; values: readonly unknown[] }> = [];
+  const pendingArchives = new Map<string, Record<string, unknown>>();
+  const pendingOutbox = new Set<string>();
+  const committedArchives = new Map<string, Record<string, unknown>>();
+  const committedOutbox = new Set<string>();
+
+  const handle = (sql: unknown, values: readonly unknown[] = []): QueryResult | undefined => {
+    const statement = String(sql);
+    calls.push({ statement, values });
+    if (statement === "BEGIN") return { rows: [] };
+    if (statement === "ROLLBACK") {
+      pendingArchives.clear();
+      pendingOutbox.clear();
+      return { rows: [] };
+    }
+    if (statement === "COMMIT") {
+      for (const [key, row] of pendingArchives) committedArchives.set(key, row);
+      for (const key of pendingOutbox) committedOutbox.add(key);
+      pendingArchives.clear();
+      pendingOutbox.clear();
+      return { rows: [] };
+    }
+    if (statement.includes("INSERT INTO public.authoritative_pdf_archives")) {
+      const result = authoritativePdfQueueDbMock(sql, values);
+      const key = String(values[5]);
+      const row = result?.rows[0];
+      if (!row) throw new Error("test queue fixture did not return an archive row");
+      pendingArchives.set(key, row);
+      return result;
+    }
+    if (statement.includes("INSERT INTO public.authoritative_pdf_archive_outbox")) {
+      if (options.failOutbox) throw new Error("authoritative outbox unavailable");
+      const result = authoritativePdfQueueDbMock(sql, values);
+      pendingOutbox.add(String(values[1]));
+      return result ?? { rows: [], rowCount: 1 };
+    }
+    return undefined;
+  };
+
+  return { calls, committedArchives, committedOutbox, handle };
+}
+
+const originalCommande = {
+  numero: "CC-123",
+  client_id: "001",
+  contact_id: null,
+  destinataire_id: null,
+  adresse_facturation_id: null,
+  emetteur: null,
+  code_client: "ACME",
+  compteur_affaire_id: null,
+  type_affaire: "livraison",
+  order_type: "FERME",
+  cadre_start_date: null,
+  cadre_end_date: null,
+  dest_stock_magasin_id: null,
+  dest_stock_emplacement_id: null,
+  mode_port_id: null,
+  mode_reglement_id: null,
+  conditions_paiement_id: null,
+  biller_id: null,
+  compte_vente_id: null,
+  commentaire: null,
+  remise_globale: 0,
+  total_ht: 0,
+  total_ttc: 0,
+};
+
+function customerDuplicateDispatcher(queue: ReturnType<typeof transactionalAuthoritativeQueue>) {
+  return async (sql: unknown, values: readonly unknown[] = []): Promise<QueryResult> => {
+    const queued = queue.handle(sql, values);
+    if (queued) return queued;
+
+    const shared = authoritativePdfQueueDbMock(sql, values);
+    if (shared) return shared;
+
+    const statement = String(sql);
+    if (statement.includes("FROM commande_client") && statement.includes("WHERE id = $1") && statement.includes("FOR UPDATE")) {
+      return { rows: [originalCommande] };
+    }
+    if (statement.includes("FROM commande_ligne") && statement.includes("WHERE commande_id = $1")) {
+      return { rows: [] };
+    }
+    if (statement.includes("nextval('public.commande_client_id_seq')")) {
+      return { rows: [{ id: CUSTOMER_ORDER_ID }] };
+    }
+    return { rows: [] };
+  };
+}
+
+type SupplierReplayState = { resultat: Record<string, unknown> | null };
+
+function supplierProposalDispatcher(
+  queue: ReturnType<typeof transactionalAuthoritativeQueue>,
+  replay: SupplierReplayState,
+) {
+  return async (sql: unknown, values: readonly unknown[] = []): Promise<QueryResult> => {
+    const queued = queue.handle(sql, values);
+    if (queued) return queued;
+
+    const statement = String(sql);
+    if (statement.includes("FROM public.commande_fournisseur_idempotence")) {
+      return replay.resultat
+        ? { rows: [{ action: "GENERATE", resultat: replay.resultat }] }
+        : { rows: [] };
+    }
+    if (statement.includes("INSERT INTO public.commande_fournisseur_idempotence")) {
+      replay.resultat = JSON.parse(String(values[3])) as Record<string, unknown>;
+      return { rows: [] };
+    }
+    if (statement.includes("FROM public.commande_fournisseur cf") && statement.includes("JOIN public.fournisseurs f")) {
+      return {
+        rows: [{
+          code: "BCF-2026-0042", statut: "BROUILLON", issued_at: "2026-08-23T12:00:00.000Z", devise: "EUR",
+          need_date: null, incoterm: null, payment_terms: null, transport_mode: null, public_comment: null,
+          delivery_address: null, supplier_code: "FOU-001", supplier_name: "Fournisseur test",
+          supplier_street: null, supplier_house_no: null, supplier_postal_code: null, supplier_city: null, supplier_country: null,
+          total_ht: "20", total_remise: "0", total_tva: "4", freight_ht: "0", total_ttc: "24",
+        }],
+      };
+    }
+    if (statement.includes("SELECT position::int") && statement.includes("FROM public.commande_fournisseur_ligne") && statement.includes("statut_ligne = 'ACTIVE'")) {
+      return { rows: [{ position: 1, reference: null, designation: "Article test", unit: "u", quantity: "10", unit_price_ht: "2", discount_pct: "0", vat_pct: "20", net_ht: "20", need_date: null }] };
+    }
+    if (statement.includes("SELECT updated_at::text AS source_revision") && statement.includes("FROM public.commande_fournisseur")) {
+      return { rows: [{ source_revision: "2026-08-23T12:00:00.000Z" }] };
+    }
+    if (statement.includes("SELECT id, COALESCE(code, code_fournisseur)") && statement.includes("FROM public.fournisseurs")) {
+      return { rows: [{ id: SUPPLIER_ID, code: "FOU-001", nom: "Fournisseur test", status: "actif", actif: true }] };
+    }
+    if (
+      statement.includes("INSERT INTO public.commande_fournisseur") &&
+      !statement.includes("commande_fournisseur_ligne") &&
+      !statement.includes("commande_fournisseur_idempotence")
+    ) {
+      return { rows: [{ id: SUPPLIER_ORDER_ID }] };
+    }
+    if (statement.includes("INSERT INTO public.commande_fournisseur_ligne_besoin")) {
+      return { rows: [] };
+    }
+    if (statement.includes("INSERT INTO public.commande_fournisseur_ligne (") && !statement.includes("ligne_besoin")) {
+      return { rows: [{ id: SUPPLIER_LINE_ID }] };
+    }
+    if (statement.includes("SELECT quantite::text") && statement.includes("FROM public.commande_fournisseur_ligne")) {
+      return { rows: [{ quantite: "10", prix_unitaire_ht: "2", remise_pct: "0", tva_pct: "20", frais_ht: "0", statut_ligne: "ACTIVE" }] };
+    }
+    if (statement.includes("SELECT frais_port_ht::text") && statement.includes("FROM public.commande_fournisseur")) {
+      return { rows: [{ frais_port_ht: "0", tva_frais_pct: "20" }] };
+    }
+    return { rows: [] };
+  };
+}
+
+const supplierAudit = {
+  user_id: 7,
+  ip: "127.0.0.1",
+  user_agent: "vitest",
+  device_type: null,
+  os: null,
+  browser: null,
+  path: "/api/v1/commandes-fournisseurs/propositions/confirm",
+  page_key: "commandes-fournisseurs",
+  client_session_id: "creation-snapshot-transaction-test",
+};
+
+const supplierProposalBody = {
+  idempotency_key: "supplier-proposal-creation-42",
+  groupes: [{
+    fournisseur_id: SUPPLIER_ID,
+    devise: "EUR",
+    date_besoin: null,
+    lignes: [{
+      besoin_type: "STOCK_LEVEL",
+      besoin_ref: "stock-level-42",
+      of_id: null,
+      article_id: null,
+      catalogue_id: null,
+      type: "ARTICLE",
+      designation: "Article test",
+      quantite: 10,
+      unite: "u",
+      prix_unitaire_ht: 2,
+      tva_pct: 20,
+      date_besoin: null,
+      delai_jours: null,
+    }],
+  }],
+};
+
+function indices(state: ReturnType<typeof transactionalAuthoritativeQueue>) {
+  return {
+    begin: state.calls.findIndex(({ statement }) => statement === "BEGIN"),
+    archive: state.calls.findIndex(({ statement }) => statement.includes("INSERT INTO public.authoritative_pdf_archives")),
+    outbox: state.calls.findIndex(({ statement }) => statement.includes("INSERT INTO public.authoritative_pdf_archive_outbox")),
+    commit: state.calls.findIndex(({ statement }) => statement === "COMMIT"),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.poolConnect.mockReset();
+  mocks.poolQuery.mockReset();
+  mocks.clientRelease.mockReset();
+  mocks.generateCommandeCode.mockResolvedValue("CMD-2026-0456");
+  mocks.generateSupplierCode.mockResolvedValue("BCF-2026-0042");
+  mocks.insertAudit.mockResolvedValue(undefined);
+  mocks.issuer.mockResolvedValue({ company_name: "CERP Test" });
+  mocks.poolQuery.mockResolvedValue({ rows: [] });
+});
+
+describe("automatic creation snapshot queue transactions", () => {
+  it("rolls back a failed customer-order duplicate queue and commits exactly one archive/outbox on retry", async () => {
+    const failedQueue = transactionalAuthoritativeQueue({ failOutbox: true });
+    mocks.poolConnect.mockResolvedValueOnce({
+      query: vi.fn(customerDuplicateDispatcher(failedQueue)),
+      release: mocks.clientRelease,
+    });
+
+    await expect(repoDuplicateCommande("123")).rejects.toThrow("authoritative outbox unavailable");
+    expect(failedQueue.committedArchives.size).toBe(0);
+    expect(failedQueue.committedOutbox.size).toBe(0);
+    expect(failedQueue.calls.some(({ statement }) => statement === "ROLLBACK")).toBe(true);
+    expect(failedQueue.calls.some(({ statement }) => statement === "COMMIT")).toBe(false);
+
+    const successfulQueue = transactionalAuthoritativeQueue();
+    mocks.poolConnect.mockResolvedValueOnce({
+      query: vi.fn(customerDuplicateDispatcher(successfulQueue)),
+      release: mocks.clientRelease,
+    });
+
+    await expect(repoDuplicateCommande("123")).resolves.toEqual({ id: Number(CUSTOMER_ORDER_ID) });
+    expect([...successfulQueue.committedArchives.keys()]).toEqual([`commande-client:${CUSTOMER_ORDER_ID}:creation:v1`]);
+    expect([...successfulQueue.committedOutbox]).toEqual([`authoritative-pdf:commande-client:${CUSTOMER_ORDER_ID}:creation:v1`]);
+    expect(successfulQueue.calls.filter(({ statement }) => statement.includes("INSERT INTO public.authoritative_pdf_archives"))).toHaveLength(1);
+    expect(successfulQueue.calls.filter(({ statement }) => statement.includes("INSERT INTO public.authoritative_pdf_archive_outbox"))).toHaveLength(1);
+    expect(indices(successfulQueue)).toMatchObject({ begin: 0 });
+    const order = indices(successfulQueue);
+    expect(order.begin).toBeLessThan(order.archive);
+    expect(order.archive).toBeLessThan(order.outbox);
+    expect(order.outbox).toBeLessThan(order.commit);
+  });
+
+  it("persists one supplier-proposal snapshot, rolls back a failed outbox, then replays without another queue", async () => {
+    const replay: SupplierReplayState = { resultat: null };
+    const failedQueue = transactionalAuthoritativeQueue({ failOutbox: true });
+    mocks.poolConnect.mockResolvedValueOnce({
+      query: vi.fn(supplierProposalDispatcher(failedQueue, replay)),
+      release: mocks.clientRelease,
+    });
+
+    await expect(repoConfirmPropositions(supplierProposalBody, supplierAudit)).rejects.toThrow("authoritative outbox unavailable");
+    expect(replay.resultat).toBeNull();
+    expect(failedQueue.committedArchives.size).toBe(0);
+    expect(failedQueue.committedOutbox.size).toBe(0);
+    expect(failedQueue.calls.some(({ statement }) => statement === "ROLLBACK")).toBe(true);
+
+    const successfulQueue = transactionalAuthoritativeQueue();
+    mocks.poolConnect.mockResolvedValueOnce({
+      query: vi.fn(supplierProposalDispatcher(successfulQueue, replay)),
+      release: mocks.clientRelease,
+    });
+
+    await expect(repoConfirmPropositions(supplierProposalBody, supplierAudit)).resolves.toMatchObject({
+      idempotent_replay: false,
+      commandes: [{ id: SUPPLIER_ORDER_ID, code: "BCF-2026-0042", fournisseur_id: SUPPLIER_ID }],
+    });
+    expect([...successfulQueue.committedArchives.keys()]).toEqual([`commande-fournisseur:${SUPPLIER_ORDER_ID}:creation:v1`]);
+    expect([...successfulQueue.committedOutbox]).toEqual([`authoritative-pdf:commande-fournisseur:${SUPPLIER_ORDER_ID}:creation:v1`]);
+    expect(successfulQueue.calls.filter(({ statement }) => statement.includes("INSERT INTO public.authoritative_pdf_archives"))).toHaveLength(1);
+    expect(successfulQueue.calls.filter(({ statement }) => statement.includes("INSERT INTO public.authoritative_pdf_archive_outbox"))).toHaveLength(1);
+    const order = indices(successfulQueue);
+    expect(order.begin).toBeLessThan(order.archive);
+    expect(order.archive).toBeLessThan(order.outbox);
+    expect(order.outbox).toBeLessThan(order.commit);
+
+    const replayQueue = transactionalAuthoritativeQueue();
+    mocks.poolConnect.mockResolvedValueOnce({
+      query: vi.fn(supplierProposalDispatcher(replayQueue, replay)),
+      release: mocks.clientRelease,
+    });
+
+    await expect(repoConfirmPropositions(supplierProposalBody, supplierAudit)).resolves.toMatchObject({
+      idempotent_replay: true,
+      commandes: [{ id: SUPPLIER_ORDER_ID, code: "BCF-2026-0042", fournisseur_id: SUPPLIER_ID }],
+    });
+    expect(replayQueue.committedArchives.size).toBe(0);
+    expect(replayQueue.committedOutbox.size).toBe(0);
+    expect(replayQueue.calls.some(({ statement }) => statement.includes("INSERT INTO public.commande_fournisseur"))).toBe(false);
+    expect(replayQueue.calls.some(({ statement }) => statement.includes("INSERT INTO public.authoritative_pdf_archives"))).toBe(false);
+    expect(replayQueue.calls.some(({ statement }) => statement.includes("INSERT INTO public.authoritative_pdf_archive_outbox"))).toBe(false);
+  });
+});

--- a/src/__tests__/creation-snapshot.mounted.routes.test.ts
+++ b/src/__tests__/creation-snapshot.mounted.routes.test.ts
@@ -1,0 +1,381 @@
+import request from "supertest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+import { HttpError } from "../utils/httpError";
+import { setLogSinkForTests } from "../shared/observability/logger";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+  getClient: vi.fn(),
+  getFournisseur: vi.fn(),
+  getCommande: vi.fn(),
+  getOf: vi.fn(),
+  getPieceTechnique: vi.fn(),
+  getAffaire: vi.fn(),
+  getStockArticle: vi.fn(),
+  envelope: vi.fn(),
+  read: vi.fn(),
+  print: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+// The test uses the real mounted v1 router. Authentication is intentionally
+// minimal but rejects a missing bearer token before controllers/services run.
+vi.mock("../module/auth/middlewares/auth.middleware", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../module/auth/middlewares/auth.middleware")>();
+  return {
+    ...actual,
+    authenticateToken: (
+      req: { user?: unknown; headers: Record<string, string | string[] | undefined> },
+      res: { status: (status: number) => { json: (body: unknown) => void } },
+      next: () => void
+    ) => {
+      if (typeof req.headers.authorization !== "string" || !req.headers.authorization.startsWith("Bearer ")) {
+        res.status(401).json({ code: "UNAUTHORIZED" });
+        return;
+      }
+      const role = typeof req.headers["x-test-role"] === "string"
+        ? req.headers["x-test-role"]
+        : "Administrateur Systeme et Reseau";
+      req.user = { id: 7, username: "mounted-test", email: "mounted@example.test", role };
+      next();
+    },
+  };
+});
+
+// Keep the real app/router composition while making the global account-module
+// decision explicit and deterministic for the rejection matrix below.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (
+    req: { headers: Record<string, string | string[] | undefined> },
+    res: { status: (status: number) => { json: (body: unknown) => void } },
+    next: () => void
+  ) => {
+    if (req.headers["x-test-module"] === "denied") {
+      res.status(403).json({ code: "MODULE_ACCESS_FORBIDDEN" });
+      return;
+    }
+    next();
+  },
+}));
+
+vi.mock("../module/client/services/clients.read.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../module/client/services/clients.read.service")>()),
+  svcGetClientById: mocks.getClient,
+}));
+vi.mock("../module/fournisseurs/services/fournisseurs.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../module/fournisseurs/services/fournisseurs.service")>()),
+  getFournisseurSVC: mocks.getFournisseur,
+}));
+vi.mock("../module/commande-client/services/commande-client.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../module/commande-client/services/commande-client.service")>()),
+  getCommandeSVC: mocks.getCommande,
+}));
+vi.mock("../module/production/services/production.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../module/production/services/production.service")>()),
+  svcGetOrdreFabrication: mocks.getOf,
+}));
+vi.mock("../module/pieces-techniques/services/pieces-techniques.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../module/pieces-techniques/services/pieces-techniques.service")>()),
+  getPieceTechniqueSVC: mocks.getPieceTechnique,
+}));
+vi.mock("../module/affaire/services/affaire.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../module/affaire/services/affaire.service")>()),
+  svcGetAffaire: mocks.getAffaire,
+}));
+vi.mock("../module/stock/services/stock.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../module/stock/services/stock.service")>()),
+  getStockArticleSVC: mocks.getStockArticle,
+}));
+vi.mock("../shared/authoritative-documents/authoritative-document.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../shared/authoritative-documents/authoritative-document.service")>()),
+  getOfficialDocumentGenerationEnvelope: mocks.envelope,
+  readOfficialPdfBytes: mocks.read,
+  recordOfficialPdfPrintIntent: mocks.print,
+}));
+
+import app from "../config/app";
+
+const ARCHIVE_ID = "11111111-1111-4111-8111-111111111111";
+const FOREIGN_ARCHIVE_ID = "22222222-2222-4222-8222-222222222222";
+const SNAPSHOT_BYTES = Buffer.from("%PDF-1.7 mounted immutable snapshot\n%%EOF\n", "utf8");
+
+function binaryParser(response: NodeJS.ReadableStream, callback: (error: Error | null, value?: Buffer) => void): void {
+  const chunks: Buffer[] = [];
+  response.on("data", (chunk: Buffer | string) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+  response.on("error", (error: Error) => callback(error));
+  response.on("end", () => callback(null, Buffer.concat(chunks)));
+}
+
+type MountedRoute = Readonly<{
+  label: string;
+  path: string;
+  entityType: string;
+  documentKind: string;
+  baseUrl: string;
+  root: ReturnType<typeof vi.fn>;
+  expectRootLookup: () => void;
+}>;
+
+const clientId = "client-mounted";
+const fournisseurId = "33333333-3333-4333-8333-333333333333";
+const commandeId = "42";
+const ofId = "73";
+const pieceTechniqueId = "44444444-4444-4444-8444-444444444444";
+const affaireId = "91";
+const stockArticleId = "55555555-5555-4555-8555-555555555555";
+
+const routes: readonly MountedRoute[] = [
+  {
+    label: "client",
+    path: `/api/v1/clients/${clientId}/creation-snapshot`,
+    entityType: "client",
+    documentKind: "CLIENT_CREATION_SNAPSHOT",
+    baseUrl: `/clients/${clientId}/creation-snapshot`,
+    root: mocks.getClient,
+    expectRootLookup: () => expect(mocks.getClient).toHaveBeenCalledWith(clientId, { includeSensitiveFinance: false }),
+  },
+  {
+    label: "fournisseur",
+    path: `/api/v1/fournisseurs/${fournisseurId}/creation-snapshot`,
+    entityType: "fournisseur",
+    documentKind: "SUPPLIER_CREATION_SNAPSHOT",
+    baseUrl: `/fournisseurs/${fournisseurId}/creation-snapshot`,
+    root: mocks.getFournisseur,
+    expectRootLookup: () => expect(mocks.getFournisseur).toHaveBeenCalledWith(fournisseurId),
+  },
+  {
+    label: "commande client",
+    path: `/api/v1/commandes/${commandeId}/creation-snapshot`,
+    entityType: "commande-client",
+    documentKind: "CUSTOMER_ORDER_CREATION_SNAPSHOT",
+    baseUrl: `/commandes/${commandeId}/creation-snapshot`,
+    root: mocks.getCommande,
+    expectRootLookup: () => expect(mocks.getCommande).toHaveBeenCalledWith(commandeId, expect.any(Set)),
+  },
+  {
+    label: "ordre de fabrication",
+    path: `/api/v1/production/ofs/${ofId}/creation-snapshot`,
+    entityType: "ordre-fabrication",
+    documentKind: "OF_CREATION_SNAPSHOT",
+    baseUrl: `/production/ofs/${ofId}/creation-snapshot`,
+    root: mocks.getOf,
+    expectRootLookup: () => expect(mocks.getOf).toHaveBeenCalledWith({ id: Number(ofId), user_id: 7 }),
+  },
+  {
+    label: "pièce technique",
+    path: `/api/v1/pieces-techniques/${pieceTechniqueId}/creation-snapshot`,
+    entityType: "piece-technique",
+    documentKind: "TECHNICAL_PIECE_CREATION_SNAPSHOT",
+    baseUrl: `/pieces-techniques/${pieceTechniqueId}/creation-snapshot`,
+    root: mocks.getPieceTechnique,
+    expectRootLookup: () => expect(mocks.getPieceTechnique).toHaveBeenCalledWith(pieceTechniqueId, expect.any(Set)),
+  },
+  {
+    label: "affaire",
+    path: `/api/v1/affaires/${affaireId}/creation-snapshot`,
+    entityType: "affaire",
+    documentKind: "AFFAIR_CREATION_SNAPSHOT",
+    baseUrl: `/affaires/${affaireId}/creation-snapshot`,
+    root: mocks.getAffaire,
+    expectRootLookup: () => expect(mocks.getAffaire).toHaveBeenCalledWith(Number(affaireId), ""),
+  },
+  {
+    label: "article stock",
+    path: `/api/v1/stock/articles/${stockArticleId}/creation-snapshot`,
+    entityType: "stock-article",
+    documentKind: "STOCK_ARTICLE_CREATION_SNAPSHOT",
+    baseUrl: `/stock/articles/${stockArticleId}/creation-snapshot`,
+    root: mocks.getStockArticle,
+    expectRootLookup: () => expect(mocks.getStockArticle).toHaveBeenCalledWith(stockArticleId, false),
+  },
+];
+
+function authenticated(requestBuilder: request.Test): request.Test {
+  return requestBuilder.set("Authorization", "Bearer mounted-test");
+}
+
+beforeEach(() => {
+  // The error-path matrix intentionally exercises 401/403/404 responses.
+  // Keep CI output focused on assertions rather than structured application logs.
+  setLogSinkForTests(() => {});
+  mocks.poolQuery.mockReset().mockResolvedValue({ rows: [] });
+  mocks.poolConnect.mockReset().mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+  mocks.clientQuery.mockReset().mockResolvedValue({ rows: [] });
+  mocks.clientRelease.mockReset();
+
+  for (const root of [
+    mocks.getClient,
+    mocks.getFournisseur,
+    mocks.getCommande,
+    mocks.getOf,
+    mocks.getPieceTechnique,
+    mocks.getAffaire,
+    mocks.getStockArticle,
+  ]) {
+    root.mockReset().mockResolvedValue({ id: "visible" });
+  }
+  mocks.envelope.mockReset().mockResolvedValue({
+    state: "READY",
+    latest_document: { id: ARCHIVE_ID },
+    retryable: false,
+    failure_code: null,
+  });
+  mocks.read.mockReset().mockResolvedValue({
+    bytes: SNAPSHOT_BYTES,
+    filename: "creation-snapshot.pdf",
+    sha256: "a".repeat(64),
+  });
+  mocks.print.mockReset().mockResolvedValue(undefined);
+});
+
+afterAll(() => setLogSinkForTests(null));
+
+describe("mounted Wave 2 creation-snapshot routes", () => {
+  it.each(routes)("rejects unauthenticated $label route before its root/archive adapter", async (route) => {
+    const response = await request(app).get(route.path);
+
+    expect(response.status).toBe(401);
+    expect(route.root).not.toHaveBeenCalled();
+    expect(mocks.envelope).not.toHaveBeenCalled();
+  });
+
+  it.each(routes)("honors the global module-access rejection on actual $label mount", async (route) => {
+    const response = await authenticated(request(app).get(route.path)).set("x-test-module", "denied");
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ code: "MODULE_ACCESS_FORBIDDEN" });
+    expect(route.root).not.toHaveBeenCalled();
+    expect(mocks.envelope).not.toHaveBeenCalled();
+  });
+
+  it("routes every mounted aggregate to its fixed kind after the real root-scope adapter", async () => {
+    for (const route of routes) {
+      route.root.mockClear();
+      mocks.envelope.mockClear();
+      const response = await authenticated(request(app).get(route.path));
+
+      expect(response.status, route.label).toBe(200);
+      expect(response.headers["cache-control"]).toBe("private, no-store, max-age=0");
+      expect(response.headers.pragma).toBe("no-cache");
+      expect(response.body).toMatchObject({ state: "READY", latest_document: { id: ARCHIVE_ID } });
+      route.expectRootLookup();
+      expect(mocks.envelope).toHaveBeenCalledWith({
+        tx: expect.any(Object),
+        entityType: route.entityType,
+        entityId: route.path.split("/").at(-2),
+        documentKind: route.documentKind,
+        baseUrl: route.baseUrl,
+      });
+    }
+  });
+
+  it("returns the same 404 before archive metadata for a scoped-away root on every mount", async () => {
+    for (const route of routes) {
+      mocks.envelope.mockClear();
+      route.root.mockResolvedValueOnce(null);
+      const response = await authenticated(request(app).get(route.path));
+
+      expect(response.status, route.label).toBe(404);
+      expect(response.body.code).toBe("CREATION_SNAPSHOT_ENTITY_NOT_FOUND");
+      expect(mocks.envelope, route.label).not.toHaveBeenCalled();
+    }
+  });
+
+  it("retains aggregate export/read capability guards where the module has one", async () => {
+    const deniedCases = [
+      { path: `/api/v1/commandes/${commandeId}/creation-snapshot`, role: "Employee" },
+      { path: `/api/v1/affaires/${affaireId}/creation-snapshot`, role: "Employee" },
+      { path: `/api/v1/stock/articles/${stockArticleId}/creation-snapshot`, role: "Commercial" },
+    ] as const;
+
+    for (const denied of deniedCases) {
+      mocks.envelope.mockClear();
+      const response = await authenticated(request(app).get(denied.path)).set("x-test-role", denied.role);
+      expect(response.status, denied.path).toBe(403);
+      expect(mocks.envelope, denied.path).not.toHaveBeenCalled();
+    }
+  });
+
+  it("serves the exact immutable command snapshot bytes through both mounted PDF surfaces", async () => {
+    const base = `/api/v1/commandes/${commandeId}/creation-snapshot/${ARCHIVE_ID}`;
+    const preview = await authenticated(request(app).get(`${base}/preview`)).buffer(true).parse(binaryParser);
+    const download = await authenticated(request(app).get(`${base}/download`)).buffer(true).parse(binaryParser);
+
+    for (const response of [preview, download]) {
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(SNAPSHOT_BYTES);
+      expect(response.headers["content-type"]).toMatch(/^application\/pdf/);
+      expect(response.headers["content-length"]).toBe(String(SNAPSHOT_BYTES.byteLength));
+      expect(response.headers["cache-control"]).toBe("private, no-store, max-age=0");
+      expect(response.headers["x-content-type-options"]).toBe("nosniff");
+    }
+    expect(preview.headers["content-disposition"]).toContain('inline; filename="creation-snapshot.pdf"');
+    expect(download.headers["content-disposition"]).toContain('attachment; filename="creation-snapshot.pdf"');
+    expect(mocks.read).toHaveBeenNthCalledWith(1, {
+      entityType: "commande-client",
+      entityId: commandeId,
+      documentKind: "CUSTOMER_ORDER_CREATION_SNAPSHOT",
+      archiveId: ARCHIVE_ID,
+      actorUserId: 7,
+      eventType: "AUTHORITATIVE_PDF_PREVIEWED",
+    });
+    expect(mocks.read).toHaveBeenNthCalledWith(2, {
+      entityType: "commande-client",
+      entityId: commandeId,
+      documentKind: "CUSTOMER_ORDER_CREATION_SNAPSHOT",
+      archiveId: ARCHIVE_ID,
+      actorUserId: 7,
+      eventType: "AUTHORITATIVE_PDF_DOWNLOADED",
+    });
+  });
+
+  it("rejects malformed and foreign archive IDs without falling back to another document", async () => {
+    const root = `/api/v1/commandes/${commandeId}/creation-snapshot`;
+    const malformed = await authenticated(request(app).get(`${root}/not-a-uuid/download`));
+    expect(malformed.status).toBe(400);
+    expect(malformed.body.code).toBe("INVALID_ROUTE_PARAM");
+    expect(mocks.read).not.toHaveBeenCalled();
+
+    mocks.read.mockRejectedValueOnce(
+      new HttpError(404, "OFFICIAL_DOCUMENT_NOT_FOUND", "Document officiel introuvable.")
+    );
+    const foreign = await authenticated(request(app).get(`${root}/${FOREIGN_ARCHIVE_ID}/download`));
+    expect(foreign.status).toBe(404);
+    expect(foreign.body.code).toBe("OFFICIAL_DOCUMENT_NOT_FOUND");
+    expect(mocks.read).toHaveBeenCalledWith(expect.objectContaining({ archiveId: FOREIGN_ARCHIVE_ID }));
+  });
+
+  it("records a byte-free print intent through the mounted stock-article route", async () => {
+    const response = await authenticated(
+      request(app).post(`/api/v1/stock/articles/${stockArticleId}/creation-snapshot/${ARCHIVE_ID}/print-intents`)
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers["cache-control"]).toBe("private, no-store, max-age=0");
+    expect(mocks.print).toHaveBeenCalledWith({
+      entityType: "stock-article",
+      entityId: stockArticleId,
+      documentKind: "STOCK_ARTICLE_CREATION_SNAPSHOT",
+      archiveId: ARCHIVE_ID,
+      actorUserId: 7,
+    });
+  });
+});

--- a/src/__tests__/creation-snapshot.routes.test.ts
+++ b/src/__tests__/creation-snapshot.routes.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { GENERATED_ROUTE_INVENTORY } from "../swagger/generated-route-inventory";
+
+type RouteExpectation = Readonly<{
+  root: string;
+  rbac?: string;
+}>;
+
+const aggregates: readonly RouteExpectation[] = [
+  { root: "/clients/{id}/creation-snapshot" },
+  { root: "/fournisseurs/{id}/creation-snapshot" },
+  { root: "/commandes/{id}/creation-snapshot", rbac: "requireAcknowledgementExport" },
+  { root: "/production/ofs/{id}/creation-snapshot" },
+  { root: "/pieces-techniques/{id}/creation-snapshot" },
+  { root: "/affaires/{id}/creation-snapshot", rbac: "requireAffaireCapability(read)" },
+  { root: "/stock/articles/{id}/creation-snapshot", rbac: "requireStockCapability(read)" },
+];
+
+describe("Wave 2 creation-snapshot route contract", () => {
+  it("exposes only the four authenticated, read-only surfaces for every aggregate", () => {
+    const allSnapshotRoutes = GENERATED_ROUTE_INVENTORY.filter((route) => route.path.includes("/creation-snapshot"));
+    expect(allSnapshotRoutes).toHaveLength(aggregates.length * 4);
+
+    for (const aggregate of aggregates) {
+      const expected = [
+        ["get", aggregate.root],
+        ["get", `${aggregate.root}/{documentId}/preview`],
+        ["get", `${aggregate.root}/{documentId}/download`],
+        ["post", `${aggregate.root}/{documentId}/print-intents`],
+      ] as const;
+      const actual = GENERATED_ROUTE_INVENTORY.filter((route) =>
+        expected.some(([method, path]) => route.method === method && route.path === path)
+      );
+
+      expect(actual).toHaveLength(expected.length);
+      for (const route of actual) {
+        expect(route.authenticated).toBe(true);
+        expect(route.rbac).toContain("moduleAccessGate");
+        if (aggregate.rbac) expect(route.rbac).toContain(aggregate.rbac);
+      }
+
+      // Creation is queue-driven in the aggregate transaction. A browser may
+      // observe it, preview/download its immutable bytes, or record a print intent,
+      // but can never create/reissue a snapshot through an HTTP collection POST.
+      expect(
+        GENERATED_ROUTE_INVENTORY.some(
+          (route) => route.method === "post" && route.path === aggregate.root
+        )
+      ).toBe(false);
+    }
+  });
+});

--- a/src/__tests__/devis-workflow-167.routes.test.ts
+++ b/src/__tests__/devis-workflow-167.routes.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   clientQuery: vi.fn(),
   clientRelease: vi.fn(),
 }));
+const officialArchive = vi.hoisted(() => ({ queue: vi.fn() }));
 
 vi.mock("pg", () => {
   const emitter = new EventEmitter();
@@ -23,6 +24,14 @@ vi.mock("pg", () => {
 
 vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../shared/authoritative-documents/authoritative-document.service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../shared/authoritative-documents/authoritative-document.service")>();
+  return { ...actual, queueCreationPdfArchive: officialArchive.queue };
+});
+vi.mock("../shared/documents/issuer-identity.repository", () => ({
+  readIssuerParty: vi.fn().mockResolvedValue({ company_name: "CERP Test" }),
 }));
 
 vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
@@ -126,6 +135,18 @@ function dispatch(sqlRaw: unknown, params?: unknown[]): { rows: unknown[]; rowCo
   if (/commande_client_id_seq/.test(sql)) return { rows: [{ id: "55" }] };
   if (/fn_next(_issued)?_code_value/.test(sql)) return { rows: [{ v: "1" }] };
   if (/MAX\(version_number\)/i.test(sql)) return { rows: [{ next_version: state.nextVersion }] };
+  if (/SELECT updated_at::text AS source_revision FROM public\.devis/.test(sql)) {
+    return { rows: [{ source_revision: "2026-07-22 08:00:00+00" }] };
+  }
+
+  if (/d\.date_creation::text AS issued_at/.test(sql) && /FROM public\.devis d/.test(sql)) {
+    return { rows: [{
+      numero: "DEV-2026-0001", statut: "BROUILLON", issued_at: "2026-07-22T08:00:00.000Z",
+      valid_until: null, version_number: 1, total_ht: "100", total_ttc: "120",
+      global_discount_pct: "0", public_comment: null, biller_id: null, customer_name: "ACME",
+    }] };
+  }
+  if (/FROM public\.devis_ligne WHERE devis_id = \$1/.test(sql)) return { rows: [] };
 
   if (/AS converted/.test(sql)) return { rows: state.deleteCurrent ? [state.deleteCurrent] : [] };
   if (/FOR UPDATE OF d/.test(sql)) return { rows: state.updateCurrent ? [state.updateCurrent] : [] };
@@ -154,6 +175,8 @@ beforeEach(() => {
   mocks.poolConnect.mockReset();
   mocks.clientQuery.mockReset();
   mocks.clientRelease.mockReset();
+  officialArchive.queue.mockReset();
+  officialArchive.queue.mockResolvedValue(undefined);
   mocks.poolConnect.mockResolvedValue({
     query: withRealtimeOutboxDbMock(mocks.clientQuery),
     release: mocks.clientRelease,
@@ -433,6 +456,12 @@ describe("#167 — idempotence création / révision / conversion", () => {
       .field("data", JSON.stringify(createPayload));
     expect(first.status).toBe(201);
     expect(first.body).toMatchObject({ id: 7, idempotent_replay: false });
+    expect(officialArchive.queue).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      entityType: "devis",
+      entityId: "7",
+      documentKind: "CUSTOMER_QUOTE",
+      renderVersion: "devis-pdf-v1",
+    }));
 
     const recordCall = mocks.clientQuery.mock.calls.find((c) =>
       String(c[0]).includes("INSERT INTO public.devis_idempotence")

--- a/src/__tests__/devis.routes.test.ts
+++ b/src/__tests__/devis.routes.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   clientQuery: vi.fn(),
   clientRelease: vi.fn(),
 }));
+const officialArchive = vi.hoisted(() => ({ queue: vi.fn() }));
 
 vi.mock("pg", () => {
   const emitter = new EventEmitter();
@@ -34,6 +35,14 @@ vi.mock("pg", () => {
 
 vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../shared/authoritative-documents/authoritative-document.service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../shared/authoritative-documents/authoritative-document.service")>();
+  return { ...actual, queueCreationPdfArchive: officialArchive.queue };
+});
+vi.mock("../shared/documents/issuer-identity.repository", () => ({
+  readIssuerParty: vi.fn().mockResolvedValue({ company_name: "CERP Test" }),
 }));
 
 // #167 — la conversion directe DÉLÈGUE au moteur commande (repoCreateCommande) ; on le
@@ -151,6 +160,18 @@ function dispatch(sqlRaw: unknown, params?: unknown[]): { rows: unknown[]; rowCo
   if (/fn_next(_issued)?_code_value/.test(sql)) return { rows: [{ v: "1" }] };
 
   if (/MAX\(version_number\)/i.test(sql)) return { rows: [{ next_version: state.nextVersion }] };
+  if (/SELECT updated_at::text AS source_revision FROM public\.devis/.test(sql)) {
+    return { rows: [{ source_revision: "2026-07-22 08:00:00+00" }] };
+  }
+
+  if (/d\.date_creation::text AS issued_at/.test(sql) && /FROM public\.devis d/.test(sql)) {
+    return { rows: [{
+      numero: "DEV-2026-0001", statut: "BROUILLON", issued_at: "2026-07-22T08:00:00.000Z",
+      valid_until: null, version_number: 1, total_ht: "100", total_ttc: "120",
+      global_discount_pct: "0", public_comment: null, biller_id: null, customer_name: "ACME",
+    }] };
+  }
+  if (/FROM public\.devis_ligne WHERE devis_id = \$1/.test(sql)) return { rows: [] };
 
   // Ligne courante verrouillée : suppression (AS converted) / mise à jour (FOR UPDATE OF d).
   if (/AS converted/.test(sql)) return { rows: state.deleteCurrent ? [state.deleteCurrent] : [] };
@@ -207,6 +228,8 @@ beforeEach(() => {
   mocks.poolConnect.mockReset();
   mocks.clientQuery.mockReset();
   mocks.clientRelease.mockReset();
+  officialArchive.queue.mockReset();
+  officialArchive.queue.mockResolvedValue(undefined);
 
   mocks.poolConnect.mockResolvedValue({
     query: withRealtimeOutboxDbMock(mocks.clientQuery),
@@ -734,6 +757,12 @@ describe("/api/v1/devis", () => {
 
     expect(res.status).toBe(201);
     expect(res.body).toMatchObject({ id: 7, idempotent_replay: false });
+    expect(officialArchive.queue).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      entityType: "devis",
+      entityId: "7",
+      documentKind: "CUSTOMER_QUOTE",
+      renderVersion: "devis-pdf-v1",
+    }));
     expect(mocks.poolConnect).toHaveBeenCalledTimes(1);
 
     const insertDocClientCall = mocks.clientQuery.mock.calls.find((c) =>

--- a/src/__tests__/fournisseurs.routes.test.ts
+++ b/src/__tests__/fournisseurs.routes.test.ts
@@ -50,6 +50,7 @@ vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
 }));
 
 import app from "../config/app"
+import { authoritativePdfQueueDbMock } from "./helpers/authoritative-pdf-queue-db-mock"
 
 beforeEach(() => {
   mocks.poolQuery.mockReset()
@@ -70,6 +71,18 @@ function makeToken() {
   return jwt.sign({ id: 1, username: "test", email: "test@example.com", role: "admin" }, process.env.JWT_SECRET, {
     expiresIn: "1h",
   })
+}
+
+function createdFournisseurRow(id: string) {
+  return {
+    id, code: "FOU-001", nom: "Fournisseur pilote", actif: true, status: "actif", type_principal: null,
+    tva: null, siret: null, email: null, telephone: null, site_web: null, adresse_ligne: null,
+    house_no: null, postcode: null, city: null, country: null, nom_commercial: null, logo: null, notes: null,
+    archived_at: null, created_at: "2026-07-27T00:00:00.000Z", updated_at: "2026-07-27T00:00:00.000Z",
+    created_by: 1, updated_by: 1, domaines: [], relations: null, homologation: null, adresses: [],
+    contacts_count: 0, catalogue_count: 0, documents_count: 0, events_count: 0, adresses_count: 0,
+    homologations_count: 0,
+  }
 }
 
 describe("/api/v1/fournisseurs", () => {
@@ -125,8 +138,13 @@ describe("/api/v1/fournisseurs", () => {
     const token = makeToken()
     const fournisseurId = "22222222-2222-4222-8222-222222222222"
 
-    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const query = String(sql)
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params)
+      if (authoritativePdf) return authoritativePdf
+      if (query.includes("SELECT updated_at::text AS updated_at FROM public.fournisseurs")) {
+        return { rows: [{ updated_at: "2026-08-23T12:00:00.000Z" }] }
+      }
       if (query.includes("fn_next_issued_code_value")) {
         return { rows: [{ v: "1" }] }
       }
@@ -135,44 +153,7 @@ describe("/api/v1/fournisseurs", () => {
       }
       return { rows: [] }
     })
-    mocks.poolQuery.mockResolvedValueOnce({
-      rows: [{
-        id: fournisseurId,
-        code: "FOU-001",
-        nom: "Fournisseur pilote",
-        actif: true,
-        status: "actif",
-        type_principal: null,
-        tva: null,
-        siret: null,
-        email: null,
-        telephone: null,
-        site_web: null,
-        adresse_ligne: null,
-        house_no: null,
-        postcode: null,
-        city: null,
-        country: null,
-        nom_commercial: null,
-        logo: null,
-        notes: null,
-        archived_at: null,
-        created_at: "2026-07-27T00:00:00.000Z",
-        updated_at: "2026-07-27T00:00:00.000Z",
-        created_by: 1,
-        updated_by: 1,
-        domaines: [],
-        relations: null,
-        homologation: null,
-        adresses: [],
-        contacts_count: 0,
-        catalogue_count: 0,
-        documents_count: 0,
-        events_count: 0,
-        adresses_count: 0,
-        homologations_count: 0,
-      }],
-    })
+    mocks.poolQuery.mockResolvedValueOnce({ rows: [createdFournisseurRow(fournisseurId)] })
 
     const res = await request(app)
       .post("/api/v1/fournisseurs")
@@ -186,5 +167,43 @@ describe("/api/v1/fournisseurs", () => {
     expect(insertCall).toBeDefined()
     expect(String(insertCall?.[0])).toContain("$1::text,$1::varchar(30)")
     expect(String(insertCall?.[0])).toContain("$2::text,$2::varchar(255)")
+  })
+
+  it("archives the same normalized primary domain that it persists", async () => {
+    const token = makeToken()
+    const fournisseurId = "33333333-3333-4333-8333-333333333333"
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
+      const query = String(sql)
+      const authoritativePdf = authoritativePdfQueueDbMock(sql, params)
+      if (authoritativePdf) return authoritativePdf
+      if (query.includes("SELECT updated_at::text AS updated_at FROM public.fournisseurs")) {
+        return { rows: [{ updated_at: "2026-08-23T12:00:00.000Z" }] }
+      }
+      if (query.includes("fn_next_issued_code_value")) return { rows: [{ v: "1" }] }
+      if (query.includes("INSERT INTO public.fournisseurs")) return { rows: [{ id: fournisseurId }] }
+      return { rows: [] }
+    })
+    mocks.poolQuery.mockResolvedValueOnce({ rows: [createdFournisseurRow(fournisseurId)] })
+
+    const res = await request(app)
+      .post("/api/v1/fournisseurs")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        nom: "Fournisseur pilote",
+        domaines: [
+          { domaine_code: "usinage", is_primary: false },
+          { domaine_code: "traitement", is_primary: false },
+        ],
+      })
+
+    expect(res.status).toBe(201)
+    const domainCalls = mocks.clientQuery.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.fournisseur_domaine_lien"))
+    expect(domainCalls.map((call) => call[1]?.[2])).toEqual([true, false])
+    const archiveCall = mocks.clientQuery.mock.calls.find(([sql]) => String(sql).includes("INSERT INTO public.authoritative_pdf_archives"))
+    const snapshot = JSON.parse(String(archiveCall?.[1]?.[8])) as { sections: Array<{ title: string; table?: { rows: Array<Record<string, string>> } }> }
+    expect(snapshot.sections.find((section) => section.title === "Domaines")?.table?.rows).toEqual([
+      { domaine: "usinage", principal: "Oui" },
+      { domaine: "traitement", principal: "Non" },
+    ])
   })
 })

--- a/src/__tests__/helpers/authoritative-pdf-queue-db-mock.ts
+++ b/src/__tests__/helpers/authoritative-pdf-queue-db-mock.ts
@@ -1,0 +1,38 @@
+/**
+ * Minimal database double for the creation-side authoritative-PDF outbox.
+ * It models the archive row returned by the new same-transaction enqueue,
+ * while deliberately leaving every unrelated query to the owning fixture.
+ */
+export function authoritativePdfQueueDbMock(sql: unknown, params: readonly unknown[] = []) {
+  const statement = String(sql);
+  if (statement.includes("FROM public.commande_client cc") && statement.includes("LEFT JOIN public.clients c") && statement.includes("FOR UPDATE")) {
+    const id = String(params[0] ?? "123");
+    return { rows: [{ id, numero: `CC-${id}`, client_id: "001", client_name: "ACME", billing_address_id: null, billing_address_name: null, billing_street: null, billing_house_number: null, billing_postal_code: null, billing_city: null, billing_country: null, date_commande: "2026-08-23", order_type: "FERME", total_ht: 0, total_ttc: 0, remise_globale: 0, commentaire: null, updated_at: "2026-08-23T12:00:00.000Z" }], rowCount: 1 };
+  }
+  if (statement.includes("FROM public.ordres_fabrication o") && statement.includes("o.parent_of_id IS NULL") && statement.includes("FOR UPDATE")) {
+    const id = String(params[0] ?? "9");
+    return { rows: [{ id, numero: `OF-${id}`, root_of_id: null, parent_of_id: null, generation_level: 0, piece_technique_id: null, piece_technique_version_id: null, technical_snapshot_sha256: null, commande_id: "123", affaire_id: "7", client_id: "001", client_name: "ACME", quantite_lancee: 1, statut: "PLANIFIE", priority: "NORMAL", date_lancement_prevue: null, date_fin_prevue: null, updated_at: "2026-08-23T12:00:00.000Z" }], rowCount: 1 };
+  }
+  if (statement.includes("FROM public.of_operations")) return { rows: [], rowCount: 0 };
+  if (statement.includes("FROM public.affaire a") && statement.includes("FOR UPDATE")) {
+    const id = String(params[0] ?? "7");
+    return { rows: [{ id, reference: `AFF-${id}`, statut: "OUVERTE", type_affaire: "LIVRAISON", date_ouverture: null, updated_at: "2026-08-23T12:00:00.000Z", client_id: "001", client_name: "ACME", commande_id: "123", commande_numero: "CC-123", devis_id: null }], rowCount: 1 };
+  }
+  if (statement.includes("INSERT INTO public.authoritative_pdf_archives")) {
+    return {
+      rows: [{
+        id: "99999999-9999-4999-8999-999999999999",
+        entity_type: String(params[0]), entity_id: String(params[1]), document_kind: String(params[2]),
+        document_version: Number(params[3]), render_version: String(params[4]), idempotency_key: String(params[5]),
+        title: String(params[6]), original_name: String(params[7]), source_snapshot: JSON.parse(String(params[8])),
+        source_revision: String(params[9]), snapshot_sha256: String(params[10]), pdf_sha256: null,
+        pdf_size_bytes: null, ged_document_id: null, ged_version_id: null, archived_at: null,
+        created_at: "2026-08-23T12:00:00.000Z", created_by: params[11] == null ? null : Number(params[11]),
+      }], rowCount: 1,
+    };
+  }
+  if (statement.includes("INSERT INTO public.authoritative_pdf_archive_outbox")) {
+    return { rows: [], rowCount: 1 };
+  }
+  return null;
+}

--- a/src/__tests__/piece-technique-document-policy-227.routes.test.ts
+++ b/src/__tests__/piece-technique-document-policy-227.routes.test.ts
@@ -74,6 +74,7 @@ vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
 }));
 
 import app from "../config/app";
+import { authoritativePdfQueueDbMock } from "./helpers/authoritative-pdf-queue-db-mock";
 
 const PIECE_ID = "11111111-1111-4111-8111-111111111111";
 const VERSION_ID = "22222222-2222-4222-8222-222222222222";
@@ -479,6 +480,8 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
       const query = vi.fn(async (sql: unknown, params?: unknown[]) => {
         const statement = String(sql);
         queries.push(statement);
+        const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+        if (authoritativePdf) return authoritativePdf;
         if (statement === "BEGIN") {
           return { rows: [], rowCount: 0 };
         }

--- a/src/__tests__/replenishment-proposals.repository.test.ts
+++ b/src/__tests__/replenishment-proposals.repository.test.ts
@@ -4,12 +4,13 @@ const mocks = vi.hoisted(() => ({
   poolConnect: vi.fn(),
   clientQuery: vi.fn(),
   clientRelease: vi.fn(),
+  poolQuery: vi.fn(),
   generateCode: vi.fn(),
   insertAudit: vi.fn(),
 }))
 
 vi.mock("../config/database", () => ({
-  default: { connect: mocks.poolConnect, query: vi.fn() },
+  default: { connect: mocks.poolConnect, query: mocks.poolQuery },
 }))
 
 vi.mock("../shared/codes/code-generator.service", () => ({
@@ -21,6 +22,7 @@ vi.mock("../module/audit-logs/repository/audit-logs.repository", () => ({
 }))
 
 import { repoValidateReplenishmentProposal } from "../module/commande-fournisseur/repository/replenishment-proposal.repository"
+import { authoritativePdfQueueDbMock } from "./helpers/authoritative-pdf-queue-db-mock"
 
 const PROPOSAL_ID = "11111111-1111-4111-8111-111111111111"
 const ARTICLE_ID = "22222222-2222-4222-8222-222222222222"
@@ -48,6 +50,25 @@ let activeCoverageConflict = false
 
 function dispatch(sqlRaw: unknown, values?: unknown[]) {
   const sql = String(sqlRaw)
+  const authoritativePdf = authoritativePdfQueueDbMock(sql, values)
+  if (authoritativePdf) return authoritativePdf
+  if (sql.includes("FROM public.commande_fournisseur cf") && sql.includes("JOIN public.fournisseurs f")) {
+    return {
+      rows: [{
+        code: "BCF-2026-0002", statut: "BROUILLON", issued_at: "2026-08-23T12:00:00.000Z", devise: "EUR",
+        need_date: null, incoterm: null, payment_terms: null, transport_mode: null, public_comment: null,
+        delivery_address: null, supplier_code: "FOU-001", supplier_name: "Fournisseur test",
+        supplier_street: null, supplier_house_no: null, supplier_postal_code: null, supplier_city: null, supplier_country: null,
+        total_ht: "20", total_remise: "0", total_tva: "4", freight_ht: "0", total_ttc: "24",
+      }], rowCount: 1,
+    }
+  }
+  if (sql.includes("SELECT position::int") && sql.includes("FROM public.commande_fournisseur_ligne") && sql.includes("statut_ligne = 'ACTIVE'")) {
+    return { rows: [{ position: 1, reference: null, designation: "Article agrégé", unit: "u", quantity: "10", unit_price_ht: "2", discount_pct: "0", vat_pct: "20", net_ht: "20", need_date: null }], rowCount: 1 }
+  }
+  if (sql.includes("SELECT updated_at::text AS source_revision") && sql.includes("public.commande_fournisseur")) {
+    return { rows: [{ source_revision: "2026-08-23T12:00:00.000Z" }], rowCount: 1 }
+  }
   if (sql.includes("FROM public.replenishment_proposal_idempotence")) return { rows: [], rowCount: 0 }
   if (sql.includes("FROM public.replenishment_proposals p") && sql.includes("FOR UPDATE OF p")) {
     return {
@@ -144,6 +165,7 @@ beforeEach(() => {
   mocks.generateCode.mockResolvedValue("BCF-2026-0002")
   mocks.insertAudit.mockResolvedValue(undefined)
   mocks.clientQuery.mockImplementation(dispatch)
+  mocks.poolQuery.mockResolvedValue({ rows: [{ party: { company_name: "CERP Test" } }], rowCount: 1 })
 })
 
 describe("repoValidateReplenishmentProposal — remplacement après annulation", () => {
@@ -180,5 +202,13 @@ describe("repoValidateReplenishmentProposal — remplacement après annulation",
     )
     expect(mocks.clientQuery).toHaveBeenCalledWith("COMMIT")
     expect(mocks.clientQuery).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO public.authoritative_pdf_archives"),
+      expect.any(Array),
+    )
+    expect(mocks.clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO public.authoritative_pdf_archive_outbox"),
+      expect.any(Array),
+    )
   })
 })

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -34,6 +34,11 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }));
 
+vi.mock("../shared/authoritative-documents/authoritative-document.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../shared/authoritative-documents/authoritative-document.service")>()),
+  queueCreationPdfArchive: vi.fn(),
+}));
+
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authenticateToken: (req: { user?: { id: number; role: string } }, _res: unknown, next: () => void) => {
     req.user = { id: 1, role: mocks.currentRole.value };
@@ -58,12 +63,14 @@ vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
 }));
 
 import app from "../config/app";
+import { queueCreationPdfArchive } from "../shared/authoritative-documents/authoritative-document.service";
 
 beforeEach(() => {
   mocks.poolQuery.mockReset();
   mocks.poolConnect.mockReset();
   mocks.clientQuery.mockReset();
   mocks.clientRelease.mockReset();
+  vi.mocked(queueCreationPdfArchive).mockReset();
   mocks.currentRole.value = "Administrateur Systeme et Reseau";
 
   mocks.poolConnect.mockResolvedValue({
@@ -159,7 +166,7 @@ describe("/api/v1/stock", () => {
       }
     if (q.includes("public.fn_next_issued_code_value")) return { rows: [{ v: "1" }] };
       if (q.includes("INSERT INTO public.articles")) {
-        return { rows: [{ id: "11111111-1111-1111-1111-111111111111" }] };
+        return { rows: [{ id: "11111111-1111-1111-1111-111111111111", updated_at: "2026-03-13T00:00:00.000Z" }] };
       }
       if (q.includes("INSERT INTO public.article_category_link")) {
         return { rows: [] };
@@ -173,6 +180,7 @@ describe("/api/v1/stock", () => {
       if (q.includes("INSERT INTO public.articles_fabrique")) {
         return { rows: [] };
       }
+      if (q.includes("SELECT updated_at::text AS updated_at FROM public.articles")) return { rows: [{ updated_at: "2026-03-13T00:00:00.000Z" }] };
       return { rows: [] };
     });
 
@@ -243,6 +251,20 @@ describe("/api/v1/stock", () => {
         String(call[0]).includes("FROM public.affaire") && String(call[0]).includes("type_affaire = 'projet'")
       )
     ).toBe(false);
+    expect(queueCreationPdfArchive).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        entityType: "stock-article",
+        entityId: "11111111-1111-1111-1111-111111111111",
+        documentKind: "STOCK_ARTICLE_CREATION_SNAPSHOT",
+        documentVersion: 1,
+        idempotencyKey: "stock-article:11111111-1111-1111-1111-111111111111:creation:v1",
+        sourceRevision: "2026-03-13T00:00:00.000Z",
+      })
+    );
+    const snapshot = vi.mocked(queueCreationPdfArchive).mock.calls[0]?.[1]?.sourceSnapshot as { type?: string; sections?: unknown[] };
+    expect(snapshot).toMatchObject({ type: "INTERNAL_CREATION_SNAPSHOT" });
+    expect(snapshot.sections).toHaveLength(1);
   });
 
   it("PATCH /api/v1/stock/articles/:id refuses to relink an existing fabricated article", async () => {
@@ -504,7 +526,7 @@ describe("/api/v1/stock", () => {
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
     if (q.includes("public.fn_next_issued_code_value")) return { rows: [{ v: "1" }] };
       if (q.includes("INSERT INTO public.articles (") || q.includes("INSERT INTO public.articles\n")) {
-        return { rows: [{ id: "11111111-1111-1111-1111-111111111111" }] };
+        return { rows: [{ id: "11111111-1111-1111-1111-111111111111", updated_at: "2026-03-13T00:00:00.000Z" }] };
       }
       if (q.includes("INSERT INTO public.article_category_link")) {
         return { rows: [] };
@@ -520,6 +542,7 @@ describe("/api/v1/stock", () => {
       if (q.includes("FROM public.stock_nuances")) return { rows: [{ code: "ALU" }] };
       if (q.includes("FROM public.stock_etats")) return { rows: [{ code: "ETAT" }] };
       if (q.includes("FROM public.stock_sous_etats")) return { rows: [] };
+      if (q.includes("SELECT updated_at::text AS updated_at FROM public.articles")) return { rows: [{ updated_at: "2026-03-13T00:00:00.000Z" }] };
       return { rows: [] };
     });
 

--- a/src/__tests__/surface-finish-210.routes.test.ts
+++ b/src/__tests__/surface-finish-210.routes.test.ts
@@ -58,6 +58,7 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
 }));
 
 import app from "../config/app";
+import { authoritativePdfQueueDbMock } from "./helpers/authoritative-pdf-queue-db-mock";
 import { withRealtimeOutboxDbMock } from "./helpers/realtime-outbox-db-mock";
 
 const FIN_BASE = "/api/v1/finitions";
@@ -184,10 +185,12 @@ type Scenario = {
 };
 
 function installQueryRouter(scenario: Scenario = {}) {
-  const handler = async (sql: string): Promise<{ rows: Row[]; rowCount: number }> => {
+  const handler = async (sql: string, params?: unknown[]): Promise<{ rows: Row[]; rowCount: number }> => {
     sqlLog.push(sql);
     const empty = { rows: [] as Row[], rowCount: 0 };
     const one = (row: Row) => ({ rows: [row], rowCount: 1 });
+    const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
+    if (authoritativePdf) return authoritativePdf;
 
     if (/surface_finish_command_receipts/.test(sql) && /^\s*SELECT/i.test(sql)) {
       return scenario.receipt ? one(scenario.receipt as Row) : empty;
@@ -221,6 +224,9 @@ function installQueryRouter(scenario: Scenario = {}) {
     }
     if (/fn_next_issued_code_value/.test(sql)) return one({ v: "123" });
     if (/FROM public\.units/.test(sql)) return one({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", code: "u" });
+    if (/SELECT updated_at::text AS updated_at FROM public\.articles WHERE id = \$1::uuid FOR SHARE/.test(sql)) {
+      return one({ updated_at: "2026-07-28T08:05:00.000Z" });
+    }
     if (/INSERT INTO public\.articles\b/.test(sql)) return one({ id: ARTICLE_ID });
     if (/INSERT INTO erp_audit_logs/.test(sql)) {
       return one({ id: "audit-1", created_at: "2026-07-28T08:05:00.000Z" });
@@ -235,8 +241,8 @@ function installQueryRouter(scenario: Scenario = {}) {
     return empty;
   };
 
-  mocks.poolQuery.mockImplementation((sql: string) => handler(sql));
-  mocks.clientQuery.mockImplementation((sql: string) => handler(sql));
+  mocks.poolQuery.mockImplementation((sql: string, params?: unknown[]) => handler(sql, params));
+  mocks.clientQuery.mockImplementation((sql: string, params?: unknown[]) => handler(sql, params));
   mocks.poolConnect.mockResolvedValue({
     query: withRealtimeOutboxDbMock(mocks.clientQuery),
     release: mocks.clientRelease,
@@ -414,6 +420,8 @@ describe("#164 création d'un article de traitement depuis Stock", () => {
     expect(sqlLog.some((sql) => /INSERT INTO public\.pieces_techniques_achats/.test(sql))).toBe(false);
     expect(sqlLog.some((sql) => /gamme_operation_finitions/.test(sql))).toBe(false);
     expect(sqlLog.some((sql) => /stock_movement/i.test(sql))).toBe(false);
+    expect(sqlLog.some((sql) => /INSERT INTO public\.authoritative_pdf_archives/.test(sql))).toBe(true);
+    expect(sqlLog.some((sql) => /INSERT INTO public\.authoritative_pdf_archive_outbox/.test(sql))).toBe(true);
   });
 
   it("refuse la confirmation Stock à un rôle qui n'a que le droit de prévisualiser", async () => {
@@ -663,6 +671,8 @@ describe("#210 confirmation", () => {
     expect(sqlLog.filter((sql) => /^\s*BEGIN\s*$/i.test(sql))).toHaveLength(1);
     expect(sqlLog.filter((sql) => /^\s*COMMIT\s*$/i.test(sql))).toHaveLength(1);
     expect(sqlLog.some((sql) => /^\s*ROLLBACK\s*$/i.test(sql))).toBe(false);
+    expect(sqlLog.some((sql) => /INSERT INTO public\.authoritative_pdf_archives/.test(sql))).toBe(true);
+    expect(sqlLog.some((sql) => /INSERT INTO public\.authoritative_pdf_archive_outbox/.test(sql))).toBe(true);
   });
 
   it("lie la ligne d'achat à l'opération par clé étrangère, jamais par la seule phase", async () => {

--- a/src/__tests__/technical-piece-creation-pdf.contract.test.ts
+++ b/src/__tests__/technical-piece-creation-pdf.contract.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { buildTechnicalPieceCreationSnapshotInput } from "../shared/authoritative-documents/technical-piece-creation-snapshot";
+import { buildStockArticleCreationSnapshotInput } from "../shared/authoritative-documents/stock-article-creation-snapshot";
+
+const piecesSource = fs.readFileSync(path.join(__dirname, "../module/pieces-techniques/repository/pieces-techniques.repository.ts"), "utf8");
+const commandesSource = fs.readFileSync(path.join(__dirname, "../module/commande-client/repository/commande-client.repository.ts"), "utf8");
+const stockSource = fs.readFileSync(path.join(__dirname, "../module/stock/repository/stock.repository.ts"), "utf8");
+
+describe("technical root creation PDF contracts", () => {
+  it("uses stable, safe, server-only creation inputs", () => {
+    const technical = buildTechnicalPieceCreationSnapshotInput({
+      id: "11111111-1111-1111-1111-111111111111", code: "PT/ 01", designation: "Piece", clientId: "client-1", clientName: null,
+      status: "DRAFT", sourceRevision: "2026-08-23T12:00:00.000Z", actorUserId: 7, articleId: null, familyId: null,
+    });
+    const article = buildStockArticleCreationSnapshotInput({
+      id: "22222222-2222-2222-2222-222222222222", code: "ART/ 01", designation: "Article", articleType: "PURCHASED",
+      articleCategory: "achat", familyCode: "ACH", unit: "u", status: "VALIDE", stockManaged: true, lotTracking: false,
+      isActive: true, sourceRevision: "2026-08-23T12:00:00.000Z", actorUserId: 7,
+    });
+    expect(technical).toMatchObject({ entityType: "piece-technique", documentKind: "TECHNICAL_PIECE_CREATION_SNAPSHOT", idempotencyKey: "piece-technique:11111111-1111-1111-1111-111111111111:creation:v1" });
+    expect(article).toMatchObject({ entityType: "stock-article", documentKind: "STOCK_ARTICLE_CREATION_SNAPSHOT", idempotencyKey: "stock-article:22222222-2222-2222-2222-222222222222:creation:v1" });
+    expect(technical.originalName).toBe("piece-technique-PT-01-creation.pdf");
+    expect(article.originalName).toBe("article-ART-01-creation.pdf");
+    expect(JSON.stringify(technical.sourceSnapshot)).not.toMatch(/upload|path|file/i);
+  });
+
+  it("queues a duplicated technical root only after its copied aggregate and before commit", () => {
+    const duplicate = piecesSource.slice(piecesSource.indexOf("export async function repoDuplicatePieceTechnique"));
+    const history = duplicate.indexOf("INSERT INTO pieces_techniques_historique");
+    const queue = duplicate.indexOf("await queueCreationPdfArchive(client, buildTechnicalPieceCreationSnapshotInput");
+    const commit = duplicate.indexOf('await client.query("COMMIT")');
+    expect(history).toBeGreaterThan(0);
+    expect(queue).toBeGreaterThan(history);
+    expect(queue).toBeLessThan(commit);
+    expect(duplicate).toContain("copiedFromCode: o.code_piece");
+  });
+
+  it("queues preparatory promotions only for fresh root rows and excludes OLD recovery imports", () => {
+    const technical = commandesSource.slice(commandesSource.indexOf("async function ensureOfficialPieceFromPreparatory"), commandesSource.indexOf("async function ensureOfficialArticleFromPreparatory"));
+    const article = commandesSource.slice(commandesSource.indexOf("async function ensureOfficialArticleFromPreparatory"), commandesSource.indexOf("let commandeToAffaireHasRoleColumnCache"));
+    expect(technical).toContain("RETURNING id::text AS id, updated_at::text AS updated_at");
+    expect(technical).toContain("buildTechnicalPieceCreationSnapshotInput");
+    expect(technical).toContain("preparatory-piece-promotion");
+    expect(article).toContain("buildStockArticleCreationSnapshotInput");
+    expect(article).toContain("preparatory-article-promotion");
+    expect(article).toContain("if (createdArticle)");
+    expect(stockSource).toContain("OLD recovery/import scaffolding is intentionally excluded from creation-PDF");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { startExpiredLockMaintenance } from "./module/locks/services/locks.servi
 import { startReminderMaintenance } from "./module/facturation/services/reminder-job.service";
 import { startElectronicInvoiceMaintenance } from "./module/facturation/electronic-invoicing/electronic-invoice.service";
 import { startWebhookDeliveryMaintenance } from "./module/integrations/webhooks/webhook.service";
+import { startAuthoritativePdfArchiveMaintenance } from "./shared/authoritative-documents/authoritative-document.worker";
 import { createApplicationShutdown } from "./shared/runtime/application-shutdown";
 import { preflightSecureUploadStorageRoots } from "./shared/uploads/secure-upload";
 import { getUploadScannerStartupConfiguration } from "./shared/uploads/upload-scanner";
@@ -50,6 +51,7 @@ async function start(): Promise<void> {
   const stopReminderMaintenance = startReminderMaintenance();
   const stopElectronicInvoiceMaintenance = startElectronicInvoiceMaintenance();
   const stopWebhookDeliveryMaintenance = startWebhookDeliveryMaintenance();
+  const stopAuthoritativePdfArchiveMaintenance = startAuthoritativePdfArchiveMaintenance();
 
   initSocketServer(httpServer);
   const stopExpiredLockMaintenance = startExpiredLockMaintenance();
@@ -78,6 +80,7 @@ async function start(): Promise<void> {
       stopReminderMaintenance,
       stopElectronicInvoiceMaintenance,
       stopWebhookDeliveryMaintenance,
+      stopAuthoritativePdfArchiveMaintenance,
     ],
     closeDatabase: () => pool.end(),
     log: (type, fields) => logger.error(type, fields),

--- a/src/module/affaire/controllers/affaire.controller.ts
+++ b/src/module/affaire/controllers/affaire.controller.ts
@@ -1,6 +1,7 @@
 import type { Request, RequestHandler } from "express";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import { createCreationSnapshotHandlers } from "../../../shared/authoritative-documents/creation-snapshot-http";
 import {
   affaireIdParamsSchema,
   archiveAffaireBodySchema,
@@ -54,6 +55,21 @@ function buildAuditContext(req: Request): AuditContext {
     client_session_id: clientSessionId,
   };
 }
+
+const affaireCreationSnapshotHandlers = createCreationSnapshotHandlers({
+  entityType: "affaire",
+  documentKind: "AFFAIR_CREATION_SNAPSHOT",
+  parseEntityId: (req) => String(affaireIdParamsSchema.parse(req.params).id),
+  // The route preserves requireAffaireCapability("read"); this root lookup then
+  // keeps missing/out-of-scope affairs from exposing archive state or bytes.
+  canReadEntity: async (id) => Boolean(await svcGetAffaire(Number(id), "")),
+  baseUrl: (id) => `/affaires/${encodeURIComponent(id)}/creation-snapshot`,
+});
+
+export const getAffaireCreationSnapshot = affaireCreationSnapshotHandlers.metadata;
+export const previewAffaireCreationSnapshot = affaireCreationSnapshotHandlers.preview;
+export const downloadAffaireCreationSnapshot = affaireCreationSnapshotHandlers.download;
+export const printAffaireCreationSnapshot = affaireCreationSnapshotHandlers.printIntent;
 
 export const listAffaires: RequestHandler = async (req, res, next) => {
   try {

--- a/src/module/affaire/repository/affaire.repository.ts
+++ b/src/module/affaire/repository/affaire.repository.ts
@@ -3,6 +3,9 @@ import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
 import { generateAffaireCode } from "../../../shared/codes/code-generator.service";
+import { authoritativePdfFilename } from "../../../shared/authoritative-documents/authoritative-document.filename";
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
+import { buildInternalCreationSnapshot } from "../../../shared/authoritative-documents/internal-creation-snapshot";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import {
   classifyTransition,
@@ -1222,10 +1225,10 @@ export async function repoCreateAffaire(input: CreateAffaireBodyDTO, audit?: Aud
         NULL,
         $8
       )
-      RETURNING id::text AS id, updated_at::text AS updated_at
+      RETURNING id::text AS id, updated_at::text AS updated_at, date_ouverture::text AS date_ouverture
     `;
 
-    const ins = await client.query<{ id: string; updated_at: string }>(insertSql, [
+    const ins = await client.query<{ id: string; updated_at: string; date_ouverture: string }>(insertSql, [
       id,
       reference,
       input.client_id ?? null,
@@ -1254,6 +1257,56 @@ export async function repoCreateAffaire(input: CreateAffaireBodyDTO, audit?: Aud
         },
       });
     }
+
+    if (!updatedAt) throw new Error("AFFAIR_CREATION_SOURCE_REVISION_MISSING");
+    const commercial = await client.query<{
+      client_name: string | null;
+      commande_numero: string | null;
+      commande_total_ht: number | null;
+      commande_total_ttc: number | null;
+    }>(
+      `SELECT c.company_name AS client_name, cc.numero AS commande_numero,
+              cc.total_ht::float8 AS commande_total_ht, cc.total_ttc::float8 AS commande_total_ttc
+         FROM public.affaire a
+         LEFT JOIN public.clients c ON c.client_id = a.client_id
+         LEFT JOIN public.commande_client cc ON cc.id = a.commande_id
+        WHERE a.id = $1`,
+      [affaireId]
+    );
+    const commercialRow = commercial.rows[0];
+    await queueCreationPdfArchive(client, {
+      entityType: "affaire",
+      entityId: String(affaireId),
+      documentKind: "AFFAIR_CREATION_SNAPSHOT",
+      documentVersion: 1,
+      renderVersion: "internal-creation-snapshot-v1",
+      idempotencyKey: `affaire:${affaireId}:creation:v1`,
+      title: `Instantané de création — affaire ${reference}`,
+      originalName: authoritativePdfFilename(["affaire", reference, "creation"]),
+      sourceRevision: updatedAt,
+      sourceSnapshot: buildInternalCreationSnapshot({
+        entityLabel: "Affaire",
+        reference,
+        summary: [
+          { label: "Référence", value: reference },
+          { label: "Client", value: commercialRow?.client_name ?? input.client_id ?? null },
+          { label: "Commande client", value: commercialRow?.commande_numero ?? input.commande_id ?? null },
+          { label: "Statut initial", value: "OUVERTE" },
+        ],
+        sections: [{
+          title: "Cadre commercial initial",
+          rows: [
+            { label: "Type", value: typeAffaire },
+            { label: "Date d'ouverture", value: ins.rows[0]?.date_ouverture ?? input.date_ouverture ?? null },
+            { label: "Date de clôture", value: null },
+            { label: "Devis lié", value: input.devis_id ?? null },
+            { label: "Montant HT commande", value: commercialRow?.commande_total_ht ?? null },
+            { label: "Montant TTC commande", value: commercialRow?.commande_total_ttc ?? null },
+          ],
+        }],
+      }),
+      actorUserId: audit?.user_id ?? null,
+    });
 
     await client.query("COMMIT");
     return { id: affaireId, reference, updated_at: updatedAt };

--- a/src/module/affaire/routes/affaire.routes.ts
+++ b/src/module/affaire/routes/affaire.routes.ts
@@ -6,11 +6,15 @@ import { roleHasAffaireCapability, type AffaireCapability } from "../domain/affa
 import {
   archiveAffaire,
   createAffaire,
+  downloadAffaireCreationSnapshot,
   getAffaire,
+  getAffaireCreationSnapshot,
   getAffaireOperations,
   listAffaires,
   listAffairesCommandCenter,
   previewAffaire,
+  previewAffaireCreationSnapshot,
+  printAffaireCreationSnapshot,
   transitionAffaire,
   updateAffaire,
 } from "../controllers/affaire.controller";
@@ -55,6 +59,12 @@ router.use(authenticateToken);
 router.get("/command-center", requireAffaireCapability("read"), listAffairesCommandCenter);
 router.get("/", requireAffaireCapability("read"), listAffaires);
 router.get("/:id/operations", requireAffaireCapability("read"), getAffaireOperations);
+// Immutable internal creation snapshot. It is discoverable only through the
+// normal affair read capability and cannot be issued from HTTP.
+router.get("/:id/creation-snapshot", requireAffaireCapability("read"), getAffaireCreationSnapshot);
+router.get("/:id/creation-snapshot/:documentId/preview", requireAffaireCapability("read"), previewAffaireCreationSnapshot);
+router.get("/:id/creation-snapshot/:documentId/download", requireAffaireCapability("read"), downloadAffaireCreationSnapshot);
+router.post("/:id/creation-snapshot/:documentId/print-intents", requireAffaireCapability("read"), printAffaireCreationSnapshot);
 router.get("/:id", requireAffaireCapability("read"), getAffaire);
 
 // Écritures

--- a/src/module/client/controllers/client.controller.ts
+++ b/src/module/client/controllers/client.controller.ts
@@ -3,6 +3,7 @@ import { Request, RequestHandler } from "express";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import { stripQueryFromUrl } from "../../../utils/logPath";
+import { createCreationSnapshotHandlers } from "../../../shared/authoritative-documents/creation-snapshot-http";
 
 import * as clientService from "../services/client.service"; // ✅ namespace import
 import { svcGetClientById, svcListClientAddresses } from "../services/clients.read.service";
@@ -87,6 +88,21 @@ function routeParam(req: Request, name: string): string {
   if (typeof value === "string" && value.length > 0) return value;
   throw new HttpError(400, "INVALID_ROUTE_PARAM", `${name} must be a string`);
 }
+
+const clientCreationSnapshotHandlers = createCreationSnapshotHandlers({
+  entityType: "client",
+  documentKind: "CLIENT_CREATION_SNAPSHOT",
+  parseEntityId: (req) => routeParam(req, "id"),
+  // Keep the existing client read policy (including its active record semantics)
+  // ahead of the archive lookup; finance fields are never used by this endpoint.
+  canReadEntity: async (id) => Boolean(await svcGetClientById(id, { includeSensitiveFinance: false })),
+  baseUrl: (id) => `/clients/${encodeURIComponent(id)}/creation-snapshot`,
+});
+
+export const getClientCreationSnapshot = clientCreationSnapshotHandlers.metadata;
+export const previewClientCreationSnapshot = clientCreationSnapshotHandlers.preview;
+export const downloadClientCreationSnapshot = clientCreationSnapshotHandlers.download;
+export const printClientCreationSnapshot = clientCreationSnapshotHandlers.printIntent;
 
 /**
  * Le code visible est généré côté serveur et immuable (ADR-0013). Toute valeur

--- a/src/module/client/repository/client.repository.ts
+++ b/src/module/client/repository/client.repository.ts
@@ -9,6 +9,9 @@ import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-lo
 import { generateClientCode } from "../../../shared/codes/code-generator.service";
 import type { CreateClientContactInput, ClientContactRow } from "../services/client.service";
 import type { DuplicateCheckDTO } from "../validators/client.validators";
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
+import { authoritativePdfFilename } from "../../../shared/authoritative-documents/authoritative-document.filename";
+import { buildInternalCreationSnapshot } from "../../../shared/authoritative-documents/internal-creation-snapshot";
 
 export type AuditContext = {
   user_id: number;
@@ -441,6 +444,31 @@ export async function repoCreateClient(
         contacts_count: Array.isArray(dto.contacts) ? dto.contacts.length : 0,
         payment_modes_count: Array.isArray(dto.payment_mode_ids) ? dto.payment_mode_ids.length : 0,
       },
+    });
+
+    // The creation receipt is built from the aggregate just written in this
+    // transaction. Bank credentials intentionally never enter this snapshot.
+    const revision = await db.query<{ updated_at: string }>(
+      `SELECT updated_at::text AS updated_at FROM clients WHERE client_id = $1 FOR UPDATE`, [clientId]
+    );
+    const sourceRevision = revision.rows[0]?.updated_at;
+    if (!sourceRevision) throw new Error("CLIENT_CREATION_SNAPSHOT_REVISION_MISSING");
+    await queueCreationPdfArchive(db, {
+      entityType: "client", entityId: clientId, documentKind: "CLIENT_CREATION_SNAPSHOT", documentVersion: 1,
+      renderVersion: "internal-creation-snapshot-v1", idempotencyKey: `client:${clientId}:creation-snapshot:v1`,
+      title: `Création fiche client ${clientCode}`, originalName: authoritativePdfFilename(["Client", clientCode, "creation"]), sourceRevision,
+      sourceSnapshot: buildInternalCreationSnapshot({
+        entityLabel: "Fiche client", reference: clientCode,
+        summary: [{ label: "Client", value: dto.company_name }, { label: "Code", value: clientCode }, { label: "Statut", value: dto.status }, { label: "Créé par", value: String(audit.user_id) }],
+        sections: [
+          { title: "Coordonnées", rows: [{ label: "Email", value: dto.email }, { label: "Téléphone", value: dto.phone }, { label: "SIRET", value: dto.siret }, { label: "TVA", value: dto.vat_number }, { label: "Site web", value: dto.website_url }] },
+          { title: "Adresses", table: { columns: [{ key: "type", label: "Type" }, { key: "adresse", label: "Adresse" }], rows: [
+            { type: "Facturation", adresse: [dto.bill_address.house_number, dto.bill_address.street, dto.bill_address.postal_code, dto.bill_address.city, dto.bill_address.country].filter(Boolean).join(", ") },
+            { type: "Livraison", adresse: [dto.delivery_address.house_number, dto.delivery_address.street, dto.delivery_address.postal_code, dto.delivery_address.city, dto.delivery_address.country].filter(Boolean).join(", ") },
+          ] } },
+          { title: "Contacts créés", table: { columns: [{ key: "nom", label: "Nom" }, { key: "email", label: "Email" }, { key: "role", label: "Rôle" }], rows: [dto.primary_contact, ...(dto.contacts ?? [])].filter(Boolean).map((contact) => ({ nom: [contact!.first_name, contact!.last_name].filter(Boolean).join(" "), email: contact!.email ?? null, role: contact!.role ?? null })) } },
+        ],
+      }), actorUserId: audit.user_id,
     });
 
     await db.query('COMMIT');

--- a/src/module/client/routes/client.routes.ts
+++ b/src/module/client/routes/client.routes.ts
@@ -5,14 +5,18 @@ import {
   archiveClient,
   checkClientDuplicates,
   deleteClient,
+  downloadClientCreationSnapshot,
   getClientById,
+  getClientCreationSnapshot,
   listClientAddresses,
   listClientContacts,
   listClients,
   patchClient,
   patchClientPrimaryContact,
+  previewClientCreationSnapshot,
   postClient,
   postClientContact,
+  printClientCreationSnapshot,
 } from "../controllers/client.controller";
 import { listClientsAnalytics } from "../controllers/clients.analytics.controller"
 import { CLIENT_WRITE_ROLES } from "../client.permissions";
@@ -35,6 +39,11 @@ router.post("/duplicate-check", checkClientDuplicates);
 router.get("/:clientId/contacts", listClientContacts);
 router.post("/:clientId/contacts", requireClientWriteRole, postClientContact);
 router.get("/:clientId/addresses", listClientAddresses);
+// Immutable internal creation snapshot; no issue/reissue surface is exposed here.
+router.get("/:id/creation-snapshot", getClientCreationSnapshot);
+router.get("/:id/creation-snapshot/:documentId/preview", previewClientCreationSnapshot);
+router.get("/:id/creation-snapshot/:documentId/download", downloadClientCreationSnapshot);
+router.post("/:id/creation-snapshot/:documentId/print-intents", printClientCreationSnapshot);
 router.get("/:id", getClientById);
 
 // 🆕 upload du logo client

--- a/src/module/commande-client/controllers/commande-ar.controller.ts
+++ b/src/module/commande-client/controllers/commande-ar.controller.ts
@@ -2,8 +2,8 @@ import type { Request, RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
 import { asyncHandler } from "../../../utils/asyncHandler";
-import { generateCommandeArSchema, sendCommandeArSchema } from "../validators/commande-ar.validators";
-import { svcGenerateCommandeAr, svcSendCommandeAr } from "../services/commande-ar.service";
+import { acknowledgementDocumentParamsSchema, createAcknowledgementSchema, generateCommandeArSchema, sendAcknowledgementSchema, sendCommandeArSchema } from "../validators/commande-ar.validators";
+import { svcCreateCommandeArOfficial, svcGenerateCommandeAr, svcGetCommandeArOfficialDocument, svcListCommandeArOfficialDocuments, svcReadCommandeArOfficialDocument, svcRecordCommandeArOfficialPrint, svcSendCommandeAr, svcSendCommandeArOfficial } from "../services/commande-ar.service";
 
 function getUserId(req: Request): number {
   const userId = typeof req.user?.id === "number" ? req.user.id : null;
@@ -29,5 +29,53 @@ export const sendCommandeAr: RequestHandler = asyncHandler(async (req, res) => {
     user_role: req.user?.role,
     body: parsed.body,
   });
+  res.status(200).json(out);
+});
+
+/** Collection POST uses the same checkpoint authorization as the legacy AR generator. */
+export const createAcknowledgement: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = createAcknowledgementSchema.parse({ params: req.params, body: req.body });
+  const key = req.headers["idempotency-key"];
+  if (typeof key !== "string" || key.trim().length < 8 || key.trim().length > 120) {
+    throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "Une clé d'idempotence est requise.");
+  }
+  const out = await svcCreateCommandeArOfficial({ commande_id: Number(parsed.params.id), user_id: getUserId(req), user_role: req.user?.role, source_revision: parsed.body.source_revision, reissue_reason: parsed.body.reissue_reason, idempotency_key: key.trim() });
+  res.status(201).json(out);
+});
+
+export const listAcknowledgements: RequestHandler = asyncHandler(async (req, res) => {
+  const { id } = generateCommandeArSchema.parse({ params: req.params }).params;
+  res.json(await svcListCommandeArOfficialDocuments(Number(id)));
+});
+
+export const getAcknowledgement: RequestHandler = asyncHandler(async (req, res) => {
+  const { id, documentId } = acknowledgementDocumentParamsSchema.parse(req.params);
+  const out = await svcGetCommandeArOfficialDocument(Number(id), documentId);
+  if (!out) throw new HttpError(404, "OFFICIAL_DOCUMENT_NOT_FOUND", "Document officiel introuvable.");
+  res.json(out);
+});
+
+function sendAcknowledgementPdf(disposition: "inline" | "attachment"): RequestHandler {
+  return asyncHandler(async (req, res) => {
+    const { id, documentId } = acknowledgementDocumentParamsSchema.parse(req.params);
+    const file = await svcReadCommandeArOfficialDocument(Number(id), documentId, getUserId(req), disposition === "inline" ? "AUTHORITATIVE_PDF_PREVIEWED" : "AUTHORITATIVE_PDF_DOWNLOADED");
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Length", String(file.bytes.byteLength));
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Cache-Control", "private, no-store");
+    res.setHeader("Content-Disposition", `${disposition}; filename="${file.filename}"`);
+    res.send(file.bytes);
+  });
+}
+export const previewAcknowledgement = sendAcknowledgementPdf("inline");
+export const downloadAcknowledgement = sendAcknowledgementPdf("attachment");
+export const printAcknowledgement: RequestHandler = asyncHandler(async (req, res) => {
+  const { id, documentId } = acknowledgementDocumentParamsSchema.parse(req.params);
+  await svcRecordCommandeArOfficialPrint(Number(id), documentId, getUserId(req));
+  res.status(204).send();
+});
+export const sendAcknowledgement: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = sendAcknowledgementSchema.parse({ params: req.params, body: req.body });
+  const out = await svcSendCommandeArOfficial({ commande_id: Number(parsed.params.id), archive_id: parsed.params.documentId, user_id: getUserId(req), user_role: req.user?.role, body: parsed.body });
   res.status(200).json(out);
 });

--- a/src/module/commande-client/controllers/commande-client.controller.ts
+++ b/src/module/commande-client/controllers/commande-client.controller.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { HttpError } from "../../../utils/httpError";
 import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
+import { createCreationSnapshotHandlers } from "../../../shared/authoritative-documents/creation-snapshot-http";
 import {
   createCommandeSVC,
   createCadreReleaseSVC,
@@ -99,6 +100,21 @@ function routeParam(req: Request, name: string): string {
   if (typeof value === "string" && value.length > 0) return value;
   throw new HttpError(400, "INVALID_ROUTE_PARAM", `${name} must be a string`);
 }
+
+const commandeCreationSnapshotHandlers = createCreationSnapshotHandlers({
+  entityType: "commande-client",
+  documentKind: "CUSTOMER_ORDER_CREATION_SNAPSHOT",
+  parseEntityId: (req) => routeParam(req, "id"),
+  // Route-level acknowledgement export RBAC is retained; this root lookup keeps a
+  // missing/out-of-scope order from becoming an archive metadata oracle.
+  canReadEntity: async (id) => Boolean(await getCommandeSVC(id, new Set())),
+  baseUrl: (id) => `/commandes/${encodeURIComponent(id)}/creation-snapshot`,
+});
+
+export const getCommandeCreationSnapshot = commandeCreationSnapshotHandlers.metadata;
+export const previewCommandeCreationSnapshot = commandeCreationSnapshotHandlers.preview;
+export const downloadCommandeCreationSnapshot = commandeCreationSnapshotHandlers.download;
+export const printCommandeCreationSnapshot = commandeCreationSnapshotHandlers.printIntent;
 
 function buildAudit(req: Request) {
   return {

--- a/src/module/commande-client/repository/commande-ar.repository.test.ts
+++ b/src/module/commande-client/repository/commande-ar.repository.test.ts
@@ -74,8 +74,8 @@ describe("commande AR atomic send claim", () => {
   it("revalide sous verrou et refuse un brouillon rendu avant un envoi concurrent", async () => {
     mocks.clientQuery.mockImplementation(async (sql: unknown) => {
       const query = String(sql);
-      if (query.includes("SELECT id::int AS id FROM public.commande_client") && query.includes("FOR UPDATE")) {
-        return { rows: [{ id: 123 }] };
+      if (query.includes("FROM public.commande_client WHERE id = $1 FOR UPDATE")) {
+        return { rows: [{ id: 123, updated_at: "2026-08-04T08:00:00.000Z" }] };
       }
       if (query.includes("st.nouveau_statut AS raw_statut")) {
         return {

--- a/src/module/commande-client/repository/commande-ar.repository.ts
+++ b/src/module/commande-client/repository/commande-ar.repository.ts
@@ -11,6 +11,8 @@ import {
 import { withRealtimeOutboxTransaction } from "../../../shared/realtime/realtime-outbox-transaction";
 import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
+import { authoritativePdfFilename } from "../../../shared/authoritative-documents/authoritative-document.filename";
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
 import {
   repoApplyCommandeWorkflowMilestone,
   repoEnsureCommandeWorkflowCheckpoints,
@@ -26,6 +28,43 @@ import type {
 
 type DbQueryer = Pick<PoolClient, "query">;
 
+export async function repoListCommandeArIds(commandeId: number): Promise<string[]> {
+  const result = await pool.query<{ id: string }>(
+    `SELECT id::text AS id FROM public.commande_ar_log WHERE commande_id = $1::bigint ORDER BY generated_at DESC`, [commandeId]
+  );
+  return result.rows.map((row) => row.id);
+}
+
+/** Resolves an opaque archive id only when it belongs to this customer order. */
+export async function repoResolveCommandeArOfficialArchive(commandeId: number, archiveId: string): Promise<string | null> {
+  const result = await pool.query<{ ar_id: string }>(
+    `SELECT ar.id::text AS ar_id
+       FROM public.authoritative_pdf_archives a
+       JOIN public.commande_ar_log ar ON ar.id::text = a.source_snapshot->>'acknowledgement_id'
+      WHERE a.id = $1::uuid AND a.entity_type = 'commande-client' AND a.entity_id = $2::text
+        AND a.document_kind = 'CUSTOMER_ORDER_ACKNOWLEDGEMENT' AND ar.commande_id = $2::bigint`,
+    [archiveId, commandeId]
+  );
+  return result.rows[0]?.ar_id ?? null;
+}
+
+/** Finds the immutable order-scoped issuance corresponding to a legacy AR draft. */
+export async function repoFindCommandeArOfficialArchiveId(commandeId: number, arId: string): Promise<string | null> {
+  const result = await pool.query<{ id: string }>(
+    `SELECT a.id::text AS id
+       FROM public.authoritative_pdf_archives a
+       JOIN public.authoritative_pdf_archive_outbox o ON o.archive_id = a.id
+      WHERE a.entity_type = 'commande-client' AND a.entity_id = $1::text
+        AND a.document_kind = 'CUSTOMER_ORDER_ACKNOWLEDGEMENT'
+        AND a.source_snapshot->>'acknowledgement_id' = $2::text
+        AND o.status = 'ARCHIVED'
+      ORDER BY a.document_version DESC
+      LIMIT 1`,
+    [commandeId, arId]
+  );
+  return result.rows[0]?.id ?? null;
+}
+
 function toInt(value: unknown, label = "id"): number {
   if (typeof value === "number" && Number.isInteger(value)) return value;
   if (typeof value === "string" && /^\d+$/.test(value)) return Number.parseInt(value, 10);
@@ -37,6 +76,7 @@ type CommandeArHeader = {
   numero: string;
   statut: string | null;
   date_commande: string;
+  updated_at: string;
   commentaire: string | null;
   total_ht: number;
   total_ttc: number;
@@ -252,6 +292,7 @@ export async function repoLoadCommandeArGenerationData(tx: DbQueryer, commandeId
           ELSE COALESCE(st.nouveau_statut, 'BROUILLON')
         END AS statut,
         cc.date_commande::text AS date_commande,
+        cc.updated_at::text AS updated_at,
         cc.commentaire,
         cc.total_ht::float8 AS total_ht,
         cc.total_ttc::float8 AS total_ttc,
@@ -387,6 +428,12 @@ export async function repoCreateCommandeArDraft(params: {
   subject: string;
   body_text: string;
   recipient_suggestions: CommandeArRecipientSuggestion[];
+  /** Required by the production generator; optional only for legacy repository callers/tests. */
+  official_source_snapshot?: Record<string, unknown>;
+  official_request_idempotency_key?: string;
+  /** Expected `commande_client.updated_at` supplied by the authoritative collection POST. */
+  official_expected_source_revision?: string | null;
+  official_reissue_reason?: string | null;
 }): Promise<CommandeArStoredDraft> {
   const client = await pool.connect();
   const documentId = crypto.randomUUID();
@@ -395,8 +442,9 @@ export async function repoCreateCommandeArDraft(params: {
 
   try {
     return await withRealtimeOutboxTransaction(client, async (tx) => {
-    const exists = await tx.query<{ id: number }>(
-      `SELECT id::int AS id FROM public.commande_client WHERE id = $1 FOR UPDATE`,
+    const exists = await tx.query<{ id: number; updated_at: string }>(
+      `SELECT id::int AS id, updated_at::text AS updated_at
+         FROM public.commande_client WHERE id = $1 FOR UPDATE`,
       [params.commande_id]
     );
     if (!exists.rows[0]?.id) {
@@ -412,6 +460,45 @@ export async function repoCreateCommandeArDraft(params: {
       user_id: params.user_id,
       user_role: params.user_role,
     });
+
+    if (params.official_request_idempotency_key) {
+      const replay = await tx.query<{ ar_id: string | null }>(
+        `SELECT source_snapshot->>'acknowledgement_id' AS ar_id
+           FROM public.authoritative_pdf_archives
+          WHERE idempotency_key = $1 AND entity_type = 'commande-client' AND entity_id = $2::text
+            AND document_kind = 'CUSTOMER_ORDER_ACKNOWLEDGEMENT'`,
+        [params.official_request_idempotency_key, params.commande_id]
+      );
+      if (replay.rows[0]?.ar_id) {
+        const existing = await repoGetCommandeArDraft({ commande_id: params.commande_id, ar_id: replay.rows[0].ar_id, tx });
+        if (existing) return existing;
+        throw new HttpError(409, "ACKNOWLEDGEMENT_IDEMPOTENCY_CONFLICT", "La clé d'idempotence ne peut pas être rapprochée.");
+      }
+    }
+
+    // The renderer ran before this transaction so it would otherwise be able
+    // to freeze an order that changed just before the write lock was acquired.
+    // Check after the idempotency replay branch: a legitimate network retry
+    // must return the original immutable acknowledgement.
+    if (
+      params.official_expected_source_revision &&
+      exists.rows[0]?.updated_at !== params.official_expected_source_revision
+    ) {
+      throw new HttpError(409, "OFFICIAL_DOCUMENT_SOURCE_REVISION_CONFLICT", "La source du document a changé. Rechargez avant de générer.");
+    }
+
+    if (params.official_request_idempotency_key) {
+      const prior = await tx.query<{ count: string }>(
+        `SELECT count(*)::text AS count
+           FROM public.authoritative_pdf_archives
+          WHERE entity_type = 'commande-client' AND entity_id = $1::text
+            AND document_kind = 'CUSTOMER_ORDER_ACKNOWLEDGEMENT'`,
+        [params.commande_id]
+      );
+      if (Number(prior.rows[0]?.count ?? 0) > 0 && !params.official_reissue_reason?.trim()) {
+        throw new HttpError(422, "OFFICIAL_DOCUMENT_REISSUE_REASON_REQUIRED", "Un motif de réémission est requis.");
+      }
+    }
 
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, params.pdf_buffer);
@@ -465,6 +552,48 @@ export async function repoCreateCommandeArDraft(params: {
     const row = ins.rows[0];
     if (!row) throw new Error("Failed to create AR draft");
 
+    // The AR is an externally shared document. Queue an immutable source
+    // snapshot with this same business transaction; the worker files its
+    // official rendition in GED before any send path may attach it.
+    let archivedSourceRevision: string | null = null;
+    let documentVersion: number | null = null;
+    if (params.official_source_snapshot) {
+      // Updating the parent first makes the stored revision exactly the token
+      // returned by the order API after this acknowledgement is created.
+      const revisionResult = await tx.query<{ source_revision: string | null }>(
+        `UPDATE public.commande_client
+            SET updated_at = now()
+          WHERE id = $1
+        RETURNING updated_at::text AS source_revision`,
+        [params.commande_id]
+      );
+      archivedSourceRevision = revisionResult.rows[0]?.source_revision?.trim() ?? null;
+      if (!archivedSourceRevision) throw new HttpError(409, "OFFICIAL_DOCUMENT_SOURCE_REVISION_UNAVAILABLE", "La révision source du document est indisponible.");
+      const versionResult = await tx.query<{ count: string }>(
+        `SELECT count(*)::text AS count
+           FROM public.authoritative_pdf_archives
+          WHERE entity_type = 'commande-client' AND entity_id = $1::text
+            AND document_kind = 'CUSTOMER_ORDER_ACKNOWLEDGEMENT'`,
+        [params.commande_id]
+      );
+      documentVersion = Number(versionResult.rows[0]?.count ?? 0) + 1;
+      await queueCreationPdfArchive(tx, {
+        entityType: "commande-client",
+        entityId: String(params.commande_id),
+        documentKind: "CUSTOMER_ORDER_ACKNOWLEDGEMENT",
+        documentVersion,
+        renderVersion: "customer-ar-pdf-v1",
+        idempotencyKey: params.official_request_idempotency_key ?? `commande-client:${params.commande_id}:acknowledgement:${documentVersion}:${arId}`,
+        title: `Accusé de réception ${params.document_name.replace(/\.pdf$/i, "")}`,
+        originalName: authoritativePdfFilename(["AR", String(params.commande_id), `v${documentVersion}`]),
+        sourceRevision: archivedSourceRevision,
+        sourceSnapshot: { ...params.official_source_snapshot, acknowledgement_id: arId },
+        actorUserId: params.user_id,
+      });
+    } else {
+      await tx.query(`UPDATE public.commande_client SET updated_at = now() WHERE id = $1`, [params.commande_id]);
+    }
+
     await insertCommandeEvent(tx, {
       commande_id: params.commande_id,
       event_type: "AR_GENERATED",
@@ -473,11 +602,13 @@ export async function repoCreateCommandeArDraft(params: {
         document_id: documentId,
         document_name: params.document_name,
         subject: params.subject,
+        source_revision: archivedSourceRevision,
+        document_version: documentVersion,
+        reissue_reason: params.official_reissue_reason?.trim() ?? null,
       },
       user_id: params.user_id,
     });
 
-    await tx.query(`UPDATE public.commande_client SET updated_at = now() WHERE id = $1`, [params.commande_id]);
     await enqueueEntityChanged(
       tx,
       {

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -10,6 +10,11 @@ import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { generateAffaireCode, generateCommandeCode, generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
 import { transferSecureUploadToDestination } from "../../../shared/uploads/secure-upload";
 import { withUploadTransaction } from "../../../shared/uploads/upload-transaction";
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
+import { buildInternalCreationSnapshot } from "../../../shared/authoritative-documents/internal-creation-snapshot";
+import { buildStockArticleCreationSnapshotInput } from "../../../shared/authoritative-documents/stock-article-creation-snapshot";
+import { buildTechnicalPieceCreationSnapshotInput } from "../../../shared/authoritative-documents/technical-piece-creation-snapshot";
+import { authoritativePdfFilename } from "../../../shared/authoritative-documents/authoritative-document.filename";
 import {
   enqueueAppNotificationCreated,
   enqueueEntityChanged,
@@ -52,6 +57,7 @@ import {
   createRecursiveOrdresFabrication,
   type GeneratedOfRef,
 } from "../../production/domain/of-generation";
+import { queueRootOfCreationPdf } from "../../production/domain/of-creation-pdf";
 import { canActOnCommandeWorkflowCheckpoint, canLaunchInternalOrder } from "../domain/commande-client-rbac";
 import {
   assertCommandeFullyInvoiced,
@@ -510,6 +516,14 @@ async function ensureOfficialPieceFromPreparatory(
   const dossier = source.dossier_technique_piece_devis;
   if (!dossier) return null;
 
+  // A promotion row that does not yet exist cannot be protected by FOR UPDATE.
+  // Serialize a same-dossier replay before allocating a root id, so retries and
+  // concurrent requests cannot create two roots (and two GED snapshots).
+  await db.query(
+    "SELECT pg_advisory_xact_lock(hashtext('preparatory-piece-promotion'), hashtext($1))",
+    [dossier.id]
+  );
+
   const existingPromotion = await db.query<{ promoted_piece_technique_id: string }>(
     `
       SELECT promoted_piece_technique_id::text AS promoted_piece_technique_id
@@ -542,8 +556,8 @@ async function ensureOfficialPieceFromPreparatory(
     const maybeDesignation2 = typeof payload.designation_2 === "string" ? payload.designation_2 : null;
     const maybePrixUnitaire = typeof payload.prix_unitaire === "number" ? payload.prix_unitaire : 0;
 
-    officialPieceId = crypto.randomUUID();
-    await db.query(
+    const requestedPieceId = crypto.randomUUID();
+    const inserted = await db.query<{ id: string; updated_at: string }>(
       `
         INSERT INTO public.pieces_techniques (
           id,
@@ -590,9 +604,10 @@ async function ensureOfficialPieceFromPreparatory(
           $9,
           false
         )
+        RETURNING id::text AS id, updated_at::text AS updated_at
       `,
       [
-        officialPieceId,
+        requestedPieceId,
         maybeClientId,
         maybeNamePiece,
         dossier.code_piece,
@@ -603,6 +618,31 @@ async function ensureOfficialPieceFromPreparatory(
         maybeClientName,
       ]
     );
+    const created = inserted.rows[0];
+    if (!created?.id || !created.updated_at) {
+      throw new Error("PREPARATORY_TECHNICAL_PIECE_CREATE_FAILED");
+    }
+    officialPieceId = created.id;
+
+    // A preparatory dossier is persisted server-side, but it is not the
+    // controlled technical dossier. Freeze only its selected root metadata;
+    // raw dossier payload, paths and uploaded bytes are intentionally absent.
+    await queueCreationPdfArchive(db, buildTechnicalPieceCreationSnapshotInput({
+      id: officialPieceId,
+      code: dossier.code_piece,
+      designation: dossier.designation,
+      clientId: maybeClientId,
+      clientName: maybeClientName,
+      status: "ACTIVE",
+      sourceRevision: created.updated_at,
+      actorUserId: null,
+      articleId: null,
+      familyId: null,
+      pieceVersion: 1,
+      planReference: typeof payload.plan_reference === "string" ? payload.plan_reference : null,
+      externalIndex: typeof payload.indice_externe === "string" ? payload.indice_externe : null,
+      internalVersion: 1,
+    }));
   }
 
   await db.query(
@@ -633,6 +673,12 @@ async function ensureOfficialArticleFromPreparatory(
   commandeId: number,
   officialPieceId: string | null
 ): Promise<CommandeLineArticleResolution> {
+  // Same reasoning as the technical-root promotion lock above: this source
+  // article has a unique promotion target, including its creation PDF.
+  await db.query(
+    "SELECT pg_advisory_xact_lock(hashtext('preparatory-article-promotion'), hashtext($1))",
+    [source.source_article_devis_id]
+  );
   const existingPromotion = await db.query<{ promoted_article_id: string }>(
     `
       SELECT promoted_article_id::text AS promoted_article_id
@@ -657,13 +703,14 @@ async function ensureOfficialArticleFromPreparatory(
     officialArticleId = null;
   }
 
+  let createdArticle: { id: string; updated_at: string } | null = null;
   if (!officialArticleId) {
-    officialArticleId = crypto.randomUUID();
+    const requestedArticleId = crypto.randomUUID();
     const categories = Array.from(new Set([source.article_devis.primary_category, ...(source.article_devis.article_categories ?? [])]))
       .filter((c) => c && c.trim().length > 0)
       .map((c) => c.trim());
 
-    await db.query(
+    const inserted = await db.query<{ id: string; updated_at: string }>(
       `
         INSERT INTO public.articles (
           id,
@@ -689,9 +736,10 @@ async function ensureOfficialArticleFromPreparatory(
         ) VALUES (
           $1::uuid,$2,$3,'PIECE_TECHNIQUE','fabrique',$4,true,$5::uuid,'u',$1::uuid,NULL,1,$6::int,'VALIDE',$7::bigint,false,true,NULL,NULL,NULL
         )
+        RETURNING id::text AS id, updated_at::text AS updated_at
       `,
       [
-        officialArticleId,
+        requestedArticleId,
         source.article_devis.code,
         source.article_devis.designation,
         source.article_devis.family_code,
@@ -700,6 +748,11 @@ async function ensureOfficialArticleFromPreparatory(
         source.article_devis.projet_id ?? null,
       ]
     );
+    createdArticle = inserted.rows[0] ?? null;
+    if (!createdArticle?.id || !createdArticle.updated_at) {
+      throw new Error("PREPARATORY_STOCK_ARTICLE_CREATE_FAILED");
+    }
+    officialArticleId = createdArticle.id;
 
     if (categories.length > 0) {
       await db.query(`DELETE FROM public.article_category_link WHERE article_id = $1::uuid`, [officialArticleId]);
@@ -735,7 +788,32 @@ async function ensureOfficialArticleFromPreparatory(
     [source.source_article_devis_id, officialArticleId, commandeId]
   );
 
-  await db.query(`UPDATE public.articles SET status = 'VALIDE', updated_at = now() WHERE id = $1::uuid`, [officialArticleId]);
+  const statusUpdate = await db.query<{ updated_at: string }>(
+    `UPDATE public.articles
+        SET status = 'VALIDE', updated_at = now()
+      WHERE id = $1::uuid
+      RETURNING updated_at::text AS updated_at`,
+    [officialArticleId]
+  );
+  if (!statusUpdate.rows[0]?.updated_at) throw new Error("PREPARATORY_STOCK_ARTICLE_REVISION_MISSING");
+
+  if (createdArticle) {
+    await queueCreationPdfArchive(db, buildStockArticleCreationSnapshotInput({
+      id: officialArticleId,
+      code: source.article_devis.code,
+      designation: source.article_devis.designation,
+      articleType: "PIECE_TECHNIQUE",
+      articleCategory: "fabrique",
+      familyCode: source.article_devis.family_code,
+      unit: "u",
+      status: "VALIDE",
+      stockManaged: true,
+      lotTracking: false,
+      isActive: true,
+      sourceRevision: statusUpdate.rows[0].updated_at,
+      actorUserId: null,
+    }));
+  }
 
   const meta = await getOfficialArticleMetaById(db, officialArticleId);
   if (!meta) {
@@ -3298,6 +3376,15 @@ export async function repoCreateCommande(input: CreateCommandeInput, documents: 
       });
     }
 
+    // This is deliberately last in the business transaction: the snapshot contains
+    // the persisted header and dependants, and a queue failure aborts the order
+    // together with any uploaded files.  It is an internal creation record, not an
+    // acknowledgement de réception (which has its own document kind and workflow).
+    await queueCommandeCreationPdf(client, {
+      commandeId,
+      actorUserId: null,
+    });
+
     return { id: toInt(commandeId, "commande.id") };
       },
       reconcile: async () => commandeIdForReconciliation
@@ -3315,6 +3402,141 @@ export async function repoCreateCommande(input: CreateCommandeInput, documents: 
     throw e;
   }
   return result;
+}
+
+type CommandeCreationPdfHeader = {
+  id: string;
+  numero: string;
+  client_id: string | null;
+  client_name: string | null;
+  billing_address_id: string | null;
+  billing_address_name: string | null;
+  billing_street: string | null;
+  billing_house_number: string | null;
+  billing_postal_code: string | null;
+  billing_city: string | null;
+  billing_country: string | null;
+  date_commande: string | null;
+  order_type: string;
+  total_ht: number;
+  total_ttc: number;
+  remise_globale: number;
+  commentaire: string | null;
+  updated_at: string;
+};
+
+/** Builds a server-read, path-free creation snapshot after all order children exist. */
+async function queueCommandeCreationPdf(
+  tx: Pick<PoolClient, "query">,
+  params: { commandeId: string; actorUserId: number | null }
+): Promise<void> {
+  const headerRes = await tx.query<CommandeCreationPdfHeader>(
+    `
+      SELECT cc.id::text AS id,
+             cc.numero,
+             cc.client_id,
+             c.company_name AS client_name,
+             cc.adresse_facturation_id::text AS billing_address_id,
+             af.name AS billing_address_name,
+             af.street AS billing_street,
+             af.house_number AS billing_house_number,
+             af.postal_code AS billing_postal_code,
+             af.city AS billing_city,
+             af.country AS billing_country,
+             cc.date_commande::text AS date_commande,
+             cc.order_type,
+             cc.total_ht::float8 AS total_ht,
+             cc.total_ttc::float8 AS total_ttc,
+             cc.remise_globale::float8 AS remise_globale,
+             cc.commentaire,
+             to_char(cc.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at
+      FROM public.commande_client cc
+      LEFT JOIN public.clients c ON c.client_id = cc.client_id
+      LEFT JOIN public.adresse_facturation af ON af.bill_address_id = cc.adresse_facturation_id
+      WHERE cc.id = $1::bigint
+      FOR UPDATE
+    `,
+    [params.commandeId]
+  );
+  const header = headerRes.rows[0];
+  if (!header?.id || !header.updated_at) throw new Error("COMMANDE_CREATION_PDF_SOURCE_NOT_FOUND");
+
+  const [linesRes, dueDatesRes, documentsRes] = await Promise.all([
+    tx.query<Record<string, unknown>>(
+      `SELECT id::text AS id, ordre::int AS ordre, designation, code_piece,
+              quantite::float8 AS quantite, unite, delai_client::text AS delai_client,
+              prix_unitaire_ht::float8 AS prix_unitaire_ht, remise_ligne::float8 AS remise_ligne,
+              taux_tva::float8 AS taux_tva, total_ht::float8 AS total_ht, total_ttc::float8 AS total_ttc
+       FROM public.commande_ligne WHERE commande_id = $1::bigint ORDER BY ordre ASC, id ASC`,
+      [header.id]
+    ),
+    tx.query<Record<string, unknown>>(
+      `SELECT id::text AS id, libelle, date_echeance::text AS date_echeance,
+              pourcentage::float8 AS pourcentage, montant::float8 AS montant
+       FROM public.commande_echeance WHERE commande_id = $1::bigint ORDER BY date_echeance ASC NULLS LAST, id ASC`,
+      [header.id]
+    ),
+    // Deliberately do not read documents_clients.file_path/content: creation PDFs
+    // may expose only filing metadata, never a filesystem location or raw upload.
+    tx.query<Record<string, unknown>>(
+      `SELECT cd.id::text AS link_id, cd.type, dc.id::text AS document_id,
+              dc.document_name, dc.type AS document_type
+       FROM public.commande_documents cd
+       JOIN public.documents_clients dc ON dc.id = cd.document_id
+       WHERE cd.commande_id = $1::bigint ORDER BY cd.id ASC`,
+      [header.id]
+    ),
+  ]);
+
+  const toText = (value: unknown): string | null => value === null || value === undefined ? null : String(value);
+  const snapshot = buildInternalCreationSnapshot({
+    entityLabel: "Commande client — instantané de création",
+    reference: header.numero,
+    summary: [
+      { label: "Commande", value: header.numero }, { label: "Statut initial", value: "ATTENTE_TECHNIQUE" },
+      { label: "Type", value: header.order_type }, { label: "Date", value: header.date_commande },
+      { label: "Client", value: header.client_name ?? header.client_id }, { label: "Total HT", value: header.total_ht },
+      { label: "Total TTC", value: header.total_ttc }, { label: "Remise globale", value: header.remise_globale },
+    ],
+    sections: [
+      {
+        title: "Client et adresse de facturation",
+        rows: [
+          { label: "Référence client", value: header.client_id }, { label: "Nom", value: header.client_name },
+          { label: "Référence adresse", value: header.billing_address_id },
+          { label: "Adresse", value: [header.billing_house_number, header.billing_street].filter(Boolean).join(" ") || null },
+          { label: "Ville", value: [header.billing_postal_code, header.billing_city, header.billing_country].filter(Boolean).join(" ") || null },
+        ],
+      },
+      {
+        title: "Lignes de commande",
+        table: { columns: [{ key: "position", label: "Pos." }, { key: "designation", label: "Désignation" }, { key: "quantity", label: "Qté" }, { key: "total", label: "Total HT" }], rows: linesRes.rows.map((line) => ({ position: toText(line.ordre), designation: toText(line.designation), quantity: toText(line.quantite), total: toText(line.total_ht) })) },
+      },
+      {
+        title: "Échéances",
+        table: { columns: [{ key: "label", label: "Libellé" }, { key: "date", label: "Date" }, { key: "percent", label: "%" }, { key: "amount", label: "Montant" }], rows: dueDatesRes.rows.map((item) => ({ label: toText(item.libelle), date: toText(item.date_echeance), percent: toText(item.pourcentage), amount: toText(item.montant) })) },
+      },
+      {
+        title: "Documents joints",
+        table: { columns: [{ key: "name", label: "Nom" }, { key: "type", label: "Type" }], rows: documentsRes.rows.map((item) => ({ name: toText(item.document_name), type: toText(item.document_type ?? item.type) })) },
+      },
+      { title: "Commentaire", notes: header.commentaire },
+    ],
+  });
+
+  await queueCreationPdfArchive(tx, {
+    entityType: "commande-client",
+    entityId: header.id,
+    documentKind: "CUSTOMER_ORDER_CREATION_SNAPSHOT",
+    documentVersion: 1,
+    renderVersion: "customer-order-creation-snapshot-v1",
+    idempotencyKey: `commande-client:${header.id}:creation:v1`,
+    title: `Création commande ${header.numero}`,
+    originalName: `commande-${header.id}-creation-v1.pdf`,
+    sourceRevision: header.updated_at,
+    sourceSnapshot: snapshot,
+    actorUserId: params.actorUserId,
+  });
 }
 
 export async function repoUpdateCommande(id: string, input: CreateCommandeInput, documents: UploadedDocument[]) {
@@ -4048,6 +4270,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           role: "LIVRAISON",
           commentaire: `Split delivery (${existingLivraisons.length + i + 1}/${requestedLivraisonCount})`,
         });
+        await queueAffaireCreationPdf(client, { affaireId: livraisonId, actorUserId: audit.user_id });
         created.push(livraisonId);
       }
 
@@ -4219,6 +4442,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         role: "LIVRAISON",
         commentaire: "Generated from commande",
       });
+      await queueAffaireCreationPdf(client, { affaireId: createdId, actorUserId: audit.user_id });
       livraisonAffaireIds.push(createdId);
     }
 
@@ -4234,6 +4458,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         role: "LIVRAISON",
         commentaire: `Split delivery (${i + 1}/${requestedLivraisonCount})`,
       });
+      await queueAffaireCreationPdf(client, { affaireId: extraId, actorUserId: audit.user_id });
       livraisonAffaireIds.push(extraId);
     }
 
@@ -4333,6 +4558,11 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
     }
 
     const ofIds = generatedOfs.map((of) => of.id);
+    // The recursive generator returns the complete tree.  Creation PDFs are
+    // filed only for its business roots, inside this launch transaction.
+    for (const root of generatedOfs.filter((of) => of.parent_of_id === null)) {
+      await queueRootOfCreationPdf(client, { ofId: root.id, actorUserId: audit.user_id });
+    }
     let workflowStatus: string | null = null;
     if (orderType === "INTERNE") {
       await advanceInternalOrderWorkflowAfterGeneration({
@@ -4464,6 +4694,77 @@ async function createAffaire(db: PoolClient, input: AffaireCreationInput): Promi
     [id, reference, input.client_id, input.commande_id, input.devis_id ?? null, typeAffaire]
   );
   return id;
+}
+
+/**
+ * Must be invoked by the outer lifecycle transaction after the new affair has
+ * been linked to its commande.  It only accepts the freshly allocated ID, so a
+ * replay path that returns an existing mapping cannot enqueue a second archive.
+ */
+async function queueAffaireCreationPdf(
+  db: Pick<PoolClient, "query">,
+  params: { affaireId: number; actorUserId: number | null }
+): Promise<void> {
+  const source = await db.query<{
+    id: string;
+    reference: string;
+    statut: string;
+    type_affaire: string;
+    date_ouverture: string | null;
+    updated_at: string | null;
+    client_id: string | null;
+    client_name: string | null;
+    commande_id: string | null;
+    commande_numero: string | null;
+    devis_id: string | null;
+  }>(
+    `
+      SELECT a.id::text AS id, a.reference, a.statut, a.type_affaire,
+             a.date_ouverture::text AS date_ouverture,
+             to_char(a.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at,
+             a.client_id, c.company_name AS client_name,
+             a.commande_id::text AS commande_id, cc.numero AS commande_numero,
+             a.devis_id::text AS devis_id
+        FROM public.affaire a
+        LEFT JOIN public.clients c ON c.client_id = a.client_id
+        LEFT JOIN public.commande_client cc ON cc.id = a.commande_id
+       WHERE a.id = $1::bigint
+       FOR UPDATE
+    `,
+    [params.affaireId]
+  );
+  const affaire = source.rows[0];
+  if (!affaire?.id || !affaire.reference || !affaire.updated_at) {
+    throw new Error("AFFAIR_CREATION_PDF_SOURCE_NOT_FOUND");
+  }
+
+  await queueCreationPdfArchive(db, {
+    entityType: "affaire",
+    entityId: affaire.id,
+    documentKind: "AFFAIR_CREATION_SNAPSHOT",
+    documentVersion: 1,
+    renderVersion: "internal-creation-snapshot-v1",
+    idempotencyKey: `affaire:${affaire.id}:creation:v1`,
+    title: `Instantané de création — affaire ${affaire.reference}`,
+    originalName: authoritativePdfFilename(["affaire", affaire.reference, "creation"]),
+    sourceRevision: affaire.updated_at,
+    sourceSnapshot: buildInternalCreationSnapshot({
+      entityLabel: "Affaire",
+      reference: affaire.reference,
+      summary: [
+        { label: "Référence", value: affaire.reference }, { label: "Statut initial", value: affaire.statut },
+        { label: "Client", value: affaire.client_name ?? affaire.client_id }, { label: "Commande client", value: affaire.commande_numero ?? affaire.commande_id },
+      ],
+      sections: [{
+        title: "Cadre commercial initial",
+        rows: [
+          { label: "Type", value: affaire.type_affaire }, { label: "Date d'ouverture", value: affaire.date_ouverture },
+          { label: "Référence client", value: affaire.client_id }, { label: "Devis lié", value: affaire.devis_id },
+        ],
+      }],
+    }),
+    actorUserId: params.actorUserId,
+  });
 }
 
 type MappingInsertInput = {
@@ -5451,6 +5752,7 @@ export async function repoGenerateAffairesFromCommande(id: string, body: Generat
       role: "LIVRAISON",
       commentaire: "Generated from commande",
     });
+    await queueAffaireCreationPdf(client, { affaireId: livraisonAffaireId, actorUserId: null });
 
     const allocationMode = requiresConfirmation ? body.strategy : needsProduction ? "AUTO_OF" : "AUTO_STOCK";
     await upsertCommandeAllocations(client, {
@@ -5520,6 +5822,7 @@ export async function repoConfirmGenerateAffaires(id: string, body: ConfirmGener
         role: "LIVRAISON",
         commentaire: "Generated from commande",
       });
+      await queueAffaireCreationPdf(client, { affaireId: livraisonAffaireId, actorUserId: null });
     }
 
     const computed = await computeCommandeAllocationPlan(client, commandeId);
@@ -5747,6 +6050,11 @@ export async function repoDuplicateCommande(id: string) {
       `,
       [newIdInt, null, null, initialWorkflowStatus, `Duplicated from commande ${originalCommandeId}`]
     );
+
+    // The duplicated aggregate is fully materialised only after its lines and
+    // workflow checkpoints exist.  A durable outbox failure is allowed to
+    // abort this explicit transaction rather than leave an unfiled clone.
+    await queueCommandeCreationPdf(client, { commandeId: String(newIdInt), actorUserId: null });
 
     await client.query("COMMIT");
     return { id: newIdInt };

--- a/src/module/commande-client/repository/commande-creation-pdf.contract.test.ts
+++ b/src/module/commande-client/repository/commande-creation-pdf.contract.test.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = fs.readFileSync(path.join(__dirname, "commande-client.repository.ts"), "utf8");
+const productionSource = fs.readFileSync(path.join(__dirname, "../../production/repository/production.repository.ts"), "utf8");
+const generationSource = fs.readFileSync(path.join(__dirname, "../../production/repository/production-generation.repository.ts"), "utf8");
+
+describe("commande creation PDF transaction contract", () => {
+  it("queues the sanitized internal snapshot before the create transaction returns", () => {
+    const queue = source.indexOf("await queueCommandeCreationPdf(client");
+    const result = source.indexOf("return { id: toInt(commandeId");
+    expect(queue).toBeGreaterThan(0);
+    expect(queue).toBeLessThan(result);
+    expect(source).toContain('documentKind: "CUSTOMER_ORDER_CREATION_SNAPSHOT"');
+    expect(source).toContain('idempotencyKey: `commande-client:${header.id}:creation:v1`');
+    expect(source).toContain("buildInternalCreationSnapshot");
+    expect(source).not.toContain("dc.document_path");
+  });
+
+  it("queues manual and generated OF roots inside their transactions, excluding children", () => {
+    const manualQueue = productionSource.indexOf("await queueRootOfCreationPdf(client");
+    const manualReturn = productionSource.indexOf("return ofId;", manualQueue);
+    expect(manualQueue).toBeGreaterThan(0);
+    expect(manualQueue).toBeLessThan(manualReturn);
+    expect(generationSource).toContain("generated.ofs.filter((of) => of.parent_of_id === null)");
+    expect(source).toContain("generatedOfs.filter((of) => of.parent_of_id === null)");
+    expect(generationSource).toContain("await queueRootOfCreationPdf(client");
+    expect(source).toContain("await queueRootOfCreationPdf(client");
+  });
+
+  it("archives clones only after their cloned aggregate is complete and before commit", () => {
+    const duplicateStart = source.indexOf("export async function repoDuplicateCommande");
+    const duplicate = source.slice(duplicateStart);
+    const checkpoints = duplicate.indexOf("await repoEnsureCommandeWorkflowCheckpoints");
+    const queue = duplicate.indexOf("await queueCommandeCreationPdf(client");
+    const commit = duplicate.indexOf('await client.query("COMMIT")');
+    expect(checkpoints).toBeGreaterThan(0);
+    expect(queue).toBeGreaterThan(checkpoints);
+    expect(queue).toBeLessThan(commit);
+  });
+
+  it("covers every lifecycle-created affaire while preserving replay no-op paths", () => {
+    const created = (source.match(/await createAffaire\(client/g) ?? []).length;
+    const queued = (source.match(/await queueAffaireCreationPdf\(client/g) ?? []).length;
+    expect(created).toBe(5);
+    expect(queued).toBe(created);
+    expect(source).toContain('documentKind: "AFFAIR_CREATION_SNAPSHOT"');
+    expect(source).toContain('idempotencyKey: `affaire:${affaire.id}:creation:v1`');
+    // Existing mappings return before any create helper call, so a replay has no queue side effect.
+    expect(source).toContain("if (existingLivraisons.length >= requestedLivraisonCount)");
+  });
+});

--- a/src/module/commande-client/routes/commande-client.routes.ts
+++ b/src/module/commande-client/routes/commande-client.routes.ts
@@ -2,6 +2,8 @@ import type { RequestHandler } from "express"
 import { Router } from "express"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
+import { effectiveRoleHasAny } from "../../auth/domain/roles"
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context"
 import { HttpError } from "../../../utils/httpError"
 import { createSecureUpload } from "../../../shared/uploads/secure-upload"
 import {
@@ -12,10 +14,12 @@ import {
   cancelCadreRelease,
   deleteCommande,
   duplicateCommande,
+  downloadCommandeCreationSnapshot,
   generateAffairesFromOrder,
   previewAffairesFromCommande,
   getCadreRelease,
   getCommande,
+  getCommandeCreationSnapshot,
   getCommandeDocumentFile,
   getCommandeWorkflow,
   listCadreReleases,
@@ -27,8 +31,10 @@ import {
   updateCadreReleaseStatus,
   updateCommande,
   updateCommandeWorkflowCheckpoint,
+  previewCommandeCreationSnapshot,
+  printCommandeCreationSnapshot,
 } from "../controllers/commande-client.controller"
-import { generateCommandeAr, sendCommandeAr } from "../controllers/commande-ar.controller"
+import { createAcknowledgement, downloadAcknowledgement, generateCommandeAr, getAcknowledgement, listAcknowledgements, previewAcknowledgement, printAcknowledgement, sendAcknowledgement, sendCommandeAr } from "../controllers/commande-ar.controller"
 import {
   generateCommandeArSchema,
   sendCommandeArSchema,
@@ -77,6 +83,17 @@ const parseCommandeBody: RequestHandler = (req, res, next) => {
 
 const router = Router()
 
+const requireAcknowledgementExport: RequestHandler = (req, _res, next) => {
+  if (
+    requestHasGrantedAccountModuleAccess(req) ||
+    effectiveRoleHasAny(req.user?.role, [
+      "Administrateur Systeme et Reseau", "Directeur", "Secretaire", "Commercial", "Comptabilite",
+      "Method", "Responsable Programmation", "Production", "Responsable Production", "Planification",
+    ])
+  ) { next(); return }
+  next(new HttpError(403, "FORBIDDEN", "Votre rôle ne permet pas d'exporter les accusés de réception."))
+}
+
 const rejectLegacyCommandeLaunch: RequestHandler = (_req, _res, next) => {
   next(
     new HttpError(
@@ -105,6 +122,13 @@ router.get("/", listCommandes)
 
 // GET /api/v1/commandes/:id
 router.get("/:id", validate(idParamSchema), getCommande)
+
+// Automatic creation snapshots are immutable GED artifacts. They deliberately
+// expose no issue/reissue endpoint and retain the acknowledgement export gate.
+router.get("/:id/creation-snapshot", authenticateToken, requireAcknowledgementExport, validate(idParamSchema), getCommandeCreationSnapshot)
+router.get("/:id/creation-snapshot/:documentId/preview", authenticateToken, requireAcknowledgementExport, validate(idParamSchema), previewCommandeCreationSnapshot)
+router.get("/:id/creation-snapshot/:documentId/download", authenticateToken, requireAcknowledgementExport, validate(idParamSchema), downloadCommandeCreationSnapshot)
+router.post("/:id/creation-snapshot/:documentId/print-intents", authenticateToken, requireAcknowledgementExport, validate(idParamSchema), printCommandeCreationSnapshot)
 
 // GET /api/v1/commandes/:id/workflow
 router.get("/:id/workflow", authenticateToken, validate(idParamSchema), getCommandeWorkflow)
@@ -175,6 +199,16 @@ router.post(
   validate(generateCommandeArSchema),
   generateCommandeAr
 )
+
+// Authoritative acknowledgement collection. Legacy `/ar/*` remains compatible;
+// these endpoints expose GED-backed immutable documents only.
+router.get("/:id/acknowledgements", authenticateToken, requireAcknowledgementExport, listAcknowledgements)
+router.post("/:id/acknowledgements", authenticateToken, requireAcknowledgementExport, createAcknowledgement)
+router.get("/:id/acknowledgements/:documentId", authenticateToken, requireAcknowledgementExport, getAcknowledgement)
+router.get("/:id/acknowledgements/:documentId/preview", authenticateToken, requireAcknowledgementExport, previewAcknowledgement)
+router.get("/:id/acknowledgements/:documentId/download", authenticateToken, requireAcknowledgementExport, downloadAcknowledgement)
+router.post("/:id/acknowledgements/:documentId/print-intents", authenticateToken, requireAcknowledgementExport, printAcknowledgement)
+router.post("/:id/acknowledgements/:documentId/send", authenticateToken, requireAcknowledgementExport, sendAcknowledgement)
 
 // POST /api/v1/commandes/:id/ar/send
 router.post(

--- a/src/module/commande-client/services/commande-ar.service.test.ts
+++ b/src/module/commande-client/services/commande-ar.service.test.ts
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   claimSend: vi.fn(),
   finalizeSend: vi.fn(),
   markFailed: vi.fn(),
+  readArchived: vi.fn(),
+  findArchive: vi.fn(),
 }));
 
 vi.mock("node:fs/promises", () => ({
@@ -29,6 +31,13 @@ vi.mock("../../../shared/email/resend.service", () => ({
 vi.mock("../../../shared/documents/issuer-identity.repository", () => ({
   readIssuerParty: vi.fn(),
 }));
+vi.mock("../../../shared/authoritative-documents/authoritative-document.service", () => ({
+  getOfficialDocumentGenerationEnvelope: vi.fn(),
+  getOfficialPdfDto: vi.fn(),
+  readOfficialPdfBytes: mocks.readArchived,
+  recordOfficialPdfPrintIntent: vi.fn(),
+  officialDocumentGenerationEnvelope: vi.fn(),
+}));
 vi.mock("../repository/commande-ar.repository", () => ({
   buildCommandeArRecipientSuggestions: vi.fn(),
   repoAbortCommandeArSendClaim: mocks.abortClaim,
@@ -36,6 +45,7 @@ vi.mock("../repository/commande-ar.repository", () => ({
   repoClaimCommandeArSend: mocks.claimSend,
   repoCreateCommandeArDraft: vi.fn(),
   repoFinalizeCommandeArSend: mocks.finalizeSend,
+  repoFindCommandeArOfficialArchiveId: mocks.findArchive,
   repoGetCommandeArDraft: vi.fn(),
   repoLoadCommandeArGenerationData: vi.fn(),
   repoMarkCommandeArFailed: mocks.markFailed,
@@ -161,7 +171,8 @@ describe("envoi AR claimé avant effet externe", () => {
     mocks.claimSend
       .mockResolvedValueOnce(claim)
       .mockResolvedValueOnce({ kind: "replay", draft: persistedReplay });
-    mocks.readFile.mockResolvedValueOnce(Buffer.from("pdf"));
+    mocks.findArchive.mockResolvedValueOnce("33333333-3333-4333-8333-333333333333");
+    mocks.readArchived.mockResolvedValueOnce({ bytes: Buffer.from("pdf"), filename: "AR-123-officiel.pdf", sha256: "a".repeat(64) });
     mocks.sendEmail.mockResolvedValueOnce({ ok: true, id: "provider-first" });
     mocks.finalizeSend.mockResolvedValueOnce({
       result: {
@@ -182,6 +193,14 @@ describe("envoi AR claimé avant effet externe", () => {
     ]);
 
     expect(mocks.sendEmail).toHaveBeenCalledTimes(1);
+    expect(mocks.readArchived).toHaveBeenCalledWith(expect.objectContaining({
+      entityType: "commande-client",
+      entityId: "123",
+      documentKind: "CUSTOMER_ORDER_ACKNOWLEDGEMENT",
+      archiveId: "33333333-3333-4333-8333-333333333333",
+      eventType: "AUTHORITATIVE_PDF_SENT",
+    }));
+    expect(mocks.readFile).not.toHaveBeenCalled();
     expect(first.email_provider_id).toBe("provider-first");
     expect(replay).toMatchObject({
       recipient_emails: ["persisted@example.test"],

--- a/src/module/commande-client/services/commande-ar.service.ts
+++ b/src/module/commande-client/services/commande-ar.service.ts
@@ -1,8 +1,4 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-
 import { HttpError } from "../../../utils/httpError";
-import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { sendTransactionalEmail, type ResendSendResult } from "../../../shared/email/resend.service";
 import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository";
 import {
@@ -10,6 +6,7 @@ import {
   renderCerpDocument,
   type CerpLineRow,
 } from "../../../shared/pdf/cerp-document";
+import { money } from "../../../shared/pdf/format-fr";
 import { issuerIdentityLine, issuerLegalMentions, type LegalParty } from "../../../shared/pdf/legal-mentions";
 import type {
   CommandeArDraft,
@@ -23,11 +20,17 @@ import {
   repoAuthorizeCommandeArGeneration,
   repoClaimCommandeArSend,
   repoCreateCommandeArDraft,
+  repoFindCommandeArOfficialArchiveId,
   repoFinalizeCommandeArSend,
   repoLoadCommandeArGenerationData,
   repoMarkCommandeArFailed,
+  repoResolveCommandeArOfficialArchive,
 } from "../repository/commande-ar.repository";
 import pool from "../../../config/database";
+import type { AuthoritativePdfArchiveRecord } from "../../../shared/authoritative-documents/authoritative-document.types";
+import { getOfficialDocumentGenerationEnvelope, getOfficialPdfDto, readOfficialPdfBytes, recordOfficialPdfPrintIntent } from "../../../shared/authoritative-documents/authoritative-document.service";
+
+const ACKNOWLEDGEMENT_DOCUMENT_KIND = "CUSTOMER_ORDER_ACKNOWLEDGEMENT";
 
 type CommandeArAddress = {
   name?: string | null;
@@ -38,8 +41,27 @@ type CommandeArAddress = {
   country?: string | null;
 };
 
-function formatCurrencyEUR(value: number): string {
-  return new Intl.NumberFormat("fr-FR", { style: "currency", currency: "EUR" }).format(value);
+export type CommandeArOfficialSnapshot = {
+  type: "CUSTOMER_ORDER_ACKNOWLEDGEMENT";
+  /** Assigned inside the locked creation transaction before archival. */
+  acknowledgement_id?: string;
+  acknowledgement_number: string;
+  order_number: string;
+  generated_at: string;
+  status: string | null;
+  customer_name: string | null;
+  date_commande: string;
+  total_ht: string;
+  total_ttc: string;
+  public_comment: string | null;
+  bill_address: CommandeArAddress;
+  delivery_address: CommandeArAddress;
+  lines: Array<{ designation: string; code_piece: string | null; quantite: string; unite: string | null; prix_unitaire_ht: string; taux_tva: string | null; total_ttc: string }>;
+  issuer: LegalParty;
+};
+
+function formatCurrencyEUR(value: number | string): string {
+  return money(value, "EUR");
 }
 
 function formatDateFR(value: string | null | undefined): string {
@@ -110,12 +132,16 @@ function isResendSendError(result: Extract<ResendSendResult, { ok: false }>): re
 
 export async function buildCommandeArPdfBuffer(params: {
   draftNumber: string;
+  /** Customer order reference; distinct from the acknowledgement number when configured. */
+  orderNumber?: string;
   companyName: string | null;
   dateCommande: string;
   generatedAt: Date;
+  /** Persisted authoritative archive edition (not PDF renderer/template version). */
+  documentVersion?: number;
   statut: string | null;
-  totalHt: number;
-  totalTtc: number;
+  totalHt: number | string;
+  totalTtc: number | string;
   commentaire: string | null;
   clientEmail: string | null;
   clientPhone: string | null;
@@ -124,11 +150,11 @@ export async function buildCommandeArPdfBuffer(params: {
   lines: Array<{
     designation: string;
     code_piece: string | null;
-    quantite: number;
+    quantite: number | string;
     unite: string | null;
-    prix_unitaire_ht: number;
-    taux_tva: number | null;
-    total_ttc: number;
+    prix_unitaire_ht: number | string;
+    taux_tva: number | string | null;
+    total_ttc: number | string;
   }>;
   /**
    * Instantane de l'emetteur : identite legale et mentions obligatoires.
@@ -140,6 +166,8 @@ export async function buildCommandeArPdfBuffer(params: {
   issuer: LegalParty;
 }): Promise<Buffer> {
   const clientName = params.companyName?.trim() || "Client";
+  const orderNumber = params.orderNumber?.trim() || params.draftNumber;
+  const draft = params.statut?.trim().toUpperCase() === "BROUILLON";
   const rows: CerpLineRow[] = params.lines.map((line) => ({
     cells: {
       designation: line.designation,
@@ -158,19 +186,22 @@ export async function buildCommandeArPdfBuffer(params: {
       documentType: "Accusé de réception",
       name: clientName,
       code: params.draftNumber,
-      subtitle: `Commande ${params.draftNumber}`,
+      subtitle: `Version ${params.documentVersion ?? 1} · Commande ${orderNumber}`,
       status: params.statut ?? "PLANIFIEE",
+      flag: draft ? "INTERNE / BROUILLON" : null,
+      watermark: draft ? "INTERNE / BROUILLON" : null,
       monogramName: clientName,
       generatedAt: formatDateFR(params.generatedAt.toISOString()),
       title: `Accusé de réception ${params.draftNumber}`,
-      subject: "Accusé de réception de commande CERP",
+      subject: draft ? "Instantané interne CERP — brouillon" : "Accusé de réception de commande CERP",
+      footerNote: draft ? "Instantané interne GED — non opposable" : null,
       legalIdentity: issuerIdentityLine(params.issuer),
       legalMentions: issuerLegalMentions(params.issuer),
       creationDate: params.generatedAt,
     },
     (ctx) => {
       ctx.legalStrip([
-        { label: "Commande", value: params.draftNumber },
+        { label: "Commande", value: orderNumber },
         { label: "Date commande", value: formatDateFR(params.dateCommande) },
         { label: "Statut", value: params.statut ?? "PLANIFIEE" },
         { label: "Total TTC", value: formatCurrencyEUR(params.totalTtc) },
@@ -227,10 +258,34 @@ export async function buildCommandeArPdfBuffer(params: {
   );
 }
 
+/** Renderer registered in the authoritative worker. It consumes the frozen source only. */
+export async function renderCommandeArOfficialPdf({ archive }: { archive: AuthoritativePdfArchiveRecord }): Promise<Buffer> {
+  const source = archive.sourceSnapshot as Partial<CommandeArOfficialSnapshot>;
+  if (source.type !== "CUSTOMER_ORDER_ACKNOWLEDGEMENT" || !source.acknowledgement_number || !Array.isArray(source.lines) || !source.issuer) {
+    throw new Error("COMMANDE_AR_OFFICIAL_SNAPSHOT_INVALID");
+  }
+  const archivedAt = new Date(archive.createdAt);
+  if (Number.isNaN(archivedAt.getTime())) throw new Error("COMMANDE_AR_ARCHIVE_CREATED_AT_INVALID");
+  return buildCommandeArPdfBuffer({
+    issuer: source.issuer, draftNumber: source.acknowledgement_number, orderNumber: source.order_number,
+    companyName: source.customer_name ?? null,
+    // `generated_at` remains inside the frozen business snapshot; the document
+    // artifact's header/footer/PDF metadata are the immutable archive time.
+    dateCommande: source.date_commande ?? "", generatedAt: archivedAt, statut: source.status ?? null,
+    documentVersion: archive.documentVersion,
+    totalHt: source.total_ht ?? "0", totalTtc: source.total_ttc ?? "0", commentaire: source.public_comment ?? null,
+    clientEmail: null, clientPhone: null, billAddress: source.bill_address ?? {}, deliveryAddress: source.delivery_address ?? {},
+    lines: source.lines.map((line) => ({ designation: line.designation, code_piece: line.code_piece ?? null, quantite: line.quantite, unite: line.unite ?? null, prix_unitaire_ht: line.prix_unitaire_ht, taux_tva: line.taux_tva, total_ttc: line.total_ttc })),
+  });
+}
+
 export async function svcGenerateCommandeAr(params: {
   commande_id: number;
   user_id: number;
   user_role: string | null | undefined;
+  source_revision?: string | null;
+  reissue_reason?: string | null;
+  idempotency_key?: string | null;
 }): Promise<CommandeArDraft> {
   const client = await pool.connect();
   try {
@@ -244,7 +299,6 @@ export async function svcGenerateCommandeAr(params: {
     if (!data) {
       throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable");
     }
-
     const recipientSuggestions = buildCommandeArRecipientSuggestions(data);
     const subject = subjectForCommande(data.header.numero);
     const bodyText = bodyTextForCommande({
@@ -257,9 +311,18 @@ export async function svcGenerateCommandeAr(params: {
     // force when that artifact is created, not the possibly much older order date.
     const issuer = await readIssuerParty({ at: generatedAt.toISOString().slice(0, 10) });
 
+    const officialSnapshot: CommandeArOfficialSnapshot = {
+      type: "CUSTOMER_ORDER_ACKNOWLEDGEMENT", acknowledgement_number: data.header.numero, order_number: data.header.numero,
+      generated_at: generatedAt.toISOString(), status: data.header.statut, customer_name: data.header.client_company_name,
+      date_commande: data.header.date_commande, total_ht: String(data.header.total_ht), total_ttc: String(data.header.total_ttc),
+      public_comment: data.header.commentaire, bill_address: { name: data.header.bill_name, street: data.header.bill_street, house_number: data.header.bill_house_number, postal_code: data.header.bill_postal_code, city: data.header.bill_city, country: data.header.bill_country },
+      delivery_address: { name: data.header.deliv_name, street: data.header.deliv_street, house_number: data.header.deliv_house_number, postal_code: data.header.deliv_postal_code, city: data.header.deliv_city, country: data.header.deliv_country },
+      lines: data.lines.map((line) => ({ designation: line.designation, code_piece: line.code_piece, quantite: String(line.quantite), unite: line.unite, prix_unitaire_ht: String(line.prix_unitaire_ht), taux_tva: line.taux_tva == null ? null : String(line.taux_tva), total_ttc: String(line.total_ttc) })), issuer,
+    };
     const pdfBuffer = await buildCommandeArPdfBuffer({
       issuer,
       draftNumber: data.header.numero,
+      orderNumber: data.header.numero,
       companyName: data.header.client_company_name,
       dateCommande: data.header.date_commande,
       generatedAt,
@@ -299,6 +362,10 @@ export async function svcGenerateCommandeAr(params: {
       subject,
       body_text: bodyText,
       recipient_suggestions: recipientSuggestions,
+      official_source_snapshot: officialSnapshot,
+      official_request_idempotency_key: params.idempotency_key ?? undefined,
+      official_expected_source_revision: params.source_revision ?? undefined,
+      official_reissue_reason: params.reissue_reason ?? undefined,
     });
 
     return {
@@ -347,8 +414,15 @@ export async function svcSendCommandeAr(params: {
   const draft = claim.draft;
   let claimOpen = true;
   try {
-    const filePath = path.resolve(getDocumentStoragePath(), `${draft.document_id}.pdf`);
-    const pdfBuffer = await fs.readFile(filePath);
+    // The supplier/customer-facing email must attach the exact archived GED
+    // bytes, never a mutable legacy working-file copy.
+    const archiveId = await repoFindCommandeArOfficialArchiveId(params.commande_id, draft.ar_id);
+    if (!archiveId) throw new HttpError(409, "OFFICIAL_DOCUMENT_NOT_READY", "Le document officiel est en cours de génération.");
+    const archived = await readOfficialPdfBytes({
+      entityType: "commande-client", entityId: String(params.commande_id), archiveId,
+      documentKind: ACKNOWLEDGEMENT_DOCUMENT_KIND,
+      actorUserId: params.user_id, eventType: "AUTHORITATIVE_PDF_SENT",
+    });
 
     const baseText = draft.body_text?.trim() || `Veuillez trouver ci-joint l'accuse de reception de la commande.`;
     const customMessage = params.body.message?.trim() || null;
@@ -362,8 +436,8 @@ export async function svcSendCommandeAr(params: {
       idempotencyKey: `commande-ar:${params.body.ar_id}`,
       attachments: [
         {
-          filename: draft.document_name,
-          content: pdfBuffer,
+          filename: archived.filename,
+          content: archived.bytes,
           contentType: "application/pdf",
         },
       ],
@@ -405,4 +479,48 @@ export async function svcSendCommandeAr(params: {
     if (claimOpen) await repoAbortCommandeArSendClaim(claim);
     throw err;
   }
+}
+
+export async function svcCreateCommandeArOfficial(params: {
+  commande_id: number; user_id: number; user_role: string | null | undefined; source_revision: string; reissue_reason?: string | null; idempotency_key: string;
+}) {
+  // The repository performs source freshness and reissue checks while holding
+  // the command row lock, after handling a same-key replay.
+  const draft = await svcGenerateCommandeAr(params);
+  return getOfficialDocumentGenerationEnvelope({
+    tx: pool, entityType: "commande-client", entityId: String(draft.commande_id), documentKind: ACKNOWLEDGEMENT_DOCUMENT_KIND, baseUrl: acknowledgementBase(params.commande_id),
+  });
+}
+
+const acknowledgementBase = (commandeId: number) => `/commandes/${commandeId}/acknowledgements`;
+
+export async function svcListCommandeArOfficialDocuments(commandeId: number) {
+  return getOfficialDocumentGenerationEnvelope({
+    tx: pool, entityType: "commande-client", entityId: String(commandeId), documentKind: ACKNOWLEDGEMENT_DOCUMENT_KIND, baseUrl: acknowledgementBase(commandeId),
+  });
+}
+
+async function resolveAcknowledgementArchive(commandeId: number, archiveId: string): Promise<string> {
+  const arId = await repoResolveCommandeArOfficialArchive(commandeId, archiveId);
+  if (!arId) throw new HttpError(404, "OFFICIAL_DOCUMENT_NOT_FOUND", "Document officiel introuvable.");
+  return arId;
+}
+
+export async function svcGetCommandeArOfficialDocument(commandeId: number, archiveId: string) {
+  return getOfficialPdfDto({ tx: pool, entityType: "commande-client", entityId: String(commandeId), documentKind: ACKNOWLEDGEMENT_DOCUMENT_KIND, archiveId, baseUrl: acknowledgementBase(commandeId) });
+}
+
+export async function svcReadCommandeArOfficialDocument(commandeId: number, archiveId: string, actorUserId: number, eventType: "AUTHORITATIVE_PDF_PREVIEWED" | "AUTHORITATIVE_PDF_DOWNLOADED") {
+  return readOfficialPdfBytes({ entityType: "commande-client", entityId: String(commandeId), documentKind: ACKNOWLEDGEMENT_DOCUMENT_KIND, archiveId, actorUserId, eventType });
+}
+
+export async function svcRecordCommandeArOfficialPrint(commandeId: number, archiveId: string, actorUserId: number) {
+  return recordOfficialPdfPrintIntent({ entityType: "commande-client", entityId: String(commandeId), documentKind: ACKNOWLEDGEMENT_DOCUMENT_KIND, archiveId, actorUserId });
+}
+
+export async function svcSendCommandeArOfficial(params: {
+  commande_id: number; archive_id: string; user_id: number; user_role: string | null | undefined; body: Omit<SendCommandeArBodyDTO, "ar_id">;
+}): Promise<CommandeArSendResult> {
+  const arId = await resolveAcknowledgementArchive(params.commande_id, params.archive_id);
+  return svcSendCommandeAr({ ...params, body: { ...params.body, ar_id: arId } });
 }

--- a/src/module/commande-client/validators/commande-ar.validators.ts
+++ b/src/module/commande-client/validators/commande-ar.validators.ts
@@ -18,4 +18,28 @@ export const sendCommandeArSchema = z.object({
   }),
 });
 
+export const acknowledgementDocumentParamsSchema = z.object({
+  id: z.string().regex(/^\d+$/, "id must be an integer"),
+  documentId: z.string().uuid(),
+});
+
+export const createAcknowledgementSchema = z.object({
+  params: z.object({ id: z.string().regex(/^\d+$/, "id must be an integer") }),
+  body: z.object({
+    // The acknowledgement is a fresh business document; this token is carried
+    // into audit provenance and lets the UI correlate a per-attempt request.
+    source_revision: z.string().trim().min(1).max(160),
+    reissue_reason: z.string().trim().min(3).max(500).optional().nullable(),
+  }).strict(),
+});
+
+export const sendAcknowledgementSchema = z.object({
+  params: acknowledgementDocumentParamsSchema,
+  body: z.object({
+    recipient_emails: z.array(z.string().email()).min(1),
+    recipient_contact_ids: z.array(z.string().uuid()).optional().default([]),
+    message: z.string().trim().max(20000).optional().nullable(),
+  }),
+});
+
 export type SendCommandeArBodyDTO = z.infer<typeof sendCommandeArSchema>["body"];

--- a/src/module/commande-fournisseur/controllers/commande-fournisseur.controller.ts
+++ b/src/module/commande-fournisseur/controllers/commande-fournisseur.controller.ts
@@ -14,6 +14,8 @@ import {
   duplicateSchema,
   generateDocumentSchema,
   ligneIdParamSchema,
+  officialDocumentIdParamSchema,
+  officialDocumentRequestSchema,
   listCommandesQuerySchema,
   propositionsConfirmSchema,
   propositionsPreviewSchema,
@@ -42,6 +44,11 @@ import {
   transitionCommandeFournisseurSVC,
   updateCommandeFournisseurSVC,
   updateLigneSVC,
+  getSupplierPoOfficialDocumentSVC,
+  listSupplierPoOfficialDocumentsSVC,
+  queueSupplierPoOfficialDocumentSVC,
+  readSupplierPoOfficialDocumentSVC,
+  recordSupplierPoOfficialPrintSVC,
 } from "../services/commande-fournisseur.service";
 
 function buildAuditContext(req: Request): AuditContext {
@@ -235,6 +242,64 @@ export const getDocument: RequestHandler = async (req, res, next) => {
   } catch (err) {
     next(err);
   }
+};
+
+export const listOfficialDocuments: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    res.json(await listSupplierPoOfficialDocumentsSVC(params.id));
+  } catch (err) { next(err); }
+};
+
+export const queueOfficialDocument: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    const { body } = officialDocumentRequestSchema.parse({ body: req.body ?? {} });
+    const key = idempotencyKeyFrom(req);
+    if (!key) throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "Une clé d'idempotence est requise.");
+    const audit = buildAuditContext(req);
+    const result = await queueSupplierPoOfficialDocumentSVC(params.id, key, audit, body);
+    res.status(201).json(result);
+  } catch (err) { next(err); }
+};
+
+export const getOfficialDocument: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = officialDocumentIdParamSchema.parse({ params: req.params });
+    const result = await getSupplierPoOfficialDocumentSVC(params.id, params.documentId);
+    if (!result) throw new HttpError(404, "OFFICIAL_DOCUMENT_NOT_FOUND", "Document officiel introuvable.");
+    res.json(result);
+  } catch (err) { next(err); }
+};
+
+function sendOfficialPdf(disposition: "inline" | "attachment"): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const { params } = officialDocumentIdParamSchema.parse({ params: req.params });
+      const actorId = buildAuditContext(req).user_id;
+      const file = await readSupplierPoOfficialDocumentSVC(
+        params.id, params.documentId, actorId,
+        disposition === "inline" ? "AUTHORITATIVE_PDF_PREVIEWED" : "AUTHORITATIVE_PDF_DOWNLOADED"
+      );
+      res.setHeader("Content-Type", "application/pdf");
+      res.setHeader("Content-Length", String(file.bytes.byteLength));
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      res.setHeader("Cache-Control", "private, no-store");
+      res.setHeader("Content-Disposition", `${disposition}; filename="${file.filename}"`);
+      res.send(file.bytes);
+    } catch (err) { next(err); }
+  };
+}
+
+export const previewOfficialDocument = sendOfficialPdf("inline");
+export const downloadOfficialDocument = sendOfficialPdf("attachment");
+
+export const printOfficialDocument: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = officialDocumentIdParamSchema.parse({ params: req.params });
+    await recordSupplierPoOfficialPrintSVC(params.id, params.documentId, buildAuditContext(req).user_id);
+    res.status(204).send();
+  } catch (err) { next(err); }
 };
 
 export const simulateTotaux: RequestHandler = async (req, res, next) => {

--- a/src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts
+++ b/src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts
@@ -20,6 +20,10 @@ import {
 } from "../domain/commande-fournisseur-rbac";
 import { computeCommandeTotaux, computeLigneTotaux, roundMoney } from "../domain/commande-fournisseur-totaux";
 import { repoRecordInitialPromiseEvent } from "../../procurement-reliability/repository/procurement-reliability.repository";
+import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository";
+import { authoritativePdfFilename } from "../../../shared/authoritative-documents/authoritative-document.filename";
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
+import { repoFindAuthoritativePdfByIdempotency } from "../../../shared/authoritative-documents/authoritative-document.repository";
 import type {
   AccuseBodyDTO,
   AddLigneBodyDTO,
@@ -59,6 +63,109 @@ export type AuditContext = {
 };
 
 type DbQueryer = Pick<PoolClient, "query">;
+
+type SupplierPoCreationSnapshot = Record<string, unknown>;
+
+/**
+ * Builds the PO's official source snapshot from persisted rows, in the same
+ * create transaction. Internal notes, actor context and procurement links are
+ * deliberately absent: an official supplier PDF is an external document.
+ */
+async function buildSupplierPoCreationSnapshot(tx: DbQueryer, commandeId: string): Promise<SupplierPoCreationSnapshot> {
+  const header = await tx.query<Record<string, unknown>>(
+    `SELECT cf.code, cf.statut, cf.created_at::text AS issued_at, cf.devise,
+            cf.date_besoin::text AS need_date, cf.incoterm, cf.conditions_paiement AS payment_terms,
+            cf.mode_transport AS transport_mode, cf.commentaire_public AS public_comment,
+            cf.adresse_livraison_texte AS delivery_address,
+            f.code AS supplier_code, COALESCE(f.nom, f.raison_sociale) AS supplier_name,
+            f.adresse_ligne AS supplier_street, f.house_no AS supplier_house_no,
+            f.postcode AS supplier_postal_code, f.city AS supplier_city, f.country AS supplier_country,
+            cf.total_ht::text, cf.total_remise::text, cf.total_tva::text,
+            cf.frais_port_ht::text AS freight_ht, cf.total_ttc::text
+       FROM public.commande_fournisseur cf
+       JOIN public.fournisseurs f ON f.id = cf.fournisseur_id
+      WHERE cf.id = $1::uuid`,
+    [commandeId]
+  );
+  const h = header.rows[0];
+  if (!h) throw new HttpError(404, "COMMANDE_FOURNISSEUR_NOT_FOUND", "Commande fournisseur introuvable.");
+  const lines = await tx.query<Record<string, unknown>>(
+    `SELECT position::int, reference_fournisseur AS reference, designation, unite AS unit,
+            quantite::text AS quantity, prix_unitaire_ht::text AS unit_price_ht,
+            remise_pct::text AS discount_pct, tva_pct::text AS vat_pct, net_ht::text,
+            date_besoin::text AS need_date
+       FROM public.commande_fournisseur_ligne
+      WHERE commande_id = $1::uuid AND statut_ligne = 'ACTIVE'
+      ORDER BY position ASC`,
+    [commandeId]
+  );
+  const issuer = await readIssuerParty({ at: String(h.issued_at ?? "").slice(0, 10) });
+  return {
+    type: "SUPPLIER_PURCHASE_ORDER", code: String(h.code), status: String(h.statut), issued_at: String(h.issued_at),
+    supplier: {
+      code: h.supplier_code == null ? null : String(h.supplier_code),
+      name: h.supplier_name == null ? null : String(h.supplier_name),
+      address: {
+        street: h.supplier_street == null ? null : String(h.supplier_street),
+        house_number: h.supplier_house_no == null ? null : String(h.supplier_house_no),
+        postal_code: h.supplier_postal_code == null ? null : String(h.supplier_postal_code),
+        city: h.supplier_city == null ? null : String(h.supplier_city),
+        country: h.supplier_country == null ? null : String(h.supplier_country),
+      },
+    },
+    currency: String(h.devise), need_date: h.need_date == null ? null : String(h.need_date),
+    incoterm: h.incoterm == null ? null : String(h.incoterm), payment_terms: h.payment_terms == null ? null : String(h.payment_terms),
+    transport_mode: h.transport_mode == null ? null : String(h.transport_mode), public_comment: h.public_comment == null ? null : String(h.public_comment),
+    delivery_address: h.delivery_address == null ? null : String(h.delivery_address),
+    lines: lines.rows.map((line) => ({
+      position: Number(line.position), reference: line.reference == null ? null : String(line.reference), designation: String(line.designation),
+      unit: line.unit == null ? null : String(line.unit), quantity: String(line.quantity), unit_price_ht: line.unit_price_ht == null ? null : String(line.unit_price_ht),
+      discount_pct: line.discount_pct == null ? null : String(line.discount_pct), vat_pct: line.vat_pct == null ? null : String(line.vat_pct),
+      net_ht: line.net_ht == null ? null : String(line.net_ht), need_date: line.need_date == null ? null : String(line.need_date),
+    })),
+    totals: { total_ht: String(h.total_ht), total_discount: String(h.total_remise), total_vat: String(h.total_tva), freight_ht: String(h.freight_ht), total_ttc: String(h.total_ttc) },
+    issuer,
+  };
+}
+
+/** Same textual timestamp exposed by the PO detail API; never client-derived. */
+async function readSupplierPoSourceRevision(tx: DbQueryer, commandeId: string): Promise<string> {
+  const result = await tx.query<{ source_revision: string | null }>(
+    `SELECT updated_at::text AS source_revision
+       FROM public.commande_fournisseur
+      WHERE id = $1::uuid`,
+    [commandeId]
+  );
+  const revision = result.rows[0]?.source_revision?.trim();
+  if (!revision) throw new HttpError(409, "OFFICIAL_DOCUMENT_SOURCE_REVISION_UNAVAILABLE", "La révision source du document est indisponible.");
+  return revision;
+}
+
+/**
+ * Enqueues the immutable creation PDF for any supplier-order creation path.
+ * Callers must invoke this after all header/line/totals work and before the
+ * transaction commits, so the business row and its future GED filing are
+ * accepted atomically.
+ */
+export async function queueSupplierPurchaseOrderCreationPdfTx(
+  tx: PoolClient,
+  input: Readonly<{ commandeId: string; code: string; actorUserId: number }>
+): Promise<void> {
+  const sourceSnapshot = await buildSupplierPoCreationSnapshot(tx, input.commandeId);
+  await queueCreationPdfArchive(tx, {
+    entityType: "commande-fournisseur",
+    entityId: input.commandeId,
+    documentKind: "SUPPLIER_PURCHASE_ORDER",
+    documentVersion: 1,
+    renderVersion: "supplier-po-pdf-v1",
+    idempotencyKey: `commande-fournisseur:${input.commandeId}:creation:v1`,
+    title: `Bon de commande fournisseur ${input.code}`,
+    originalName: authoritativePdfFilename(["BCF", input.code, "v1"]),
+    sourceRevision: await readSupplierPoSourceRevision(tx, input.commandeId),
+    sourceSnapshot,
+    actorUserId: input.actorUserId,
+  });
+}
 
 /* ------------------------------- shared helpers ------------------------------ */
 
@@ -823,6 +930,14 @@ export async function repoCreateCommandeFournisseur(
 
     await recomputeTotauxTx(client, id);
     await insertTransitionRow(client, id, null, "BROUILLON", null, audit.user_id);
+    // Automatic, server-built creation snapshot. This is queued in the same
+    // transaction as the PO so a committed order can never silently miss its
+    // future GED filing work. The browser never supplies the PDF payload.
+    await queueSupplierPurchaseOrderCreationPdfTx(client, {
+      commandeId: id,
+      code,
+      actorUserId: audit.user_id,
+    });
     await insertAuditLog(client, audit, {
       action: "commandes_fournisseurs.create",
       entity_type: "commande_fournisseur",
@@ -1511,6 +1626,76 @@ export async function repoGenerateDocumentVersion(
   }
 }
 
+/** Explicit reissue queue. Existing legacy `commande_fournisseur_document` files stay untouched. */
+export async function repoQueueSupplierPoOfficialDocument(
+  id: string,
+  idempotencyKey: string,
+  audit: AuditContext,
+  input: { source_revision: string; reissue_reason?: string | null }
+) {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const header = await client.query<{ code: string; source_revision: string | null }>(
+      `SELECT code, updated_at::text AS source_revision
+         FROM public.commande_fournisseur WHERE id = $1::uuid FOR UPDATE`, [id]
+    );
+    const code = header.rows[0]?.code;
+    if (!code) throw new HttpError(404, "COMMANDE_FOURNISSEUR_NOT_FOUND", "Commande fournisseur introuvable.");
+    // Resolve an existing accepted attempt before comparing the current mutable
+    // order. A network retry must replay its original immutable request even if
+    // somebody edited the order between the two HTTP calls.
+    const replay = await repoFindAuthoritativePdfByIdempotency(client, idempotencyKey);
+    if (replay) {
+      if (
+        replay.entityType !== "commande-fournisseur" || replay.entityId !== id ||
+        replay.documentKind !== "SUPPLIER_PURCHASE_ORDER"
+      ) {
+        throw new HttpError(409, "OFFICIAL_DOCUMENT_IDEMPOTENCY_CONFLICT", "La clé d'idempotence est déjà utilisée.");
+      }
+      await insertAuditLog(client, audit, {
+        action: "commandes_fournisseurs.official_document.idempotent_replay",
+        entity_type: "commande_fournisseur",
+        entity_id: id,
+        details: { archive_id: replay.id, render_version: replay.renderVersion },
+      });
+      await client.query("COMMIT");
+      return replay;
+    }
+    const currentArchive = await client.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM public.authoritative_pdf_archives
+        WHERE entity_type = 'commande-fournisseur' AND entity_id = $1 AND document_kind = 'SUPPLIER_PURCHASE_ORDER'`,
+      [id]
+    );
+    const existingCount = Number(currentArchive.rows[0]?.n ?? 0);
+    if (existingCount > 0 && !input.reissue_reason?.trim()) {
+      throw new HttpError(422, "OFFICIAL_DOCUMENT_REISSUE_REASON_REQUIRED", "Un motif de réémission est requis.");
+    }
+    const sourceSnapshot = await buildSupplierPoCreationSnapshot(client, id);
+    const currentSourceRevision = header.rows[0]?.source_revision?.trim();
+    if (!currentSourceRevision) throw new HttpError(409, "OFFICIAL_DOCUMENT_SOURCE_REVISION_UNAVAILABLE", "La révision source du document est indisponible.");
+    if (currentSourceRevision !== input.source_revision) {
+      throw new HttpError(409, "OFFICIAL_DOCUMENT_SOURCE_REVISION_CONFLICT", "La source du document a changé. Rechargez avant de réémettre.");
+    }
+    const archive = await queueCreationPdfArchive(client, {
+      entityType: "commande-fournisseur", entityId: id, documentKind: "SUPPLIER_PURCHASE_ORDER",
+      documentVersion: existingCount + 1, renderVersion: "supplier-po-pdf-v1", idempotencyKey, title: `Bon de commande fournisseur ${code}`,
+      originalName: authoritativePdfFilename(["BCF", code, `v${existingCount + 1}`]),
+      sourceRevision: currentSourceRevision,
+      sourceSnapshot, actorUserId: audit.user_id,
+    });
+    await insertAuditLog(client, audit, {
+      action: "commandes_fournisseurs.official_document.queue", entity_type: "commande_fournisseur", entity_id: id,
+      details: { archive_id: archive.id, document_version: archive.documentVersion, render_version: archive.renderVersion, source_revision: archive.sourceRevision, reissue_reason: input.reissue_reason?.trim() ?? null },
+    });
+    await client.query("COMMIT");
+    return archive;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally { client.release(); }
+}
+
 // Variante transactionnelle interne du détail (utilisée par la génération documentaire).
 async function repoGetCommandeFournisseurTx(tx: DbQueryer, id: string): Promise<CommandeFournisseur> {
   const res = await tx.query(
@@ -1991,6 +2176,11 @@ export async function repoConfirmPropositions(
 
       await recomputeTotauxTx(client, commandeId);
       await insertTransitionRow(client, commandeId, null, "BROUILLON", "Généré depuis propositions d'achat", audit.user_id);
+      await queueSupplierPurchaseOrderCreationPdfTx(client, {
+        commandeId,
+        code,
+        actorUserId: audit.user_id,
+      });
       await insertAuditLog(client, audit, {
         action: "commandes_fournisseurs.propositions.confirm",
         entity_type: "commande_fournisseur",
@@ -2070,6 +2260,11 @@ export async function repoDuplicateAsDraft(
 
     await recomputeTotauxTx(client, newId);
     await insertTransitionRow(client, newId, null, "BROUILLON", `Duplication de ${source.code}`, audit.user_id);
+    await queueSupplierPurchaseOrderCreationPdfTx(client, {
+      commandeId: newId,
+      code,
+      actorUserId: audit.user_id,
+    });
     await insertAuditLog(client, audit, {
       action: "commandes_fournisseurs.duplicate",
       entity_type: "commande_fournisseur",

--- a/src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts
+++ b/src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts
@@ -7,7 +7,10 @@ import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
 import { computeCommandeTotaux } from "../domain/commande-fournisseur-totaux"
 import { allocateCoverage, calculateReplenishment, normalizeUnit } from "../domain/replenishment-calculation"
-import type { AuditContext } from "./commande-fournisseur.repository"
+import {
+  queueSupplierPurchaseOrderCreationPdfTx,
+  type AuditContext,
+} from "./commande-fournisseur.repository"
 import type {
   ReplenishmentProposal,
   ReplenishmentRefreshResult,
@@ -657,6 +660,11 @@ export async function repoValidateReplenishmentProposal(
        VALUES($1::uuid,'VALIDATED',$2,'CONVERTIE',$3::jsonb,$4::jsonb,$5)`,
       [id, proposal.status, JSON.stringify(calculation), JSON.stringify({ commande_fournisseur_id: orderId, code, catalogue_id: candidate.catalogue_id }), context.user_id]
     )
+    await queueSupplierPurchaseOrderCreationPdfTx(client, {
+      commandeId: orderId,
+      code,
+      actorUserId: context.user_id,
+    })
     const result = { converted: true, proposal_id: id, commande_fournisseur_id: orderId, code, status: "BROUILLON", recalculated: calculation }
     await client.query(
       `INSERT INTO public.replenishment_proposal_idempotence(actor_id,idempotency_key,request_hash,proposal_id,result)

--- a/src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts
+++ b/src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts
@@ -14,12 +14,18 @@ import {
   deleteLigne,
   duplicateCommandeFournisseur,
   generateDocument,
+  getOfficialDocument,
   getCommandeFournisseur,
   getCommandeFournisseurKpis,
   getDocument,
   listCommandesFournisseurs,
+  listOfficialDocuments,
   previewPropositions,
   reorderLignes,
+  queueOfficialDocument,
+  previewOfficialDocument,
+  downloadOfficialDocument,
+  printOfficialDocument,
   resyncReceptions,
   simulateTotaux,
   transitionCommandeFournisseur,
@@ -82,6 +88,16 @@ router.post("/:id/accuse", requireCapability("acknowledge"), accuseReception);
 
 router.post("/:id/documents", requireCapability("send"), generateDocument);
 router.get("/:id/documents/:documentId", requireCapability("read"), getDocument);
+
+// Official generated PDFs live independently from legacy attachments. Export
+// capability is required for every metadata or byte surface because PO prices
+// are commercially sensitive; a foreign UUID resolves as the same 404.
+router.get("/:id/official-documents", requireCapability("export"), listOfficialDocuments);
+router.post("/:id/official-documents", requireCapability("export"), queueOfficialDocument);
+router.get("/:id/official-documents/:documentId", requireCapability("export"), getOfficialDocument);
+router.get("/:id/official-documents/:documentId/preview", requireCapability("export"), previewOfficialDocument);
+router.get("/:id/official-documents/:documentId/download", requireCapability("export"), downloadOfficialDocument);
+router.post("/:id/official-documents/:documentId/print-intents", requireCapability("export"), printOfficialDocument);
 
 router.post("/:id/receptions/resync", requireCapability("read"), resyncReceptions);
 router.post("/:id/duplicate", requireCapability("create"), duplicateCommandeFournisseur);

--- a/src/module/commande-fournisseur/services/commande-fournisseur-official-pdf.ts
+++ b/src/module/commande-fournisseur/services/commande-fournisseur-official-pdf.ts
@@ -1,0 +1,122 @@
+import { renderCerpDocument, type CerpLineRow } from "../../../shared/pdf/cerp-document";
+import { formatDateFR, money, percent } from "../../../shared/pdf/format-fr";
+import { issuerIdentityLine, issuerLegalMentions, type LegalParty } from "../../../shared/pdf/legal-mentions";
+import type { AuthoritativePdfArchiveRecord } from "../../../shared/authoritative-documents/authoritative-document.types";
+
+export type SupplierPurchaseOrderSnapshot = {
+  type: "SUPPLIER_PURCHASE_ORDER";
+  code: string;
+  status: string;
+  issued_at: string;
+  supplier: {
+    code: string | null; name: string | null;
+    address?: { street: string | null; house_number: string | null; postal_code: string | null; city: string | null; country: string | null } | null;
+  };
+  currency: string;
+  need_date: string | null;
+  incoterm: string | null;
+  payment_terms: string | null;
+  transport_mode: string | null;
+  public_comment: string | null;
+  delivery_address: string | null;
+  lines: Array<{
+    position: number; reference: string | null; designation: string; unit: string | null;
+    quantity: string; unit_price_ht: string | null; discount_pct: string | null;
+    vat_pct: string | null; net_ht: string | null; need_date: string | null;
+  }>;
+  totals: { total_ht: string; total_discount: string; total_vat: string; freight_ht: string; total_ttc: string };
+  issuer: LegalParty;
+};
+
+function snapshotOf(record: AuthoritativePdfArchiveRecord): SupplierPurchaseOrderSnapshot {
+  const source = record.sourceSnapshot as Partial<SupplierPurchaseOrderSnapshot>;
+  if (source.type !== "SUPPLIER_PURCHASE_ORDER" || !source.code || !Array.isArray(source.lines) || !source.totals || !source.issuer) {
+    throw new Error("SUPPLIER_PO_SNAPSHOT_INVALID");
+  }
+  return source as SupplierPurchaseOrderSnapshot;
+}
+
+function businessAddressLines(address: SupplierPurchaseOrderSnapshot["supplier"]["address"]): string[] {
+  if (!address) return [];
+  return [
+    [address.house_number, address.street].filter(Boolean).join(" ").trim(),
+    [address.postal_code, address.city].filter(Boolean).join(" ").trim(),
+    address.country ?? "",
+  ].filter((line) => line.length > 0);
+}
+
+function archiveCreationDate(record: AuthoritativePdfArchiveRecord): Date {
+  const value = new Date(record.createdAt);
+  if (Number.isNaN(value.getTime())) throw new Error("SUPPLIER_PO_ARCHIVE_CREATED_AT_INVALID");
+  return value;
+}
+
+/** Renders only data frozen in the archive snapshot — never a live PO row. */
+export async function renderSupplierPurchaseOrderOfficialPdf(input: { archive: AuthoritativePdfArchiveRecord }): Promise<Buffer> {
+  const source = snapshotOf(input.archive);
+  const supplierName = source.supplier.name?.trim() || "Fournisseur";
+  const supplierAddress = businessAddressLines(source.supplier.address);
+  const draft = source.status.trim().toUpperCase() === "BROUILLON";
+  const archivedAt = archiveCreationDate(input.archive);
+  const rows: CerpLineRow[] = source.lines.map((line) => ({
+    cells: {
+      pos: String(line.position), reference: line.reference ?? "—", designation: line.designation,
+      quantity: line.quantity, unit: line.unit ?? "—", price: line.unit_price_ht ? money(line.unit_price_ht, source.currency) : "—",
+      vat: line.vat_pct ? percent(line.vat_pct) : "—", total: line.net_ht ? money(line.net_ht, source.currency) : "—",
+    },
+    meta: [line.need_date ? `Besoin : ${formatDateFR(line.need_date)}` : null, line.discount_pct ? `Remise : ${percent(line.discount_pct)}` : null].filter(Boolean).join(" · ") || null,
+    metaColumn: "designation",
+  }));
+  return renderCerpDocument({
+    documentType: "Bon de commande fournisseur", name: source.code, code: source.code,
+    subtitle: `Version ${input.archive.documentVersion} · ${draft ? "Instantané de création" : `Émis le ${formatDateFR(source.issued_at)}`}`,
+    status: source.status, monogramName: supplierName, generatedAt: formatDateFR(archivedAt.toISOString()),
+    flag: draft ? "INTERNE / BROUILLON" : null,
+    watermark: draft ? "INTERNE / BROUILLON" : null,
+    footerNote: draft ? "Instantané interne GED — non opposable" : `Original GED · SHA-256 ${input.archive.snapshotSha256.slice(0, 16)}…`,
+    legalIdentity: issuerIdentityLine(source.issuer), legalMentions: issuerLegalMentions(source.issuer),
+    title: `Bon de commande fournisseur ${source.code}`, subject: draft ? "Instantané interne CERP — brouillon" : "Bon de commande fournisseur CERP",
+    creationDate: archivedAt,
+  }, (ctx) => {
+    ctx.legalStrip([
+      { label: "Fournisseur", value: supplierName }, { label: "Code fournisseur", value: source.supplier.code },
+      { label: "Besoin", value: source.need_date ? formatDateFR(source.need_date) : null },
+      { label: "Devise", value: source.currency },
+    ]);
+    if (supplierAddress.length) ctx.addressCards([{ caption: "Adresse fournisseur", lines: supplierAddress, accent: true }]);
+    ctx.section("Conditions");
+    const top = ctx.y;
+    const middle = 38 + 260;
+    const right = 38 + 410;
+    const bottom = Math.max(
+      ctx.field("Incoterm", source.incoterm, 38, 115),
+      ctx.field("Règlement", source.payment_terms, middle, 145),
+      ctx.field("Transport", source.transport_mode, right, 145)
+    );
+    ctx.y = Math.max(top + 34, bottom + 7);
+    if (source.delivery_address) ctx.notesSection("Livraison", source.delivery_address);
+    ctx.section("Lignes commandées");
+    ctx.linesTable({
+      columns: [
+        { key: "pos", label: "N°", flex: 0.35, align: "right" }, { key: "reference", label: "Référence", flex: 1.05 },
+        { key: "designation", label: "Désignation", flex: 2.5 }, { key: "quantity", label: "Qté", flex: 0.7, align: "right" },
+        { key: "unit", label: "U", flex: 0.45 }, { key: "price", label: "PU HT", flex: 1, align: "right" },
+        { key: "vat", label: "TVA", flex: 0.7, align: "right" }, { key: "total", label: "Total HT", flex: 1.1, align: "right" },
+      ], rows, emptyLabel: "Aucune ligne active.",
+    });
+    ctx.section("Totaux");
+    const totalTop = ctx.y;
+    const subtotalBottom = Math.max(
+      ctx.field("Total HT", money(source.totals.total_ht, source.currency), 38, 140),
+      ctx.field("Remises", money(source.totals.total_discount, source.currency), 215, 140),
+      ctx.field("Frais de port HT", money(source.totals.freight_ht, source.currency), 392, 127)
+    );
+    ctx.y = Math.max(totalTop + 34, subtotalBottom + 8);
+    const totalBottom = Math.max(
+      ctx.field("TVA", money(source.totals.total_vat, source.currency), 38, 190),
+      ctx.field("Total TTC", money(source.totals.total_ttc, source.currency), 275, 244)
+    );
+    ctx.y = Math.max(ctx.y, totalBottom + 7);
+    if (source.public_comment) ctx.notesSection("Instructions", source.public_comment);
+  });
+}

--- a/src/module/commande-fournisseur/services/commande-fournisseur.service.ts
+++ b/src/module/commande-fournisseur/services/commande-fournisseur.service.ts
@@ -10,6 +10,7 @@ import type {
   UpdateCommandeBodyDTO,
   UpdateLigneBodyDTO,
 } from "../validators/commande-fournisseur.validators";
+import db from "../../../config/database";
 import { computeCommandeTotaux } from "../domain/commande-fournisseur-totaux";
 import {
   repoAccuseReception,
@@ -24,6 +25,7 @@ import {
   repoGetKpis,
   repoListCommandesFournisseurs,
   repoPreviewPropositions,
+  repoQueueSupplierPoOfficialDocument,
   repoReorderLignes,
   repoResyncReceptions,
   repoTransitionCommandeFournisseur,
@@ -32,6 +34,7 @@ import {
   type AuditContext,
   type ListCommandesParams,
 } from "../repository/commande-fournisseur.repository";
+import { getOfficialDocumentGenerationEnvelope, getOfficialPdfDto, readOfficialPdfBytes, recordOfficialPdfPrintIntent } from "../../../shared/authoritative-documents/authoritative-document.service";
 
 export const listCommandesFournisseursSVC = (params: ListCommandesParams, includePrices: boolean) =>
   repoListCommandesFournisseurs(params, { includePrices });
@@ -93,3 +96,22 @@ export const resyncReceptionsSVC = (id: string, audit: AuditContext, allowOverRe
 
 export const duplicateAsDraftSVC = (id: string, note: string | undefined, audit: AuditContext) =>
   repoDuplicateAsDraft(id, note, audit);
+
+const supplierPoOfficialBase = (id: string) => `/commandes-fournisseurs/${encodeURIComponent(id)}/official-documents`;
+
+export const queueSupplierPoOfficialDocumentSVC = async (id: string, idempotencyKey: string, audit: AuditContext, input: { source_revision: string; reissue_reason?: string | null }) => {
+  await repoQueueSupplierPoOfficialDocument(id, idempotencyKey, audit, input);
+  return getOfficialDocumentGenerationEnvelope({ tx: db, entityType: "commande-fournisseur", entityId: id, documentKind: "SUPPLIER_PURCHASE_ORDER", baseUrl: supplierPoOfficialBase(id) });
+};
+
+export const listSupplierPoOfficialDocumentsSVC = (id: string) =>
+  getOfficialDocumentGenerationEnvelope({ tx: db, entityType: "commande-fournisseur", entityId: id, documentKind: "SUPPLIER_PURCHASE_ORDER", baseUrl: supplierPoOfficialBase(id) });
+
+export const getSupplierPoOfficialDocumentSVC = (id: string, archiveId: string) =>
+  getOfficialPdfDto({ tx: db, entityType: "commande-fournisseur", entityId: id, documentKind: "SUPPLIER_PURCHASE_ORDER", archiveId, baseUrl: supplierPoOfficialBase(id) });
+
+export const readSupplierPoOfficialDocumentSVC = (id: string, archiveId: string, actorUserId: number, eventType: "AUTHORITATIVE_PDF_PREVIEWED" | "AUTHORITATIVE_PDF_DOWNLOADED") =>
+  readOfficialPdfBytes({ entityType: "commande-fournisseur", entityId: id, documentKind: "SUPPLIER_PURCHASE_ORDER", archiveId, actorUserId, eventType });
+
+export const recordSupplierPoOfficialPrintSVC = (id: string, archiveId: string, actorUserId: number) =>
+  recordOfficialPdfPrintIntent({ entityType: "commande-fournisseur", entityId: id, documentKind: "SUPPLIER_PURCHASE_ORDER", archiveId, actorUserId });

--- a/src/module/commande-fournisseur/validators/commande-fournisseur.validators.ts
+++ b/src/module/commande-fournisseur/validators/commande-fournisseur.validators.ts
@@ -46,6 +46,18 @@ export const documentIdParamSchema = z.object({
   params: z.object({ id: uuid, documentId: uuid }).strict(),
 });
 
+export const officialDocumentIdParamSchema = z.object({
+  params: z.object({ id: uuid, documentId: uuid }).strict(),
+});
+
+export const officialDocumentRequestSchema = z.object({
+  body: z.object({
+    // Exact server-issued aggregate `updated_at` token; not a client snapshot hash.
+    source_revision: z.string().trim().min(1).max(160, "Révision source invalide"),
+    reissue_reason: z.string().trim().min(3).max(500).optional().nullable(),
+  }).strict(),
+});
+
 export const listCommandesQuerySchema = z.object({
   query: z
     .object({

--- a/src/module/devis/controllers/devis.controller.ts
+++ b/src/module/devis/controllers/devis.controller.ts
@@ -10,6 +10,8 @@ import {
   devisByArticleQuerySchema,
   devisDocumentIdParamsSchema,
   devisIdParamsSchema,
+  devisOfficialDocumentBodySchema,
+  devisOfficialDocumentParamsSchema,
   getDevisQuerySchema,
   listDevisQuerySchema,
   type CreateDevisBodyDTO,
@@ -30,6 +32,11 @@ import {
   svcListDevisVersions,
   svcReviseDevis,
   svcUpdateDevis,
+  svcGetDevisOfficialDocument,
+  svcListDevisOfficialDocuments,
+  svcQueueDevisOfficialDocument,
+  svcReadDevisOfficialDocument,
+  svcRecordDevisOfficialPrint,
 } from "../services/devis.service";
 
 /** Contexte d'audit transactionnel (#167) — même construction que #172, sans PII superflue. */
@@ -132,7 +139,9 @@ export const createDevis: RequestHandler = async (req, res, next) => {
     const dto = getParsedDevisBody(req);
     if (!dto) throw new HttpError(400, "MISSING_DATA", "Missing data field");
 
-    const userId = typeof dto.user_id === "number" ? dto.user_id : typeof req.user?.id === "number" ? req.user.id : null;
+    // The authenticated actor owns audit and official-document provenance; a
+    // multipart field must never be able to impersonate another user.
+    const userId = typeof req.user?.id === "number" ? req.user.id : null;
     if (!userId) throw new HttpError(422, "USER_ID_REQUIRED", "user_id is required");
 
     const documents = getUploadedDocuments(req);
@@ -299,4 +308,54 @@ export const getDevisDocumentFile: RequestHandler = async (req, res, next) => {
     }
     next(err);
   }
+};
+
+export const listDevisOfficialDocuments: RequestHandler = async (req, res, next) => {
+  try { res.json(await svcListDevisOfficialDocuments(devisIdParamsSchema.parse(req.params).id)); }
+  catch (error) { next(error); }
+};
+
+export const queueDevisOfficialDocument: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = devisIdParamsSchema.parse(req.params);
+    const body = devisOfficialDocumentBodySchema.parse(req.body ?? {});
+    const key = idempotencyKeyFrom(req);
+    if (!key) throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "Une clé d'idempotence est requise.");
+    const dto = await svcQueueDevisOfficialDocument(id, key, buildAuditContext(req), body);
+    res.status(201).json(dto);
+  } catch (error) { next(error); }
+};
+
+export const getDevisOfficialDocument: RequestHandler = async (req, res, next) => {
+  try {
+    const { id, documentId } = devisOfficialDocumentParamsSchema.parse(req.params);
+    const dto = await svcGetDevisOfficialDocument(id, documentId);
+    if (!dto) throw new HttpError(404, "OFFICIAL_DOCUMENT_NOT_FOUND", "Document officiel introuvable.");
+    res.json(dto);
+  } catch (error) { next(error); }
+};
+
+function sendDevisOfficialPdf(disposition: "inline" | "attachment"): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const { id, documentId } = devisOfficialDocumentParamsSchema.parse(req.params);
+      const userId = buildAuditContext(req).user_id;
+      const file = await svcReadDevisOfficialDocument(id, documentId, userId, disposition === "inline" ? "AUTHORITATIVE_PDF_PREVIEWED" : "AUTHORITATIVE_PDF_DOWNLOADED");
+      res.setHeader("Content-Type", "application/pdf");
+      res.setHeader("Content-Length", String(file.bytes.byteLength));
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      res.setHeader("Cache-Control", "private, no-store");
+      res.setHeader("Content-Disposition", `${disposition}; filename="${file.filename}"`);
+      res.send(file.bytes);
+    } catch (error) { next(error); }
+  };
+}
+export const previewDevisOfficialDocument = sendDevisOfficialPdf("inline");
+export const downloadDevisOfficialDocument = sendDevisOfficialPdf("attachment");
+export const printDevisOfficialDocument: RequestHandler = async (req, res, next) => {
+  try {
+    const { id, documentId } = devisOfficialDocumentParamsSchema.parse(req.params);
+    await svcRecordDevisOfficialPrint(id, documentId, buildAuditContext(req).user_id);
+    res.status(204).send();
+  } catch (error) { next(error); }
 };

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -36,6 +36,10 @@ import type {
 import type { CreateCommandeInput } from "../../commande-client/types/commande-client.types";
 import { repoCreateCommande } from "../../commande-client/repository/commande-client.repository";
 import { assertQuoteDiscountApprovedForSubmission } from "../../commercial-reliability/repository/commercial-reliability.repository";
+import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository";
+import { authoritativePdfFilename } from "../../../shared/authoritative-documents/authoritative-document.filename";
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
+import { repoFindAuthoritativePdfByIdempotency } from "../../../shared/authoritative-documents/authoritative-document.repository";
 
 type DevisCommandeHeaderRow = {
   id: string;
@@ -56,6 +60,83 @@ type DevisCommandeHeaderRow = {
   updated_at: string | null;
   created_at: string | null;
 };
+
+/** Server-authoritative, external-safe quote snapshot. No contact PII or internal fields. */
+async function buildDevisOfficialSnapshot(client: Pick<PoolClient, "query">, devisId: number): Promise<Record<string, unknown>> {
+  const header = await client.query<Record<string, unknown>>(
+    `SELECT d.numero, d.statut, d.date_creation::text AS issued_at, d.date_validite::text AS valid_until,
+            d.version_number::int AS version_number, d.total_ht::text, d.total_ttc::text,
+            d.remise_globale::text AS global_discount_pct, d.commentaires AS public_comment,
+            d.biller_id::text AS biller_id, c.company_name AS customer_name,
+            COALESCE(c.client_code, c.client_id)::text AS customer_code,
+            af.name AS customer_address_name, af.street AS customer_street, af.house_number AS customer_house_number,
+            af.postal_code AS customer_postal_code, af.city AS customer_city, af.country AS customer_country
+       FROM public.devis d
+       LEFT JOIN public.clients c ON c.client_id = d.client_id
+       LEFT JOIN public.adresse_facturation af ON af.bill_address_id = d.adresse_facturation_id
+      WHERE d.id = $1`, [devisId]
+  );
+  const h = header.rows[0];
+  if (!h) throw new HttpError(404, "DEVIS_NOT_FOUND", "Devis introuvable.");
+  const lines = await client.query<Record<string, unknown>>(
+    `SELECT COALESCE(position, id)::int AS position, NULL::text AS reference, description AS designation,
+            quantite::text AS quantity, unite AS unit, prix_unitaire_ht::text AS unit_price_ht,
+            remise_ligne::text AS discount_pct, taux_tva::text AS vat_pct,
+            total_ht::text, total_ttc::text
+       FROM public.devis_ligne WHERE devis_id = $1 ORDER BY COALESCE(position, id), id`, [devisId]
+  );
+  const issuer = await readIssuerParty({ billerId: h.biller_id == null ? null : String(h.biller_id), at: String(h.issued_at).slice(0, 10) });
+  return {
+    type: "CUSTOMER_QUOTE", number: String(h.numero), status: String(h.statut), issued_at: String(h.issued_at),
+    valid_until: h.valid_until == null ? null : String(h.valid_until), version: String(h.version_number),
+    customer: {
+      code: h.customer_code == null ? null : String(h.customer_code),
+      name: h.customer_name == null ? null : String(h.customer_name),
+      address: {
+        name: h.customer_address_name == null ? null : String(h.customer_address_name),
+        street: h.customer_street == null ? null : String(h.customer_street),
+        house_number: h.customer_house_number == null ? null : String(h.customer_house_number),
+        postal_code: h.customer_postal_code == null ? null : String(h.customer_postal_code),
+        city: h.customer_city == null ? null : String(h.customer_city),
+        country: h.customer_country == null ? null : String(h.customer_country),
+      },
+    }, currency: "EUR",
+    public_comment: h.public_comment == null ? null : String(h.public_comment),
+    lines: lines.rows.map((line) => ({ position: Number(line.position), reference: line.reference == null ? null : String(line.reference), designation: String(line.designation), quantity: String(line.quantity), unit: line.unit == null ? null : String(line.unit), unit_price_ht: String(line.unit_price_ht), discount_pct: line.discount_pct == null ? null : String(line.discount_pct), vat_pct: line.vat_pct == null ? null : String(line.vat_pct), total_ht: String(line.total_ht), total_ttc: String(line.total_ttc) })),
+    totals: { total_ht: String(h.total_ht), total_ttc: String(h.total_ttc), global_discount_pct: h.global_discount_pct == null ? null : String(h.global_discount_pct) }, issuer,
+  };
+}
+
+/** The public quote detail's exact `updated_at` serialization is the reissue token. */
+async function readDevisSourceRevision(client: Pick<PoolClient, "query">, devisId: number): Promise<string> {
+  const result = await client.query<{ source_revision: string | null }>(
+    `SELECT updated_at::text AS source_revision FROM public.devis WHERE id = $1`,
+    [devisId]
+  );
+  const revision = result.rows[0]?.source_revision?.trim();
+  if (!revision) throw new HttpError(409, "OFFICIAL_DOCUMENT_SOURCE_REVISION_UNAVAILABLE", "La révision source du document est indisponible.");
+  return revision;
+}
+
+/** Queue the first immutable official PDF for every newly materialised quote. */
+async function queueDevisCreationPdfTx(
+  client: PoolClient,
+  input: Readonly<{ devisId: number; numero: string; actorUserId: number | null }>
+): Promise<void> {
+  await queueCreationPdfArchive(client, {
+    entityType: "devis",
+    entityId: String(input.devisId),
+    documentKind: "CUSTOMER_QUOTE",
+    documentVersion: 1,
+    renderVersion: "devis-pdf-v1",
+    idempotencyKey: `devis:${input.devisId}:creation:v1`,
+    title: `Devis ${input.numero}`,
+    originalName: authoritativePdfFilename(["DEVIS", input.numero, "v1"]),
+    sourceRevision: await readDevisSourceRevision(client, input.devisId),
+    sourceSnapshot: await buildDevisOfficialSnapshot(client, input.devisId),
+    actorUserId: input.actorUserId,
+  });
+}
 
 type DevisCommandeLineRow = {
   id: string;
@@ -1858,6 +1939,15 @@ export async function repoCreateDevis(
       },
     });
 
+    // Same-transaction creation snapshot: this quote has a durable GED filing
+    // obligation as soon as the commercial aggregate exists. Values are read
+    // back from persisted server columns, not from the multipart payload.
+    await queueDevisCreationPdfTx(client, {
+      devisId,
+      numero,
+      actorUserId: ctx.audit?.user_id ?? userId,
+    });
+
     const inserted = ins.rows[0]?.id;
     const resultat = { id: inserted ? toInt(inserted, "devis.id") : devisId };
     expectedMutation = {
@@ -1892,6 +1982,59 @@ export async function repoCreateDevis(
     }
     throw err;
   }
+}
+
+/** Explicit, idempotent quote reissue. Creation archive remains immutable. */
+export async function repoQueueDevisOfficialDocument(id: number, idempotencyKey: string, audit: AuditContext, input: { source_revision: string; reissue_reason?: string | null }) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const header = await client.query<{ numero: string; source_revision: string | null }>(
+      `SELECT numero, updated_at::text AS source_revision FROM public.devis WHERE id = $1 FOR UPDATE`, [id]
+    );
+    const numero = header.rows[0]?.numero;
+    if (!numero) throw new HttpError(404, "DEVIS_NOT_FOUND", "Devis introuvable.");
+    // A retry must replay the previously accepted immutable request, not fail
+    // because the quote changed after the first response was lost.
+    const replay = await repoFindAuthoritativePdfByIdempotency(client, idempotencyKey);
+    if (replay) {
+      if (replay.entityType !== "devis" || replay.entityId !== String(id) || replay.documentKind !== "CUSTOMER_QUOTE") {
+        throw new HttpError(409, "OFFICIAL_DOCUMENT_IDEMPOTENCY_CONFLICT", "La clé d'idempotence est déjà utilisée.");
+      }
+      await insertDevisAuditLog(client, audit, {
+        action: "devis.official_document.idempotent_replay",
+        entity_id: String(id),
+        details: { archive_id: replay.id, render_version: replay.renderVersion },
+      });
+      await client.query("COMMIT");
+      return replay;
+    }
+    const currentArchive = await client.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM public.authoritative_pdf_archives WHERE entity_type = 'devis' AND entity_id = $1 AND document_kind = 'CUSTOMER_QUOTE'`, [String(id)]
+    );
+    const existingCount = Number(currentArchive.rows[0]?.n ?? 0);
+    if (existingCount > 0 && !input.reissue_reason?.trim()) {
+      throw new HttpError(422, "OFFICIAL_DOCUMENT_REISSUE_REASON_REQUIRED", "Un motif de réémission est requis.");
+    }
+    const sourceSnapshot = await buildDevisOfficialSnapshot(client, id);
+    const currentSourceRevision = header.rows[0]?.source_revision?.trim();
+    if (!currentSourceRevision) throw new HttpError(409, "OFFICIAL_DOCUMENT_SOURCE_REVISION_UNAVAILABLE", "La révision source du document est indisponible.");
+    if (currentSourceRevision !== input.source_revision) {
+      throw new HttpError(409, "OFFICIAL_DOCUMENT_SOURCE_REVISION_CONFLICT", "La source du document a changé. Rechargez avant de réémettre.");
+    }
+    const archive = await queueCreationPdfArchive(client, {
+      entityType: "devis", entityId: String(id), documentKind: "CUSTOMER_QUOTE", documentVersion: existingCount + 1, renderVersion: "devis-pdf-v1",
+      idempotencyKey, title: `Devis ${numero}`, originalName: authoritativePdfFilename(["DEVIS", numero, `v${existingCount + 1}`]),
+      sourceRevision: currentSourceRevision,
+      sourceSnapshot, actorUserId: audit.user_id,
+    });
+    await insertDevisAuditLog(client, audit, { action: "devis.official_document.queue", entity_id: String(id), details: { archive_id: archive.id, document_version: archive.documentVersion, render_version: archive.renderVersion, source_revision: archive.sourceRevision, reissue_reason: input.reissue_reason?.trim() ?? null } });
+    await client.query("COMMIT");
+    return archive;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally { client.release(); }
 }
 
 /** Champs de contenu commercial : figés dès qu'un devis est engagé (révision obligatoire). */
@@ -2477,6 +2620,15 @@ export async function repoReviseDevis(
     if (ctx.idempotency_key && idempotencyPayloadHash && (await hasDevisIdempotenceTable(client))) {
       await recordDevisIdempotence(client, ctx.idempotency_key, "REVISE", resultat.id, idempotencyPayloadHash, resultat);
     }
+
+    // A revision is a new quote aggregate with its own immutable creation PDF.
+    // Queue only after its lines, preparatory entities, documents, audit and
+    // idempotency receipt have been materialised in this transaction.
+    await queueDevisCreationPdfTx(client, {
+      devisId: resultat.id,
+      numero,
+      actorUserId: ctx.audit?.user_id ?? userId,
+    });
 
     return { ...resultat, idempotent_replay: false };
       },

--- a/src/module/devis/routes/devis.routes.ts
+++ b/src/module/devis/routes/devis.routes.ts
@@ -18,7 +18,13 @@ import {
   getCommandeDraftFromDevis,
   getDevis,
   getDevisDocumentFile,
+  getDevisOfficialDocument,
   listDevis,
+  listDevisOfficialDocuments,
+  queueDevisOfficialDocument,
+  previewDevisOfficialDocument,
+  downloadDevisOfficialDocument,
+  printDevisOfficialDocument,
   listDevisVersions,
   reviseDevis,
   updateDevis,
@@ -105,6 +111,12 @@ router.get("/:id", requireCapability("read"), getDevis);
 router.get("/:id/versions", requireCapability("read"), listDevisVersions);
 router.get("/:id/commande-draft", requireCapability("convert"), getCommandeDraftFromDevis);
 router.get("/:id/documents/:docId/file", requireCapability("export"), getDevisDocumentFile);
+router.get("/:id/official-documents", requireCapability("export"), listDevisOfficialDocuments);
+router.post("/:id/official-documents", requireCapability("export"), queueDevisOfficialDocument);
+router.get("/:id/official-documents/:documentId", requireCapability("export"), getDevisOfficialDocument);
+router.get("/:id/official-documents/:documentId/preview", requireCapability("export"), previewDevisOfficialDocument);
+router.get("/:id/official-documents/:documentId/download", requireCapability("export"), downloadDevisOfficialDocument);
+router.post("/:id/official-documents/:documentId/print-intents", requireCapability("export"), printDevisOfficialDocument);
 router.post("/", requireCapability("create"), upload.array("documents[]"), parseMultipartData(createDevisBodySchema), createDevis);
 router.post("/:id/convert-to-commande", requireCapability("convert"), convertDevisToCommande);
 router.post("/:id/revise", requireCapability("revise"), upload.array("documents[]"), parseMultipartData(updateDevisBodySchema), reviseDevis);

--- a/src/module/devis/services/devis-official-pdf.ts
+++ b/src/module/devis/services/devis-official-pdf.ts
@@ -1,0 +1,82 @@
+import { renderCerpDocument, type CerpLineRow } from "../../../shared/pdf/cerp-document";
+import { formatDateFR, money, percent } from "../../../shared/pdf/format-fr";
+import { issuerIdentityLine, issuerLegalMentions, type LegalParty } from "../../../shared/pdf/legal-mentions";
+import type { AuthoritativePdfArchiveRecord } from "../../../shared/authoritative-documents/authoritative-document.types";
+
+type DevisOfficialSnapshot = {
+  type: "CUSTOMER_QUOTE"; number: string; status: string; issued_at: string; valid_until: string | null;
+  version: string;
+  customer: {
+    code?: string | null; name: string | null;
+    address?: { name: string | null; street: string | null; house_number: string | null; postal_code: string | null; city: string | null; country: string | null } | null;
+  };
+  currency: string; public_comment: string | null;
+  lines: Array<{ position: number; reference: string | null; designation: string; quantity: string; unit: string | null; unit_price_ht: string; discount_pct: string | null; vat_pct: string | null; total_ht: string; total_ttc: string }>;
+  totals: { total_ht: string; total_ttc: string; global_discount_pct: string | null };
+  issuer: LegalParty;
+};
+
+function parseSnapshot(archive: AuthoritativePdfArchiveRecord): DevisOfficialSnapshot {
+  const source = archive.sourceSnapshot as Partial<DevisOfficialSnapshot>;
+  if (source.type !== "CUSTOMER_QUOTE" || !source.number || !Array.isArray(source.lines) || !source.totals || !source.issuer) throw new Error("DEVIS_OFFICIAL_SNAPSHOT_INVALID");
+  return source as DevisOfficialSnapshot;
+}
+
+function businessAddressLines(address: DevisOfficialSnapshot["customer"]["address"]): string[] {
+  if (!address) return [];
+  return [
+    address.name ?? "",
+    [address.house_number, address.street].filter(Boolean).join(" ").trim(),
+    [address.postal_code, address.city].filter(Boolean).join(" ").trim(),
+    address.country ?? "",
+  ].filter((line) => line.length > 0);
+}
+
+function archiveCreationDate(record: AuthoritativePdfArchiveRecord): Date {
+  const value = new Date(record.createdAt);
+  if (Number.isNaN(value.getTime())) throw new Error("DEVIS_ARCHIVE_CREATED_AT_INVALID");
+  return value;
+}
+
+export async function renderDevisOfficialPdf({ archive }: { archive: AuthoritativePdfArchiveRecord }): Promise<Buffer> {
+  const source = parseSnapshot(archive);
+  const customer = source.customer.name?.trim() || "Client";
+  const customerAddress = businessAddressLines(source.customer.address);
+  const draft = source.status.trim().toUpperCase() === "BROUILLON";
+  const archivedAt = archiveCreationDate(archive);
+  const rows: CerpLineRow[] = source.lines.map((line) => ({
+    cells: { pos: String(line.position), ref: line.reference ?? "—", designation: line.designation, quantity: line.quantity, unit: line.unit ?? "—", price: money(line.unit_price_ht, source.currency), vat: line.vat_pct ? percent(line.vat_pct) : "—", total: money(line.total_ht, source.currency) },
+    meta: line.discount_pct ? `Remise : ${percent(line.discount_pct)}` : null, metaColumn: "designation",
+  }));
+  return renderCerpDocument({
+    documentType: "Devis", name: source.number, code: source.number,
+    subtitle: `Version ${archive.documentVersion} · ${draft ? "Instantané de création" : `Émis le ${formatDateFR(source.issued_at)}`}`,
+    status: source.status, monogramName: customer, generatedAt: formatDateFR(archivedAt.toISOString()),
+    flag: draft ? "INTERNE / BROUILLON" : null,
+    watermark: draft ? "INTERNE / BROUILLON" : null,
+    footerNote: draft ? "Instantané interne GED — non opposable" : `Original GED · SHA-256 ${archive.snapshotSha256.slice(0, 16)}…`,
+    legalIdentity: issuerIdentityLine(source.issuer), legalMentions: issuerLegalMentions(source.issuer),
+    title: `Devis ${source.number}`, subject: draft ? "Instantané interne CERP — brouillon" : "Devis CERP", creationDate: archivedAt,
+  }, (ctx) => {
+    ctx.legalStrip([
+      { label: "Client", value: customer }, { label: "Code client", value: source.customer.code ?? null }, { label: "Validité", value: source.valid_until ? formatDateFR(source.valid_until) : null },
+      { label: "Statut", value: source.status }, { label: "Devise", value: source.currency },
+    ]);
+    if (customerAddress.length) ctx.addressCards([{ caption: "Adresse de facturation", lines: customerAddress, accent: true }]);
+    ctx.section("Prestations proposées");
+    ctx.linesTable({ columns: [
+      { key: "pos", label: "N°", flex: .35, align: "right" }, { key: "ref", label: "Référence", flex: 1 }, { key: "designation", label: "Désignation", flex: 2.7 },
+      { key: "quantity", label: "Qté", flex: .65, align: "right" }, { key: "unit", label: "U", flex: .4 }, { key: "price", label: "PU HT", flex: 1, align: "right" },
+      { key: "vat", label: "TVA", flex: .7, align: "right" }, { key: "total", label: "Total HT", flex: 1.1, align: "right" },
+    ], rows, emptyLabel: "Aucune ligne." });
+    ctx.section("Synthèse financière");
+    const top = ctx.y;
+    const bottom = Math.max(
+      ctx.field("Total HT", money(source.totals.total_ht, source.currency), 38, 135),
+      ctx.field("Remise globale", source.totals.global_discount_pct ? percent(source.totals.global_discount_pct) : "—", 208, 135),
+      ctx.field("Total TTC", money(source.totals.total_ttc, source.currency), 416, 140),
+    );
+    ctx.y = Math.max(top + 34, bottom + 7);
+    if (source.public_comment) ctx.notesSection("Conditions et observations", source.public_comment);
+  });
+}

--- a/src/module/devis/services/devis.service.ts
+++ b/src/module/devis/services/devis.service.ts
@@ -4,6 +4,8 @@ import type {
   UpdateDevisBodyDTO,
 } from "../validators/devis.validators";
 import type { UploadedDocument } from "../types/devis.types";
+import pool from "../../../config/database";
+import { getOfficialDocumentGenerationEnvelope, getOfficialPdfDto, readOfficialPdfBytes, recordOfficialPdfPrintIntent } from "../../../shared/authoritative-documents/authoritative-document.service";
 import {
   repoConvertDevisToCommande,
   repoCreateDevis,
@@ -17,6 +19,7 @@ import {
   repoListDevisVersions,
   repoReviseDevis,
   repoUpdateDevis,
+  repoQueueDevisOfficialDocument,
   type DevisWriteContext,
 } from "../repository/devis.repository";
 
@@ -65,3 +68,17 @@ export const svcConvertDevisToCommande = (
   id: number,
   opts: { expected_updated_at?: string } & DevisWriteContext = {}
 ) => repoConvertDevisToCommande(id, opts);
+
+const devisOfficialBase = (id: number) => `/devis/${id}/official-documents`;
+export const svcQueueDevisOfficialDocument = async (id: number, idempotencyKey: string, audit: NonNullable<DevisWriteContext["audit"]>, input: { source_revision: string; reissue_reason?: string | null }) => {
+  await repoQueueDevisOfficialDocument(id, idempotencyKey, audit, input);
+  return getOfficialDocumentGenerationEnvelope({ tx: pool, entityType: "devis", entityId: String(id), documentKind: "CUSTOMER_QUOTE", baseUrl: devisOfficialBase(id) });
+};
+export const svcListDevisOfficialDocuments = (id: number) =>
+  getOfficialDocumentGenerationEnvelope({ tx: pool, entityType: "devis", entityId: String(id), documentKind: "CUSTOMER_QUOTE", baseUrl: devisOfficialBase(id) });
+export const svcGetDevisOfficialDocument = (id: number, documentId: string) =>
+  getOfficialPdfDto({ tx: pool, entityType: "devis", entityId: String(id), documentKind: "CUSTOMER_QUOTE", archiveId: documentId, baseUrl: devisOfficialBase(id) });
+export const svcReadDevisOfficialDocument = (id: number, documentId: string, actorUserId: number, eventType: "AUTHORITATIVE_PDF_PREVIEWED" | "AUTHORITATIVE_PDF_DOWNLOADED") =>
+  readOfficialPdfBytes({ entityType: "devis", entityId: String(id), documentKind: "CUSTOMER_QUOTE", archiveId: documentId, actorUserId, eventType });
+export const svcRecordDevisOfficialPrint = (id: number, documentId: string, actorUserId: number) =>
+  recordOfficialPdfPrintIntent({ entityType: "devis", entityId: String(id), documentKind: "CUSTOMER_QUOTE", archiveId: documentId, actorUserId });

--- a/src/module/devis/validators/devis.validators.ts
+++ b/src/module/devis/validators/devis.validators.ts
@@ -72,6 +72,17 @@ export const devisDocumentIdParamsSchema = z.object({
   docId: z.string().uuid("docId must be a UUID"),
 });
 
+export const devisOfficialDocumentParamsSchema = z.object({
+  id: z.coerce.number().int().positive(),
+  documentId: z.string().uuid("documentId must be a UUID"),
+});
+
+export const devisOfficialDocumentBodySchema = z.object({
+  // Exact server-issued aggregate `updated_at` token; never a browser hash.
+  source_revision: z.string().trim().min(1).max(160, "source_revision is required"),
+  reissue_reason: z.string().trim().min(3).max(500).optional().nullable(),
+}).strict();
+
 export const devisArticleParamsSchema = z.object({
   articleId: z.string().uuid("articleId must be a UUID"),
 });

--- a/src/module/facturation/services/finance-document-render.test.ts
+++ b/src/module/facturation/services/finance-document-render.test.ts
@@ -226,11 +226,19 @@ describe("format des montants", () => {
     expect(money("182.40", "EUR")).toBe("182,40 €");
     expect(money("0.00", "EUR")).toBe("0,00 €");
     expect(money("1234567.89", "EUR")).toBe("1 234 567,89 €");
+    // A legacy numeric path can expose the IEEE-754 tail.  It must be rounded
+    // at the document boundary rather than printed verbatim in a legal PDF.
+    expect(money(6172.799999999999, "EUR")).toBe("6 172,80 €");
+    expect(money("2340.975", "EUR")).toBe("2 340,98 €");
+    expect(money("9.999", "EUR")).toBe("10,00 €");
+    expect(money("123456789012345678901234567890.125", "EUR"))
+      .toBe("123 456 789 012 345 678 901 234 567 890,13 €");
   });
 
   it("conserve le signe d'un montant negatif", () => {
     // Un montant negatif devenu positif ferait mentir la piece.
     expect(money("-313.96", "EUR")).toBe("-313,96 €");
+    expect(money("-9.999", "EUR")).toBe("-10,00 €");
   });
 
   it("rend un pourcentage a la francaise", () => {
@@ -242,8 +250,11 @@ describe("format des montants", () => {
     expect(money("100.00", "USD")).toBe("100,00 USD");
   });
 
-  it("ne perd pas une valeur qui n'est pas un nombre", () => {
-    expect(money("n/a", "EUR")).toBe("n/a €");
+  it("rejette une valeur monetaire invalide avant de produire un document", () => {
+    expect(() => money("n/a", "EUR")).toThrow("PDF_MONEY_INVALID");
+    expect(() => money("1e3", "EUR")).toThrow("PDF_MONEY_INVALID");
+    expect(() => money(Number.NaN, "EUR")).toThrow("PDF_MONEY_INVALID");
+    expect(() => money(Number.POSITIVE_INFINITY, "EUR")).toThrow("PDF_MONEY_INVALID");
   });
 });
 

--- a/src/module/fournisseurs/controllers/fournisseurs.controller.ts
+++ b/src/module/fournisseurs/controllers/fournisseurs.controller.ts
@@ -2,6 +2,7 @@ import type { Request, RequestHandler, Response } from "express"
 
 import { getDocumentStoragePath, resolveCerpStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
+import { createCreationSnapshotHandlers } from "../../../shared/authoritative-documents/creation-snapshot-http"
 import { sendSecureStoredFile } from "../../../shared/uploads/secure-download"
 import type { AuditContext } from "../repository/fournisseurs.repository"
 import {
@@ -87,6 +88,20 @@ function buildAuditContext(req: Request): AuditContext {
     client_session_id: clientSessionId,
   }
 }
+
+const fournisseurCreationSnapshotHandlers = createCreationSnapshotHandlers({
+  entityType: "fournisseur",
+  documentKind: "SUPPLIER_CREATION_SNAPSHOT",
+  parseEntityId: (req) => fournisseurIdParamSchema.parse({ params: req.params }).params.id,
+  // Same authenticated read path as the supplier card, before looking up an archive.
+  canReadEntity: async (id) => Boolean(await getFournisseurSVC(id)),
+  baseUrl: (id) => `/fournisseurs/${encodeURIComponent(id)}/creation-snapshot`,
+})
+
+export const getFournisseurCreationSnapshot = fournisseurCreationSnapshotHandlers.metadata
+export const previewFournisseurCreationSnapshot = fournisseurCreationSnapshotHandlers.preview
+export const downloadFournisseurCreationSnapshot = fournisseurCreationSnapshotHandlers.download
+export const printFournisseurCreationSnapshot = fournisseurCreationSnapshotHandlers.printIntent
 
 function isMulterFile(value: unknown): value is Express.Multer.File {
   if (typeof value !== "object" || value === null) return false

--- a/src/module/fournisseurs/repository/fournisseurs.repository.ts
+++ b/src/module/fournisseurs/repository/fournisseurs.repository.ts
@@ -45,6 +45,9 @@ import type {
   FournisseurStatus,
   Paginated,
 } from "../types/fournisseurs.types"
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service"
+import { authoritativePdfFilename } from "../../../shared/authoritative-documents/authoritative-document.filename"
+import { buildInternalCreationSnapshot } from "../../../shared/authoritative-documents/internal-creation-snapshot"
 
 export type AuditContext = {
   user_id: number
@@ -624,11 +627,11 @@ export async function repoCreateFournisseur(
     const id = ins.rows[0]?.id
     if (!id) throw new Error("Failed to create fournisseur")
 
-    if (body.domaines?.length) {
-      const normalized = body.domaines.map((d, i) => ({
-        ...d, is_primary: Boolean(d.is_primary) || (i === 0 && !body.domaines!.some((x) => x.is_primary)),
-      }))
-      for (const d of normalized) {
+    const normalizedDomaines = (body.domaines ?? []).map((d, i, domaines) => ({
+      ...d, is_primary: Boolean(d.is_primary) || (i === 0 && !domaines.some((x) => x.is_primary)),
+    }))
+    if (normalizedDomaines.length) {
+      for (const d of normalizedDomaines) {
         await client.query(
           `INSERT INTO public.fournisseur_domaine_lien (fournisseur_id, domaine_code, is_primary, notes, created_by, updated_by)
            VALUES ($1::uuid,$2,$3,$4,$5,$5) ON CONFLICT (fournisseur_id, domaine_code) DO NOTHING`,
@@ -653,6 +656,25 @@ export async function repoCreateFournisseur(
     await insertAuditLog(client, audit, {
       action: "fournisseurs.create", entity_type: "FOURNISSEUR", entity_id: id,
       details: { code, nom: body.nom },
+    })
+    const revision = await client.query<{ updated_at: string }>(
+      `SELECT updated_at::text AS updated_at FROM public.fournisseurs WHERE id = $1::uuid FOR UPDATE`, [id]
+    )
+    const sourceRevision = revision.rows[0]?.updated_at
+    if (!sourceRevision) throw new Error("SUPPLIER_CREATION_SNAPSHOT_REVISION_MISSING")
+    await queueCreationPdfArchive(client, {
+      entityType: "fournisseur", entityId: id, documentKind: "SUPPLIER_CREATION_SNAPSHOT", documentVersion: 1,
+      renderVersion: "internal-creation-snapshot-v1", idempotencyKey: `fournisseur:${id}:creation-snapshot:v1`,
+      title: `Création fiche fournisseur ${code}`, originalName: authoritativePdfFilename(["Fournisseur", code, "creation"]), sourceRevision,
+      sourceSnapshot: buildInternalCreationSnapshot({
+        entityLabel: "Fiche fournisseur", reference: code,
+        summary: [{ label: "Fournisseur", value: body.nom }, { label: "Code", value: code }, { label: "Statut", value: body.status ?? "actif" }, { label: "Créé par", value: String(audit.user_id) }],
+        sections: [
+          { title: "Coordonnées", rows: [{ label: "Email", value: body.email }, { label: "Téléphone", value: body.telephone }, { label: "SIRET", value: body.siret }, { label: "TVA", value: body.tva }, { label: "Site web", value: body.site_web }] },
+          { title: "Domaines", table: { columns: [{ key: "domaine", label: "Domaine" }, { key: "principal", label: "Principal" }], rows: normalizedDomaines.map((d) => ({ domaine: d.domaine_code, principal: d.is_primary ? "Oui" : "Non" })) } },
+          { title: "Adresses", table: { columns: [{ key: "type", label: "Type" }, { key: "adresse", label: "Adresse" }], rows: (body.adresses ?? []).map((a) => ({ type: a.type, adresse: [a.house_no, a.ligne1, a.ligne2, a.postcode, a.city, a.country].filter(Boolean).join(", ") })) } },
+        ],
+      }), actorUserId: audit.user_id,
     })
     await client.query("COMMIT")
     const created = await repoGetFournisseur(id)

--- a/src/module/fournisseurs/routes/fournisseurs.routes.ts
+++ b/src/module/fournisseurs/routes/fournisseurs.routes.ts
@@ -14,8 +14,10 @@ import {
   deleteFournisseurAdresse,
   deleteFournisseurCatalogueItem,
   deleteFournisseurContact,
+  downloadFournisseurCreationSnapshot,
   downloadFournisseurDocument,
   findDoublons,
+  getFournisseurCreationSnapshot,
   getFournisseur,
   listFournisseurAdresses,
   listFournisseurCatalogue,
@@ -27,6 +29,8 @@ import {
   listFournisseurs,
   removeFournisseurDocument,
   replaceFournisseurDomaines,
+  previewFournisseurCreationSnapshot,
+  printFournisseurCreationSnapshot,
   updateFournisseurAdresse,
   updateFournisseurCatalogueItem,
   updateFournisseurContact,
@@ -49,6 +53,11 @@ router.use(authenticateToken)
 router.get("/", listFournisseurs)
 router.get("/doublons", authorizeRole(...WRITE), findDoublons)
 router.get("/domaines", listFournisseurDomaines)
+// Immutable internal creation snapshot; reads retain the supplier-card policy.
+router.get("/:id/creation-snapshot", getFournisseurCreationSnapshot)
+router.get("/:id/creation-snapshot/:documentId/preview", previewFournisseurCreationSnapshot)
+router.get("/:id/creation-snapshot/:documentId/download", downloadFournisseurCreationSnapshot)
+router.post("/:id/creation-snapshot/:documentId/print-intents", printFournisseurCreationSnapshot)
 router.get("/:id", getFournisseur)
 router.get("/:id/events", listFournisseurEvents)
 

--- a/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
+++ b/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
@@ -5,6 +5,7 @@ import { repoFindIdempotentPieceCreate } from "../repository/create-drafts.repos
 import { generatePieceTechniqueBusinessCode } from "../../../shared/codes/code-generator.service"
 import { getDocumentStoragePath, resolveCerpStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
+import { createCreationSnapshotHandlers } from "../../../shared/authoritative-documents/creation-snapshot-http"
 import { sendSecureStoredFile } from "../../../shared/uploads/secure-download"
 import {
   achatIdParamSchema,
@@ -113,6 +114,21 @@ function buildAuditContext(req: Request): AuditContext {
     client_session_id: clientSessionId,
   }
 }
+
+const pieceTechniqueCreationSnapshotHandlers = createCreationSnapshotHandlers({
+  entityType: "piece-technique",
+  documentKind: "TECHNICAL_PIECE_CREATION_SNAPSHOT",
+  parseEntityId: (req) => idParamSchema.parse({ params: req.params }).params.id,
+  // This is intentionally only the root card check: versions, BOM, operations
+  // and other child changes never issue another creation snapshot.
+  canReadEntity: async (id) => Boolean(await getPieceTechniqueSVC(id, new Set())),
+  baseUrl: (id) => `/pieces-techniques/${encodeURIComponent(id)}/creation-snapshot`,
+})
+
+export const getPieceTechniqueCreationSnapshot = pieceTechniqueCreationSnapshotHandlers.metadata
+export const previewPieceTechniqueCreationSnapshot = pieceTechniqueCreationSnapshotHandlers.preview
+export const downloadPieceTechniqueCreationSnapshot = pieceTechniqueCreationSnapshotHandlers.download
+export const printPieceTechniqueCreationSnapshot = pieceTechniqueCreationSnapshotHandlers.printIntent
 
 const IDEMPOTENCY_KEY_RE = /^[A-Za-z0-9._:-]{8,128}$/
 

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -8,6 +8,8 @@ import db from "../../../config/database";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { generatePieceTechniqueBusinessCode } from "../../../shared/codes/code-generator.service";
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
+import { buildTechnicalPieceCreationSnapshotInput } from "../../../shared/authoritative-documents/technical-piece-creation-snapshot";
 import { transferSecureUploadToDestination } from "../../../shared/uploads/secure-upload";
 import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -1900,6 +1902,26 @@ export async function repoCreatePieceTechnique(
       );
     }
 
+    // This is deliberately an internal creation record, not the controlled
+    // technical dossier. Child BOM/operation/purchase mutations are not
+    // creation events and therefore never enqueue this document kind.
+    await queueCreationPdfArchive(client, buildTechnicalPieceCreationSnapshotInput({
+      id: pieceId,
+      code: generatedCode,
+      designation: core.designation,
+      clientId: core.client_id,
+      clientName: core.client_name,
+      status: core.statut,
+      sourceRevision: core.updated_at,
+      actorUserId: audit.user_id,
+      articleId: core.article_id,
+      familyId: core.famille_id,
+      pieceVersion: core.version_number,
+      planReference: body.plan_reference ?? null,
+      externalIndex: indiceExterne,
+      internalVersion: body.plan_reference ? 1 : null,
+    }));
+
     await client.query("COMMIT");
     return { piece, replayed: false };
   } catch (err) {
@@ -2720,6 +2742,24 @@ export async function repoDuplicatePieceTechnique(id: string, userId: number | n
       `,
       [newId, userId, null, statut, `Duplicated from piece technique ${id}`]
     );
+
+    // The duplicate is a distinct root aggregate. Queue only after all copied
+    // BOM/operation/purchase rows and its creation history exist, so a queue
+    // failure rolls the entire duplicate back with the same transaction.
+    await queueCreationPdfArchive(client, buildTechnicalPieceCreationSnapshotInput({
+      id: newId,
+      code: newRow.code_piece,
+      designation: newRow.designation,
+      clientId: newRow.client_id,
+      clientName: newRow.client_name,
+      status: statut,
+      sourceRevision: newRow.updated_at,
+      actorUserId: userId,
+      articleId: null,
+      familyId: null,
+      pieceVersion: 1,
+      copiedFromCode: o.code_piece,
+    }));
 
     await client.query("COMMIT");
     return repoGetPieceTechnique(newId, includesSetForCreate());

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -49,9 +49,11 @@ import {
   deleteBomLine,
   deleteOperation,
   duplicatePieceTechnique,
+  downloadPieceTechniqueCreationSnapshot,
   downloadPieceTechniqueDocument,
   getPieceTechniqueFabricationTree,
   getPieceTechnique,
+  getPieceTechniqueCreationSnapshot,
   linkPieceTechniqueAffaire,
   listAffairePieceTechniques,
   listPieceTechniqueAffaires,
@@ -64,6 +66,8 @@ import {
   reorderBom,
   reorderOperations,
   removePieceTechniqueDocument,
+  previewPieceTechniqueCreationSnapshot,
+  printPieceTechniqueCreationSnapshot,
   updateAchat,
   updateBomLine,
   updateOperation,
@@ -185,6 +189,12 @@ router.get("/:id/arborescence", validate(idParamSchema), getPieceTechniqueFabric
 router.get("/:id/document-dossier", validate(idParamSchema), getPieceDocumentDossier)
 router.get("/:id/document-dossier/pdf", validate(idParamSchema), downloadPieceDocumentDossierPdf)
 router.post("/:id/piece-critique", validate(idParamSchema), validate(setPieceCritiqueSchema), setPieceCritique)
+// Root-only immutable creation snapshot. No child version/BOM/operation route
+// may create or reissue this archive artifact.
+router.get("/:id/creation-snapshot", validate(idParamSchema), getPieceTechniqueCreationSnapshot)
+router.get("/:id/creation-snapshot/:documentId/preview", validate(idParamSchema), previewPieceTechniqueCreationSnapshot)
+router.get("/:id/creation-snapshot/:documentId/download", validate(idParamSchema), downloadPieceTechniqueCreationSnapshot)
+router.post("/:id/creation-snapshot/:documentId/print-intents", validate(idParamSchema), printPieceTechniqueCreationSnapshot)
 router.get("/:id", validate(idParamSchema), getPieceTechnique)
 router.patch("/:id", validate(idParamSchema), validate(updatePieceTechniqueSchema), updatePieceTechnique)
 router.delete("/:id", requireDeleteRole, validate(idParamSchema), deletePieceTechnique)

--- a/src/module/production/controllers/production.controller.ts
+++ b/src/module/production/controllers/production.controller.ts
@@ -2,6 +2,7 @@ import type { Request } from "express";
 import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { asyncHandler } from "../../../utils/asyncHandler";
 import { HttpError } from "../../../utils/httpError";
+import { createCreationSnapshotHandlers } from "../../../shared/authoritative-documents/creation-snapshot-http";
 import type { AuditContext } from "../repository/production.repository";
 import {
   createMachineOnboardingSchema,
@@ -127,6 +128,26 @@ export function buildAuditContext(req: Request): AuditContext {
     client_session_id: clientSessionId,
   };
 }
+
+const ofCreationSnapshotHandlers = createCreationSnapshotHandlers({
+  entityType: "ordre-fabrication",
+  documentKind: "OF_CREATION_SNAPSHOT",
+  parseEntityId: (req) => String(ofIdParamSchema.parse({ params: req.params }).params.id),
+  // Match GET /production/ofs/:id, including its existing user-aware root lookup.
+  canReadEntity: async (id, req) =>
+    Boolean(
+      await svcGetOrdreFabrication({
+        id: Number(id),
+        user_id: typeof req.user?.id === "number" ? req.user.id : undefined,
+      })
+    ),
+  baseUrl: (id) => `/production/ofs/${encodeURIComponent(id)}/creation-snapshot`,
+});
+
+export const getOfCreationSnapshot = ofCreationSnapshotHandlers.metadata;
+export const previewOfCreationSnapshot = ofCreationSnapshotHandlers.preview;
+export const downloadOfCreationSnapshot = ofCreationSnapshotHandlers.download;
+export const printOfCreationSnapshot = ofCreationSnapshotHandlers.printIntent;
 
 function hasMachineCostMutation(value: object): boolean {
   return ["hourly_rate", "hourly_rate_source", "hourly_rate_effective_at"].some((key) =>

--- a/src/module/production/domain/of-creation-pdf.test.ts
+++ b/src/module/production/domain/of-creation-pdf.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+const queue = vi.hoisted(() => vi.fn());
+vi.mock("../../../shared/authoritative-documents/authoritative-document.service", () => ({ queueCreationPdfArchive: queue }));
+
+import { queueRootOfCreationPdf } from "./of-creation-pdf";
+
+type OfCreationRow = {
+  id: string; numero: string; root_of_id: string | null; parent_of_id: string | null; generation_level: number;
+  piece_technique_id: string | null; piece_technique_version_id: string | null;
+  technical_snapshot_sha256: string | null; commande_id: string | null; affaire_id: string | null; client_id: string | null; client_name: string | null;
+  quantite_lancee: number; statut: string; priority: string; date_lancement_prevue: string | null; date_fin_prevue: string | null;
+  updated_at: string;
+};
+
+const root: OfCreationRow = {
+  id: "42", numero: "OF-00042", root_of_id: "42", parent_of_id: null, generation_level: 0,
+  piece_technique_id: "11111111-1111-1111-1111-111111111111", piece_technique_version_id: "22222222-2222-2222-2222-222222222222",
+  technical_snapshot_sha256: "a".repeat(64), commande_id: "18", affaire_id: "9", client_id: "001", client_name: "Client test",
+  quantite_lancee: 12, statut: "BROUILLON", priority: "NORMAL", date_lancement_prevue: "2026-08-23", date_fin_prevue: null,
+  updated_at: "2026-08-23T10:00:00.000000Z",
+};
+
+function txFor(row: OfCreationRow | null) {
+  return {
+    query: vi.fn(async (sql: unknown) => {
+      const statement = String(sql);
+      if (!statement.includes("FROM public.ordres_fabrication")) {
+        return { rows: [{ phase: 10, designation: "Usinage", status: "A_FAIRE", cf_code_snapshot: "USI" }] };
+      }
+      // Model the actual root-only SELECT predicate: a child is present in the
+      // database fixture but cannot be returned to the queue helper.
+      const isRoot = row?.parent_of_id === null && (row.root_of_id === null || row.root_of_id === row.id);
+      return { rows: isRoot && row ? [row] : [] };
+    }),
+  };
+}
+
+describe("root OF creation PDF queue", () => {
+  it("queues one stable, internal-safe snapshot for a root", async () => {
+    queue.mockReset(); queue.mockResolvedValue(undefined);
+    const tx = txFor(root);
+    await queueRootOfCreationPdf(tx as never, { ofId: 42, actorUserId: 7 });
+    expect(queue).toHaveBeenCalledTimes(1);
+    const input = queue.mock.calls[0]?.[1];
+    expect(input).toMatchObject({ entityType: "ordre-fabrication", entityId: "42", documentKind: "OF_CREATION_SNAPSHOT", documentVersion: 1, idempotencyKey: "ordre-fabrication:42:creation:v1", sourceRevision: root.updated_at, actorUserId: 7 });
+    expect(input.sourceSnapshot).toMatchObject({ type: "INTERNAL_CREATION_SNAPSHOT", reference: "OF-00042" });
+    expect(JSON.stringify(input.sourceSnapshot)).not.toContain("technical_snapshot\"");
+  });
+
+  it("excludes a child OF before it can enqueue", async () => {
+    queue.mockReset();
+    const child: OfCreationRow = {
+      ...root,
+      id: "43",
+      numero: "OF-00043",
+      root_of_id: "42",
+      parent_of_id: "42",
+      generation_level: 1,
+    };
+    const tx = txFor(child);
+    await queueRootOfCreationPdf(tx as never, { ofId: 43, actorUserId: 7 });
+    expect(queue).not.toHaveBeenCalled();
+    expect(tx.query).toHaveBeenCalledWith(
+      expect.stringContaining("o.parent_of_id IS NULL"),
+      [43],
+    );
+  });
+
+  it("propagates queue failures so the caller transaction rolls back", async () => {
+    queue.mockReset(); queue.mockRejectedValueOnce(new Error("outbox unavailable"));
+    await expect(queueRootOfCreationPdf(txFor(root) as never, { ofId: 42, actorUserId: 7 })).rejects.toThrow("outbox unavailable");
+  });
+});

--- a/src/module/production/domain/of-creation-pdf.ts
+++ b/src/module/production/domain/of-creation-pdf.ts
@@ -1,0 +1,113 @@
+import type { PoolClient } from "pg";
+
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
+import { buildInternalCreationSnapshot } from "../../../shared/authoritative-documents/internal-creation-snapshot";
+
+type Queryable = Pick<PoolClient, "query">;
+
+type RootOfRow = {
+  id: string;
+  numero: string;
+  root_of_id: string | null;
+  parent_of_id: string | null;
+  generation_level: number;
+  piece_technique_id: string | null;
+  piece_technique_version_id: string | null;
+  technical_snapshot_sha256: string | null;
+  commande_id: string | null;
+  affaire_id: string | null;
+  client_id: string | null;
+  client_name: string | null;
+  quantite_lancee: number;
+  statut: string;
+  priority: string;
+  date_lancement_prevue: string | null;
+  date_fin_prevue: string | null;
+  updated_at: string;
+};
+
+/**
+ * Queues exactly one internal creation snapshot for a meaningful OF root.
+ * The test in SQL (rather than only caller convention) ensures child OFs can
+ * never accidentally acquire their own creation PDF when a recursive tree is
+ * generated.  Queueing is intentionally part of the caller's DB transaction.
+ */
+export async function queueRootOfCreationPdf(
+  tx: Queryable,
+  params: { ofId: number; actorUserId: number | null }
+): Promise<void> {
+  const rootRes = await tx.query<RootOfRow>(
+    `
+      SELECT o.id::text AS id,
+             o.numero,
+             o.root_of_id::text AS root_of_id,
+             o.parent_of_id::text AS parent_of_id,
+             COALESCE(o.generation_level, 0)::int AS generation_level,
+             o.piece_technique_id::text AS piece_technique_id,
+             o.piece_technique_version_id::text AS piece_technique_version_id,
+             o.technical_snapshot_sha256,
+             o.commande_id::text AS commande_id,
+             o.affaire_id::text AS affaire_id,
+             o.client_id::text AS client_id,
+             c.company_name AS client_name,
+             o.quantite_lancee::float8 AS quantite_lancee,
+             o.statut::text AS statut,
+             o.priority::text AS priority,
+             o.date_lancement_prevue::text AS date_lancement_prevue,
+             o.date_fin_prevue::text AS date_fin_prevue,
+             to_char(o.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at
+        FROM public.ordres_fabrication o
+        LEFT JOIN public.clients c ON c.client_id = o.client_id
+       WHERE o.id = $1::bigint
+         AND o.parent_of_id IS NULL
+         AND (o.root_of_id IS NULL OR o.root_of_id = o.id)
+       FOR UPDATE
+    `,
+    [params.ofId]
+  );
+  const root = rootRes.rows[0];
+  if (!root) return;
+  if (!root.updated_at) throw new Error("OF_CREATION_PDF_SOURCE_REVISION_MISSING");
+
+  const operations = await tx.query<Record<string, unknown>>(
+    `SELECT phase::int AS phase, designation, status::text AS status,
+            cf_code_snapshot, numero_programme
+       FROM public.of_operations
+      WHERE of_id = $1::bigint
+      ORDER BY phase ASC, id ASC`,
+    [root.id]
+  );
+
+  await queueCreationPdfArchive(tx, {
+    entityType: "ordre-fabrication",
+    entityId: root.id,
+    documentKind: "OF_CREATION_SNAPSHOT",
+    documentVersion: 1,
+    renderVersion: "of-creation-snapshot-v1",
+    idempotencyKey: `ordre-fabrication:${root.id}:creation:v1`,
+    title: `Création OF ${root.numero}`,
+    originalName: `of-${root.id}-creation-v1.pdf`,
+    sourceRevision: root.updated_at,
+    sourceSnapshot: buildInternalCreationSnapshot({
+      entityLabel: "Ordre de fabrication — instantané de création",
+      reference: root.numero,
+      summary: [
+        { label: "OF", value: root.numero }, { label: "Statut initial", value: root.statut },
+        { label: "Priorité", value: root.priority }, { label: "Quantité lancée", value: root.quantite_lancee },
+        { label: "Commande", value: root.commande_id }, { label: "Affaire", value: root.affaire_id },
+        { label: "Client", value: root.client_name ?? root.client_id }, { label: "Version pièce", value: root.piece_technique_version_id },
+      ],
+      sections: [
+        { title: "Pièce technique", rows: [
+          { label: "Référence", value: root.piece_technique_id }, { label: "Version", value: root.piece_technique_version_id },
+          { label: "Empreinte du snapshot", value: root.technical_snapshot_sha256 },
+        ] },
+        { title: "Planification", rows: [
+          { label: "Début prévu", value: root.date_lancement_prevue }, { label: "Fin prévue", value: root.date_fin_prevue },
+        ] },
+        { title: "Opérations", table: { columns: [{ key: "phase", label: "Phase" }, { key: "designation", label: "Désignation" }, { key: "status", label: "Statut" }, { key: "workcenter", label: "Centre" }], rows: operations.rows.map((operation) => ({ phase: operation.phase == null ? null : String(operation.phase), designation: operation.designation == null ? null : String(operation.designation), status: operation.status == null ? null : String(operation.status), workcenter: operation.cf_code_snapshot == null ? null : String(operation.cf_code_snapshot) })) } },
+      ],
+    }),
+    actorUserId: params.actorUserId,
+  });
+}

--- a/src/module/production/repository/production-generation.repository.ts
+++ b/src/module/production/repository/production-generation.repository.ts
@@ -24,6 +24,7 @@ import {
 } from "../domain/of-generation";
 import { roleHasOfCapability } from "../domain/of-rbac";
 import { enqueueProductionOfChanged, productionRealtimeActionFromAudit } from "./production-realtime.repository";
+import { queueRootOfCreationPdf } from "../domain/of-creation-pdf";
 
 async function insertAuditLog(tx: Queryable, audit: AuditContext, entry: {
   action: string;
@@ -562,6 +563,12 @@ export async function repoGenerateOfs(params: {
         "La définition technique a changé depuis l'aperçu. Régénérez l'aperçu avant de confirmer.",
         { expected_source_hash: params.body.expected_source_hash, actual_source_hash: generated.source_hash }
       );
+    }
+
+    // A recursive batch contains children too; the helper has a DB-level root
+    // guard and this filter documents the one-snapshot-per-root invariant.
+    for (const root of generated.ofs.filter((of) => of.parent_of_id === null)) {
+      await queueRootOfCreationPdf(client, { ofId: root.id, actorUserId: params.audit.user_id });
     }
 
     await insertAuditLog(client, params.audit, {

--- a/src/module/production/repository/production.repository.ts
+++ b/src/module/production/repository/production.repository.ts
@@ -6,6 +6,7 @@ import pool from "../../../config/database";
 import { generateMachineCode, generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
 import { promoteSecureUpload } from "../../../shared/uploads/secure-upload";
 import { withUploadTransaction, type UploadCommitReconciliation } from "../../../shared/uploads/upload-transaction";
+import { queueRootOfCreationPdf } from "../domain/of-creation-pdf";
 import { ensureImagesSubdir, normalizeStoredImagePath } from "../../../utils/imageStorage";
 import { withRealtimeOutboxTransaction } from "../../../shared/realtime/realtime-outbox-transaction";
 import { HttpError } from "../../../utils/httpError";
@@ -3404,6 +3405,11 @@ export async function repoCreateOrdreFabrication(params: {
         operations_count: operationsCount,
       },
     });
+
+    // Keep the creation snapshot in the same transaction as the OF and its
+    // operation/technical snapshots: GED queueing must never outlive a rolled
+    // back OF creation.
+    await queueRootOfCreationPdf(client, { ofId, actorUserId: params.audit.user_id });
 
       return ofId;
     });

--- a/src/module/production/routes/production.routes.ts
+++ b/src/module/production/routes/production.routes.ts
@@ -17,8 +17,10 @@ import {
   createOfReceipt,
   createOrdreFabrication,
   createPoste,
+  downloadOfCreationSnapshot,
   generateOfs,
   getOfReceiptContext,
+  getOfCreationSnapshot,
   getOfTechnicalSnapshot,
   getOfTraceability,
   getOrdreFabrication,
@@ -29,6 +31,8 @@ import {
   listMachines,
   listPostes,
   previewOfGeneration,
+  previewOfCreationSnapshot,
+  printOfCreationSnapshot,
   reorderOfOperations,
   startOfOperationTimeLog,
   stopOfOperationTimeLog,
@@ -212,6 +216,12 @@ router.post("/ofs/generate/preview", requireOfCapability("generate"), previewOfG
 router.post("/ofs/generate", requireOfCapability("generate"), generateOfs);
 router.get("/ofs/:id/tree", getOrdreFabricationTree);
 router.get("/ofs/:id/technical-snapshot", getOfTechnicalSnapshot);
+// Internal creation snapshot, filed automatically on root creation. Same read
+// middleware as the OF card; no route can issue or reissue it.
+router.get("/ofs/:id/creation-snapshot", getOfCreationSnapshot);
+router.get("/ofs/:id/creation-snapshot/:documentId/preview", previewOfCreationSnapshot);
+router.get("/ofs/:id/creation-snapshot/:documentId/download", downloadOfCreationSnapshot);
+router.post("/ofs/:id/creation-snapshot/:documentId/print-intents", printOfCreationSnapshot);
 router.get("/ofs/:id", getOrdreFabrication);
 router.post("/ofs", requireOfCapability("create"), createOrdreFabrication);
 router.patch("/ofs/:id", requireAnyOfCapability(["edit_prelaunch", "launch", "operate", "cancel", "archive"]), updateOrdreFabrication);

--- a/src/module/stock/controllers/stock.controller.ts
+++ b/src/module/stock/controllers/stock.controller.ts
@@ -2,6 +2,7 @@ import type { Request, RequestHandler, Response } from "express";
 import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 
 import { previewArticleCode } from "../../../shared/codes/code-generator.service";
+import { createCreationSnapshotHandlers } from "../../../shared/authoritative-documents/creation-snapshot-http";
 import { getDocumentStoragePath, resolveCerpStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
@@ -162,6 +163,21 @@ import {
 import { canViewArticleCosts } from "../stock-article.permissions";
 import { removeTemporaryArticleDocuments, validateArticleDocuments } from "../services/article-document-validation";
 import { UploadDestinationCleanupError } from "../../../shared/uploads/secure-upload";
+
+const stockArticleCreationSnapshotHandlers = createCreationSnapshotHandlers({
+  entityType: "stock-article",
+  documentKind: "STOCK_ARTICLE_CREATION_SNAPSHOT",
+  parseEntityId: (req) => idParamSchema.parse({ params: req.params }).params.id,
+  // Only the article root establishes archive visibility. Lots, movements and
+  // inventory sessions intentionally never receive creation-snapshot PDFs.
+  canReadEntity: async (id) => Boolean(await getStockArticleSVC(id, false)),
+  baseUrl: (id) => `/stock/articles/${encodeURIComponent(id)}/creation-snapshot`,
+});
+
+export const getStockArticleCreationSnapshot = stockArticleCreationSnapshotHandlers.metadata;
+export const previewStockArticleCreationSnapshot = stockArticleCreationSnapshotHandlers.preview;
+export const downloadStockArticleCreationSnapshot = stockArticleCreationSnapshotHandlers.download;
+export const printStockArticleCreationSnapshot = stockArticleCreationSnapshotHandlers.printIntent;
 
 export const listStockInventorySessions: RequestHandler = async (req, res, next) => {
   try {

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -11,6 +11,8 @@ import {
   generateTransactionalBusinessCode,
   generatePieceTechniqueBusinessCode,
 } from "../../../shared/codes/code-generator.service";
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
+import { buildStockArticleCreationSnapshotInput } from "../../../shared/authoritative-documents/stock-article-creation-snapshot";
 import {
   assertMaterialPreviewFresh,
   buildMaterialArticleCode,
@@ -48,6 +50,7 @@ import type {
   ArticleCategory,
   ArticleBusinessCategory,
   ArticleTechnicalVersion,
+  ArticleWorkflowStatus,
   ArticleWhereUsedItem,
   Paginated,
   StockAnalytics,
@@ -3237,7 +3240,44 @@ export type CreatedArticleSummary = {
   family_code: string;
   stock_managed: boolean;
   lot_tracking: boolean;
+  designation: string;
+  unite: string | null;
+  status: ArticleWorkflowStatus;
+  is_active: boolean;
 };
+
+/**
+ * Enqueues a stock article's immutable creation snapshot inside its owning
+ * transaction. Incidental historical-import rows remain excluded because only
+ * explicit user-facing creation commands call this helper.
+ */
+export async function queueStockArticleCreationSnapshotTx(
+  client: PoolClient,
+  created: CreatedArticleSummary,
+  actorUserId: number
+): Promise<void> {
+  const sourceRevision = await client.query<{ updated_at: string }>(
+    `SELECT updated_at::text AS updated_at FROM public.articles WHERE id = $1::uuid FOR SHARE`,
+    [created.id]
+  );
+  const updatedAt = sourceRevision.rows[0]?.updated_at;
+  if (!updatedAt) throw new Error("STOCK_ARTICLE_CREATION_SOURCE_REVISION_MISSING");
+  await queueCreationPdfArchive(client, buildStockArticleCreationSnapshotInput({
+    id: created.id,
+    code: created.code,
+    designation: created.designation,
+    articleType: created.article_type,
+    articleCategory: created.article_category,
+    familyCode: created.family_code,
+    unit: created.unite,
+    status: created.status,
+    stockManaged: created.stock_managed,
+    lotTracking: created.lot_tracking,
+    isActive: created.is_active,
+    sourceRevision: updatedAt,
+    actorUserId,
+  }));
+}
 
 /**
  * Création d'article DANS une transaction déjà ouverte par l'appelant.
@@ -3321,7 +3361,7 @@ export async function repoCreateArticleTx(
 
   const articleId = crypto.randomUUID();
 
-  const res = await client.query<{ id: string }>(
+  const res = await client.query<{ id: string; updated_at: string }>(
     `
       INSERT INTO public.articles (
         id,
@@ -3331,7 +3371,7 @@ export async function repoCreateArticleTx(
         created_by, updated_by
       )
       VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9::uuid,$10,$11::uuid,$12::uuid,$13,$14,$15,$16,$17,$18,$19,$20,$21,$21)
-      RETURNING id::text AS id
+      RETURNING id::text AS id, updated_at::text AS updated_at
     `,
     [
       articleId,
@@ -3358,7 +3398,8 @@ export async function repoCreateArticleTx(
     ]
   );
 
-  const id = res.rows[0]?.id;
+  const createdRow = res.rows[0];
+  const id = createdRow?.id;
   if (!id) throw new Error("Failed to create article");
   await syncArticleCategories(client, id, normalized.article_categories, audit.user_id);
 
@@ -3407,6 +3448,10 @@ export async function repoCreateArticleTx(
     family_code: normalized.family_code,
     stock_managed: normalized.stock_managed,
     lot_tracking: normalized.lot_tracking,
+    designation,
+    unite: canonicalUnit,
+    status: normalized.status,
+    is_active: body.is_active,
   };
 }
 
@@ -3451,6 +3496,8 @@ export async function repoCreateArticle(
         [idempotencyKey, requestHash, id]
       );
     }
+
+    await queueStockArticleCreationSnapshotTx(client, created, audit.user_id);
 
     await client.query("COMMIT");
 
@@ -5530,6 +5577,11 @@ async function ensureHistoricalPositionTx(client: PoolClient, kind: "PF" | "MP",
   return { magasinId, emplacementId, ...map };
 }
 
+/**
+ * OLD recovery/import scaffolding is intentionally excluded from creation-PDF
+ * automation: an import may materialize many historical technical roots, and
+ * emitting a GED snapshot for each would create incidental mass archive output.
+ */
 async function ensureHistoricalPieceTechniqueTx(client: PoolClient, input: { clientNumber: string; reference: string; indice: string | null; designation: string }, audit: AuditContext) {
   const customer = await client.query<{ client_id: string; client_code: string; company_name: string | null }>(
     `SELECT client_id::text AS client_id, client_code, company_name FROM public.clients WHERE client_code = $1 OR client_id = $1 LIMIT 1 FOR UPDATE`, [input.clientNumber]

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -27,6 +27,7 @@ import {
   deactivateStockMagasin,
   activateStockMagasin,
   createStockMovement,
+  downloadStockArticleCreationSnapshot,
   compensateStockMovement,
   previewStockMovementCompensation,
   previewStockMovement,
@@ -35,6 +36,7 @@ import {
   getStockAnalytics,
   getStockInventorySession,
   getStockArticle,
+  getStockArticleCreationSnapshot,
   listStockArticleCategories,
   listStockUnits,
   listStockArticleFamilies,
@@ -60,6 +62,8 @@ import {
   listStockMovementDocuments,
   listStockMovements,
   postStockMovement,
+  previewStockArticleCreationSnapshot,
+  printStockArticleCreationSnapshot,
   removeStockArticleDocument,
   removeStockMovementDocument,
   upsertStockInventorySessionLine,
@@ -154,6 +158,11 @@ router.get("/articles/export.csv", requireStockCapability("read"), exportStockAr
 // comme un identifiant d'article.
 router.get("/articles/similaires", requireStockCapability("read"), listSimilarStockArticles);
 router.post("/articles", requireArticleWrite, createStockArticle);
+// Automatic root-creation snapshot only; movements/lots remain excluded by design.
+router.get("/articles/:id/creation-snapshot", requireStockCapability("read"), getStockArticleCreationSnapshot);
+router.get("/articles/:id/creation-snapshot/:documentId/preview", requireStockCapability("read"), previewStockArticleCreationSnapshot);
+router.get("/articles/:id/creation-snapshot/:documentId/download", requireStockCapability("read"), downloadStockArticleCreationSnapshot);
+router.post("/articles/:id/creation-snapshot/:documentId/print-intents", requireStockCapability("read"), printStockArticleCreationSnapshot);
 router.get("/articles/:id", requireStockCapability("read"), getStockArticle);
 router.patch("/articles/:id", requireArticleWrite, updateStockArticle);
 router.post("/articles/:id/validate", requireArticleApprove, validateStockArticle);

--- a/src/module/surface-finish/repository/surface-finish-resolution.repository.ts
+++ b/src/module/surface-finish/repository/surface-finish-resolution.repository.ts
@@ -12,7 +12,10 @@ import type { PoolClient } from "pg";
 import db from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
 import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository";
-import { repoCreateArticleTx } from "../../stock/repository/stock.repository";
+import {
+  queueStockArticleCreationSnapshotTx,
+  repoCreateArticleTx,
+} from "../../stock/repository/stock.repository";
 import type { CreateArticleBodyDTO } from "../../stock/validators/stock.validators";
 import {
   assertArticleDecisionConsistent,
@@ -835,6 +838,7 @@ export async function repoConfirmStockFinishArticle(
           audit.user_id,
         ]
       );
+      await queueStockArticleCreationSnapshotTx(client, created, audit.user_id);
     }
 
     await insertFinishAudit(client, audit, "finitions.stock-article.confirm", "articles_traitement", articleId, {
@@ -1292,6 +1296,7 @@ export async function repoConfirmOperationFinish(
           audit.user_id,
         ]
       );
+      await queueStockArticleCreationSnapshotTx(client, created, audit.user_id);
     }
 
     /* 8) Exigence de finition — créée ou mise à jour, jamais dupliquée. */

--- a/src/shared/authoritative-documents/authoritative-document.filename.ts
+++ b/src/shared/authoritative-documents/authoritative-document.filename.ts
@@ -1,0 +1,19 @@
+/**
+ * Files in the GED are an interface, not a storage key. Keep filenames stable,
+ * printable and safe across Windows, Linux and archive exports.
+ */
+export function authoritativePdfFilename(parts: readonly string[]): string {
+  const normalized = parts
+    .map((value) => value.normalize("NFKD").replace(/[\u0300-\u036f]/g, ""))
+    .map((value) => value.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, ""))
+    .filter(Boolean)
+    .join("-")
+    .slice(0, 176);
+  return `${normalized || "document"}.pdf`;
+}
+
+export function assertAuthoritativePdfFilename(value: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,180}\.pdf$/.test(value)) {
+    throw new Error("AUTHORITATIVE_PDF_FILENAME_INVALID");
+  }
+}

--- a/src/shared/authoritative-documents/authoritative-document.repository.ts
+++ b/src/shared/authoritative-documents/authoritative-document.repository.ts
@@ -1,0 +1,250 @@
+import type { PoolClient } from "pg";
+
+import { HttpError } from "../../utils/httpError";
+import type { ArchiveQueueItem, AuthoritativePdfArchiveRecord, AuthoritativePdfCreationInput } from "./authoritative-document.types";
+
+type ArchiveRow = {
+  id: string; entity_type: string; entity_id: string; document_kind: string; document_version: number | string; render_version: string;
+  idempotency_key: string; title: string; original_name: string; source_snapshot: Record<string, unknown>;
+  source_revision: string; snapshot_sha256: string; pdf_sha256: string | null; pdf_size_bytes: string | null;
+  ged_document_id: string | null; ged_version_id: string | null; archived_at: string | null; created_at: string; created_by: number | null;
+};
+
+function mapArchive(row: ArchiveRow): AuthoritativePdfArchiveRecord {
+  return {
+    id: String(row.id), entityType: row.entity_type, entityId: row.entity_id,
+    documentKind: row.document_kind, documentVersion: Number(row.document_version), renderVersion: row.render_version,
+    idempotencyKey: row.idempotency_key, title: row.title, originalName: row.original_name,
+    sourceRevision: row.source_revision, sourceSnapshot: row.source_snapshot, snapshotSha256: row.snapshot_sha256,
+    pdfSha256: row.pdf_sha256, pdfSizeBytes: row.pdf_size_bytes == null ? null : Number(row.pdf_size_bytes),
+    gedDocumentId: row.ged_document_id, gedVersionId: row.ged_version_id,
+    archivedAt: row.archived_at, createdAt: row.created_at, actorUserId: row.created_by,
+  };
+}
+
+const ARCHIVE_COLUMNS = `id::text, entity_type, entity_id, document_kind, document_version, render_version,
+  idempotency_key, title, original_name, source_snapshot, source_revision, snapshot_sha256, pdf_sha256,
+  pdf_size_bytes::text, ged_document_id::text, ged_version_id::text, archived_at::text, created_at::text, created_by`;
+
+/** Insert is intentionally idempotent; a repeated create transaction returns the same job. */
+export async function repoQueueAuthoritativePdf(
+  tx: Pick<PoolClient, "query">,
+  input: AuthoritativePdfCreationInput,
+  snapshotSha256: string
+): Promise<AuthoritativePdfArchiveRecord> {
+  let inserted;
+  try {
+    inserted = await tx.query<ArchiveRow>(
+      `INSERT INTO public.authoritative_pdf_archives
+         (entity_type, entity_id, document_kind, document_version, render_version, idempotency_key, title, original_name, source_snapshot, source_revision, snapshot_sha256, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11,$12)
+       ON CONFLICT (idempotency_key) DO NOTHING
+       RETURNING ${ARCHIVE_COLUMNS}`,
+      [input.entityType, input.entityId, input.documentKind, input.documentVersion, input.renderVersion, input.idempotencyKey,
+        input.title, input.originalName, JSON.stringify(input.sourceSnapshot), input.sourceRevision, snapshotSha256, input.actorUserId]
+    );
+  } catch (error) {
+    // Aggregate adapters serialise normal issuance, but a residual database
+    // race must remain a stable client conflict instead of a raw PG error.
+    if ((error as { code?: string; constraint?: string } | null)?.code === "23505" &&
+      (error as { constraint?: string }).constraint === "authoritative_pdf_archive_document_version_uq") {
+      throw new HttpError(409, "OFFICIAL_DOCUMENT_VERSION_CONFLICT", "Une nouvelle édition a déjà été créée. Rechargez le document.");
+    }
+    throw error;
+  }
+  const archive = inserted.rows[0] ?? (await tx.query<ArchiveRow>(
+    `SELECT ${ARCHIVE_COLUMNS} FROM public.authoritative_pdf_archives WHERE idempotency_key = $1`, [input.idempotencyKey]
+  )).rows[0];
+  if (!archive) throw new Error("AUTHORITATIVE_PDF_ARCHIVE_QUEUE_LOOKUP_FAILED");
+  const mapped = mapArchive(archive);
+  if (
+    mapped.snapshotSha256 !== snapshotSha256 || mapped.entityType !== input.entityType ||
+    mapped.entityId !== input.entityId || mapped.documentKind !== input.documentKind ||
+    mapped.documentVersion !== input.documentVersion || mapped.renderVersion !== input.renderVersion ||
+    mapped.title !== input.title || mapped.originalName !== input.originalName || mapped.sourceRevision !== input.sourceRevision
+  ) {
+    throw new HttpError(409, "OFFICIAL_DOCUMENT_IDEMPOTENCY_CONFLICT", "Cette clé d'idempotence est déjà utilisée avec une autre demande de document.");
+  }
+  await tx.query(
+    `INSERT INTO public.authoritative_pdf_archive_outbox (archive_id, event_key)
+     VALUES ($1::uuid, $2)
+     ON CONFLICT (archive_id) DO NOTHING`,
+    [mapped.id, `authoritative-pdf:${input.idempotencyKey}`]
+  );
+  return mapped;
+}
+
+/**
+ * Looks up an already accepted request before an adapter rebuilds its mutable
+ * aggregate snapshot. This is deliberately scoped by the caller afterwards:
+ * an idempotency key is globally unique, while entity authorization remains
+ * the responsibility of the aggregate route/service.
+ */
+export async function repoFindAuthoritativePdfByIdempotency(
+  tx: Pick<PoolClient, "query">,
+  idempotencyKey: string
+): Promise<AuthoritativePdfArchiveRecord | null> {
+  const result = await tx.query<ArchiveRow>(
+    `SELECT ${ARCHIVE_COLUMNS}
+       FROM public.authoritative_pdf_archives
+      WHERE idempotency_key = $1`,
+    [idempotencyKey]
+  );
+  return result.rows[0] ? mapArchive(result.rows[0]) : null;
+}
+
+/** Claims only durable, pending work. A crashing worker is recoverable by an operator requeue. */
+export async function repoClaimAuthoritativePdfWork(
+  tx: Pick<PoolClient, "query">,
+  workerId: string,
+  limit: number
+): Promise<ArchiveQueueItem[]> {
+  const result = await tx.query<ArchiveRow & { outbox_id: string; claim_token: string }>(
+    `WITH candidate AS (
+       SELECT o.id FROM public.authoritative_pdf_archive_outbox o
+       WHERE (
+         o.status IN ('PENDING', 'FAILED') AND o.available_at <= now()
+       ) OR (
+         o.status = 'PROCESSING' AND o.locked_at < now() - interval '15 minutes'
+       )
+       ORDER BY o.created_at, o.id
+       LIMIT $1
+       FOR UPDATE SKIP LOCKED
+     ), claimed AS (
+       UPDATE public.authoritative_pdf_archive_outbox o
+         SET status = 'PROCESSING', locked_at = now(), locked_by = $2, claim_token = gen_random_uuid(), attempt_count = attempt_count + 1
+         FROM candidate WHERE o.id = candidate.id
+       RETURNING o.id::text AS outbox_id, o.archive_id, o.claim_token::text AS claim_token
+     )
+     SELECT c.outbox_id, c.claim_token, ${ARCHIVE_COLUMNS}
+       FROM claimed c JOIN public.authoritative_pdf_archives a ON a.id = c.archive_id`,
+    [limit, workerId]
+  );
+  return result.rows.map((row) => ({ outboxId: String(row.outbox_id), claimToken: String(row.claim_token), archive: mapArchive(row) }));
+}
+
+/** Verifies this exact worker lease before any GED/vault side effects begin. */
+export async function repoAssertAuthoritativePdfClaim(
+  tx: Pick<PoolClient, "query">,
+  input: { archiveId: string; outboxId: string; claimToken: string }
+): Promise<void> {
+  const result = await tx.query(
+    `SELECT 1
+      FROM public.authoritative_pdf_archive_outbox
+      WHERE id = $1::uuid AND archive_id = $2::uuid AND status = 'PROCESSING'
+        AND claim_token = $3::uuid
+      FOR UPDATE`,
+    [input.outboxId, input.archiveId, input.claimToken]
+  );
+  if (!result.rows[0]) throw new Error("AUTHORITATIVE_PDF_CLAIM_STALE");
+}
+
+export async function repoMarkAuthoritativePdfArchived(
+  tx: Pick<PoolClient, "query">,
+  input: { archiveId: string; outboxId: string; claimToken: string; pdfSha256: string; pdfSizeBytes: number; gedDocumentId: string; gedVersionId: string; actorUserId: number | null }
+): Promise<void> {
+  const updated = await tx.query(
+    `UPDATE public.authoritative_pdf_archives
+        SET pdf_sha256 = $2, pdf_size_bytes = $3, ged_document_id = $4::uuid, ged_version_id = $5::uuid, archived_at = now()
+      WHERE id = $1::uuid AND archived_at IS NULL`,
+    [input.archiveId, input.pdfSha256, input.pdfSizeBytes, input.gedDocumentId, input.gedVersionId]
+  );
+  if (updated.rowCount !== 1) throw new Error("AUTHORITATIVE_PDF_ARCHIVE_ALREADY_FINALIZED");
+  const outboxUpdated = await tx.query(
+    `UPDATE public.authoritative_pdf_archive_outbox
+        SET status = 'ARCHIVED', archived_at = now(), last_error = NULL,
+            locked_at = NULL, locked_by = NULL, claim_token = NULL
+      WHERE id = $1::uuid AND archive_id = $2::uuid AND status = 'PROCESSING' AND claim_token = $3::uuid`,
+    [input.outboxId, input.archiveId, input.claimToken]
+  );
+  if (outboxUpdated.rowCount !== 1) throw new Error("AUTHORITATIVE_PDF_OUTBOX_ARCHIVE_TRANSITION_FAILED");
+}
+
+export async function repoMarkAuthoritativePdfFailure(
+  tx: Pick<PoolClient, "query">,
+  input: { outboxId: string; claimToken: string; message: string }
+): Promise<void> {
+  const updated = await tx.query(
+    `UPDATE public.authoritative_pdf_archive_outbox
+        SET status = 'FAILED', available_at = now() + interval '5 minutes', last_error = left($2, 1000), locked_at = NULL, locked_by = NULL, claim_token = NULL
+      WHERE id = $1::uuid AND status = 'PROCESSING' AND claim_token = $3::uuid`,
+    [input.outboxId, input.message, input.claimToken]
+  );
+  if (updated.rowCount !== 1) throw new Error("AUTHORITATIVE_PDF_OUTBOX_FAILURE_TRANSITION_FAILED");
+}
+
+export type AuthoritativePdfListedRecord = AuthoritativePdfArchiveRecord & {
+  state: "PENDING" | "PROCESSING" | "ARCHIVED" | "FAILED";
+};
+
+export async function repoListAuthoritativePdfs(
+  tx: Pick<PoolClient, "query">,
+  entityType: string,
+  entityId: string,
+  documentKind: string
+): Promise<AuthoritativePdfListedRecord[]> {
+  const result = await tx.query<ArchiveRow & { state: AuthoritativePdfListedRecord["state"] }>(
+    `SELECT ${ARCHIVE_COLUMNS}, o.status::text AS state
+      FROM public.authoritative_pdf_archives a
+       JOIN public.authoritative_pdf_archive_outbox o ON o.archive_id = a.id
+      WHERE a.entity_type = $1 AND a.entity_id = $2 AND a.document_kind = $3
+      ORDER BY a.created_at DESC, a.document_version DESC`,
+    [entityType, entityId, documentKind]
+  );
+  return result.rows.map((row) => ({ ...mapArchive(row), state: row.state }));
+}
+
+export async function repoGetAuthoritativePdf(
+  tx: Pick<PoolClient, "query">,
+  entityType: string,
+  entityId: string,
+  archiveId: string,
+  documentKind: string
+): Promise<AuthoritativePdfListedRecord | null> {
+  const result = await tx.query<ArchiveRow & { state: AuthoritativePdfListedRecord["state"] }>(
+    `SELECT ${ARCHIVE_COLUMNS}, o.status::text AS state
+       FROM public.authoritative_pdf_archives a
+       JOIN public.authoritative_pdf_archive_outbox o ON o.archive_id = a.id
+      WHERE a.id = $1::uuid AND a.entity_type = $2 AND a.entity_id = $3 AND a.document_kind = $4`,
+    [archiveId, entityType, entityId, documentKind]
+  );
+  const row = result.rows[0];
+  return row ? { ...mapArchive(row), state: row.state } : null;
+}
+
+export async function repoFindLatestGedDocumentForAuthoritativePdf(
+  tx: Pick<PoolClient, "query">,
+  entityType: string,
+  entityId: string,
+  documentKind: string
+): Promise<string | null> {
+  const result = await tx.query<{ ged_document_id: string }>(
+    `SELECT ged_document_id::text
+       FROM public.authoritative_pdf_archives
+      WHERE entity_type = $1 AND entity_id = $2 AND document_kind = $3
+        AND ged_document_id IS NOT NULL
+      ORDER BY archived_at DESC NULLS LAST, created_at DESC
+      LIMIT 1`,
+    [entityType, entityId, documentKind]
+  );
+  return result.rows[0]?.ged_document_id ?? null;
+}
+
+export async function repoFindLatestAuthoritativePdfForEntity(
+  tx: Pick<PoolClient, "query">,
+  entityType: string,
+  entityId: string,
+  documentKind: string
+): Promise<AuthoritativePdfListedRecord | null> {
+  const result = await tx.query<ArchiveRow & { state: AuthoritativePdfListedRecord["state"] }>(
+    `SELECT ${ARCHIVE_COLUMNS}, o.status::text AS state
+      FROM public.authoritative_pdf_archives a
+       JOIN public.authoritative_pdf_archive_outbox o ON o.archive_id = a.id
+      WHERE a.entity_type = $1 AND a.entity_id = $2 AND a.document_kind = $3
+        AND o.status = 'ARCHIVED'
+      ORDER BY a.created_at DESC, a.document_version DESC LIMIT 1`,
+    [entityType, entityId, documentKind]
+  );
+  const row = result.rows[0];
+  return row ? { ...mapArchive(row), state: row.state } : null;
+}

--- a/src/shared/authoritative-documents/authoritative-document.service.ts
+++ b/src/shared/authoritative-documents/authoritative-document.service.ts
@@ -1,0 +1,377 @@
+import crypto from "node:crypto";
+import type { PoolClient } from "pg";
+
+import { HttpError } from "../../utils/httpError";
+import { repoAddLink, repoAddVersion, repoCreateDocumentWithVersion, repoGetGedBlobReferenceState, repoInternalGetVersionContentRef, repoLockGedBlobSha256, repoLogAccess, repoObsoletePreviousApplicable, repoSetCurrentVersion, repoSetVersionStatus, repoUpsertBlob, withGedBlobSha256Coordination, withGedTransaction } from "../../module/ged/repository/ged.repository";
+import { cleanupOwnedVaultBlob, computeSha256, readBlob, writeBlob, type VaultBlobOwnership } from "../../module/ged/services/ged-vault.service";
+import { assertAuthoritativePdfFilename } from "./authoritative-document.filename";
+import { repoAssertAuthoritativePdfClaim, repoFindLatestAuthoritativePdfForEntity, repoFindLatestGedDocumentForAuthoritativePdf, repoGetAuthoritativePdf, repoListAuthoritativePdfs, repoMarkAuthoritativePdfArchived, repoMarkAuthoritativePdfFailure, repoQueueAuthoritativePdf, type AuthoritativePdfListedRecord } from "./authoritative-document.repository";
+import type { ArchiveQueueItem, AuthoritativePdfArchiveRecord, AuthoritativePdfCreationInput, AuthoritativePdfProducer } from "./authoritative-document.types";
+
+const PDF_CLASS = "CERP_AUTHORITATIVE_PDF";
+const SYSTEM_SNAPSHOT_CLASS = "CERP_SYSTEM_SNAPSHOT";
+const PDF_DOMAIN = "CERP";
+export const INTERNAL_CREATION_SNAPSHOT_KINDS = new Set([
+  "CLIENT_CREATION_SNAPSHOT", "SUPPLIER_CREATION_SNAPSHOT", "CUSTOMER_ORDER_CREATION_SNAPSHOT",
+  "OF_CREATION_SNAPSHOT", "TECHNICAL_PIECE_CREATION_SNAPSHOT", "AFFAIR_CREATION_SNAPSHOT", "STOCK_ARTICLE_CREATION_SNAPSHOT",
+]);
+
+/** GED storage policy is explicit: no suffix/pattern may silently classify an external document as internal. */
+export function authoritativePdfGedPolicy(documentKind: string): { classKey: string; linkRole: string; eventType: string } {
+  return INTERNAL_CREATION_SNAPSHOT_KINDS.has(documentKind)
+    ? { classKey: SYSTEM_SNAPSHOT_CLASS, linkRole: "CREATION_SNAPSHOT", eventType: "CREATION_SNAPSHOT_ARCHIVED" }
+    : { classKey: PDF_CLASS, linkRole: "AUTHORITATIVE_PDF", eventType: "AUTHORITATIVE_PDF_ARCHIVED" };
+}
+/** Must stay aligned with the generated-PDF GED class in migration #612. */
+const MAX_AUTHORITATIVE_PDF_BYTES = 52_428_800;
+
+/** Canonical JSON makes the source snapshot checksum reproducible across retries. */
+export function canonicalJson(value: unknown): string {
+  if (value === undefined || typeof value === "function" || typeof value === "symbol") {
+    throw new Error("AUTHORITATIVE_PDF_SNAPSHOT_NOT_JSON");
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) throw new Error("AUTHORITATIVE_PDF_SNAPSHOT_NOT_JSON");
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`).join(",")}}`;
+}
+
+export function sha256Text(value: string): string {
+  return crypto.createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function assertCreationInput(input: AuthoritativePdfCreationInput): void {
+  if (!/^[a-z][a-z0-9_-]{1,63}$/.test(input.entityType)) throw new Error("AUTHORITATIVE_PDF_ENTITY_TYPE_INVALID");
+  if (
+    !input.entityId.trim() || input.entityId.length > 160 ||
+    !/^[A-Z][A-Z0-9_]{1,63}$/.test(input.documentKind)
+  ) throw new Error("AUTHORITATIVE_PDF_IDENTITY_INVALID");
+  if (
+    !input.renderVersion.trim() || input.renderVersion.length > 64 ||
+    !Number.isSafeInteger(input.documentVersion) || input.documentVersion < 1 ||
+    !input.idempotencyKey.trim() || input.idempotencyKey.length > 240 ||
+    !input.title.trim() || input.title.length > 300 ||
+    !input.sourceRevision.trim() || input.sourceRevision.length > 160
+  ) throw new Error("AUTHORITATIVE_PDF_INPUT_INVALID");
+  assertAuthoritativePdfFilename(input.originalName);
+}
+
+/**
+ * Call inside the same business CREATE transaction, after authorization and after
+ * the aggregate row exists. It never accepts a client snapshot: the producer builds
+ * it from authorized server state. The outbox row makes GED filing automatic and durable.
+ */
+export async function queueCreationPdfArchive(
+  tx: Pick<PoolClient, "query">,
+  input: AuthoritativePdfCreationInput
+): Promise<AuthoritativePdfArchiveRecord> {
+  assertCreationInput(input);
+  return repoQueueAuthoritativePdf(tx, input, sha256Text(canonicalJson(input.sourceSnapshot)));
+}
+
+/** Registers a server-only renderer for one entity family and document kind. No HTTP route bypasses aggregate RBAC. */
+export class AuthoritativePdfProducerRegistry {
+  private readonly producers = new Map<string, AuthoritativePdfProducer>();
+  private key(entityType: string, documentKind: string): string { return `${entityType}\u0000${documentKind}`; }
+  register(entityType: string, documentKind: string, producer: AuthoritativePdfProducer): void {
+    if (!/^[a-z][a-z0-9_-]{1,63}$/.test(entityType)) throw new Error("AUTHORITATIVE_PDF_ENTITY_TYPE_INVALID");
+    if (!/^[A-Z][A-Z0-9_]{1,63}$/.test(documentKind)) throw new Error("AUTHORITATIVE_PDF_DOCUMENT_KIND_INVALID");
+    const key = this.key(entityType, documentKind);
+    if (this.producers.has(key)) throw new Error("AUTHORITATIVE_PDF_PRODUCER_ALREADY_REGISTERED");
+    this.producers.set(key, producer);
+  }
+  get(entityType: string, documentKind: string): AuthoritativePdfProducer | null {
+    return this.producers.get(this.key(entityType, documentKind)) ?? null;
+  }
+}
+
+export type OfficialPdfDto = {
+  id: string;
+  kind: string;
+  /** Monotonic business document edition, never a renderer implementation label. */
+  version: number;
+  /** Browser vocabulary; GED outbox states are intentionally hidden here. */
+  state: "ISSUED" | "SUPERSEDED" | "REVOKED";
+  safe_filename: string;
+  byte_sha256: string;
+  byte_length: number;
+  mime_type: "application/pdf";
+  issued_at: string;
+  source_revision: string;
+  preview_url: string;
+  download_url: string;
+};
+
+/** Stable UI envelope. Physical storage/worker diagnostics never cross this boundary. */
+export type OfficialDocumentGenerationEnvelope = {
+  /** `NOT_GENERATED` is distinct from a durable `PENDING` outbox record. */
+  state: "NOT_GENERATED" | "PENDING" | "PROCESSING" | "READY" | "FAILED";
+  latest_document: OfficialPdfDto | null;
+  retryable: boolean;
+  failure_code: string | null;
+};
+
+function generationState(record: AuthoritativePdfListedRecord | undefined): OfficialDocumentGenerationEnvelope["state"] {
+  if (!record) return "NOT_GENERATED";
+  return record.state === "ARCHIVED" ? "READY" : record.state;
+}
+
+function assertArchivedRecord(record: AuthoritativePdfListedRecord): asserts record is AuthoritativePdfListedRecord & {
+  pdfSha256: string; pdfSizeBytes: number; archivedAt: string;
+} {
+  if (record.state !== "ARCHIVED" || !record.pdfSha256 || !record.pdfSizeBytes || !record.archivedAt) {
+    throw new Error("AUTHORITATIVE_PDF_ARCHIVE_INTEGRITY");
+  }
+}
+
+function asOfficialDto(
+  record: AuthoritativePdfListedRecord,
+  baseUrl: string,
+  state: OfficialPdfDto["state"]
+): OfficialPdfDto {
+  assertArchivedRecord(record);
+  const root = `${baseUrl}/${encodeURIComponent(record.id)}`;
+  return {
+    id: record.id, kind: record.documentKind, version: record.documentVersion, state,
+    safe_filename: record.originalName, byte_sha256: record.pdfSha256, byte_length: record.pdfSizeBytes,
+    mime_type: "application/pdf", issued_at: record.archivedAt, source_revision: record.sourceRevision,
+    preview_url: `${root}/preview`, download_url: `${root}/download`,
+  };
+}
+
+function compareArchiveAttempts(left: AuthoritativePdfListedRecord, right: AuthoritativePdfListedRecord): number {
+  // PostgreSQL textual timestamps can use different offset/precision forms;
+  // lexical comparison would make an older offset-form row hide a newer one.
+  const leftCreatedAt = Date.parse(left.createdAt);
+  const rightCreatedAt = Date.parse(right.createdAt);
+  if (Number.isFinite(leftCreatedAt) && Number.isFinite(rightCreatedAt) && rightCreatedAt !== leftCreatedAt) {
+    return rightCreatedAt - leftCreatedAt;
+  }
+  // The database guarantees this business edition is unique within the scope.
+  // It is also the deterministic fallback for historical non-ISO timestamps.
+  return right.documentVersion - left.documentVersion || right.id.localeCompare(left.id);
+}
+
+function newestIssued(records: readonly AuthoritativePdfListedRecord[]): AuthoritativePdfListedRecord | undefined {
+  return records.filter((record) => record.state === "ARCHIVED").sort(compareArchiveAttempts)[0];
+}
+
+/**
+ * Stable browser contract: the envelope reports the current generation attempt;
+ * `NOT_GENERATED` is reserved for an empty archive collection, while
+ * `PENDING` always means a durable outbox record exists. `latest_document`
+ * only ever exposes an immutable, byte-complete issuance.
+ */
+export function officialDocumentGenerationEnvelope(
+  records: readonly AuthoritativePdfListedRecord[],
+  baseUrl: string
+): OfficialDocumentGenerationEnvelope {
+  const attempts = [...records].sort(compareArchiveAttempts);
+  const state = generationState(attempts[0]);
+  const issued = newestIssued(attempts);
+  return {
+    state,
+    latest_document: issued ? asOfficialDto(issued, baseUrl, "ISSUED") : null,
+    retryable: state === "FAILED",
+    // A detailed worker error can contain data from an external renderer. It is
+    // intentionally held in the operator outbox, not returned to a browser.
+    failure_code: state === "FAILED" ? "OFFICIAL_DOCUMENT_GENERATION_FAILED" : null,
+  };
+}
+
+/** Metadata only. Authorization belongs to the entity adapter before this call. */
+export async function getOfficialDocumentGenerationEnvelope(params: {
+  tx: Pick<PoolClient, "query">; entityType: string; entityId: string; documentKind: string; baseUrl: string;
+}): Promise<OfficialDocumentGenerationEnvelope> {
+  return officialDocumentGenerationEnvelope(
+    await repoListAuthoritativePdfs(params.tx, params.entityType, params.entityId, params.documentKind),
+    params.baseUrl
+  );
+}
+
+/**
+ * Legacy internal helper. Route collections must use the generation envelope,
+ * so pending/archive-worker diagnostics can never masquerade as issued bytes.
+ */
+export async function listOfficialPdfDtos(params: { tx: Pick<PoolClient, "query">; entityType: string; entityId: string; documentKind: string; baseUrl: string }): Promise<OfficialPdfDto[]> {
+  const records = await repoListAuthoritativePdfs(params.tx, params.entityType, params.entityId, params.documentKind);
+  const latest = newestIssued(records);
+  return records
+    .filter((record) => record.state === "ARCHIVED")
+    .map((record) => asOfficialDto(record, params.baseUrl, record.id === latest?.id ? "ISSUED" : "SUPERSEDED"));
+}
+
+export async function getOfficialPdfDto(params: { tx: Pick<PoolClient, "query">; entityType: string; entityId: string; documentKind: string; archiveId: string; baseUrl: string }): Promise<OfficialPdfDto | null> {
+  const record = await repoGetAuthoritativePdf(params.tx, params.entityType, params.entityId, params.archiveId, params.documentKind);
+  if (!record) return null;
+  if (record.state !== "ARCHIVED") {
+    throw new HttpError(409, "OFFICIAL_DOCUMENT_NOT_READY", "Le document officiel est en cours de génération.");
+  }
+  const latest = newestIssued(await repoListAuthoritativePdfs(params.tx, params.entityType, params.entityId, params.documentKind));
+  return asOfficialDto(record, params.baseUrl, record.id === latest?.id ? "ISSUED" : "SUPERSEDED");
+}
+
+/**
+ * Finalize one claimed job in its worker transaction. The archived PDF is linked
+ * to the precise entity and logged in GED; neither a path nor a blob key escapes.
+ */
+export async function archiveClaimedAuthoritativePdf(
+  tx: Pick<PoolClient, "query">,
+  item: ArchiveQueueItem,
+  pdf: Buffer,
+  observeOwnership?: (ownership: { sha256: string; ownership: VaultBlobOwnership }) => void
+): Promise<void> {
+  if (item.archive.archivedAt) return;
+  if (!Buffer.isBuffer(pdf) || pdf.length === 0) throw new Error("AUTHORITATIVE_PDF_EMPTY");
+  const exact = Buffer.from(pdf);
+  if (exact.length > MAX_AUTHORITATIVE_PDF_BYTES) throw new Error("AUTHORITATIVE_PDF_SIZE_EXCEEDED");
+  if (exact.subarray(0, 5).toString("ascii") !== "%PDF-") throw new Error("AUTHORITATIVE_PDF_NOT_PDF");
+  await repoAssertAuthoritativePdfClaim(tx, { archiveId: item.archive.id, outboxId: item.outboxId, claimToken: item.claimToken });
+  const sha256 = computeSha256(exact);
+  await repoLockGedBlobSha256(tx, sha256);
+  const stored = await writeBlob(exact);
+  if (stored.sha256 !== sha256 || stored.size_bytes !== exact.byteLength) throw new Error("AUTHORITATIVE_PDF_STORAGE_INTEGRITY");
+  observeOwnership?.({ sha256, ownership: stored.ownership });
+  const blob = await repoUpsertBlob(tx, {
+    sha256: stored.sha256, size_bytes: stored.size_bytes, mime_type: "application/pdf",
+    storage_key: stored.storage_key, created_by: item.archive.actorUserId,
+  });
+  const existingDocumentId = await repoFindLatestGedDocumentForAuthoritativePdf(tx, item.archive.entityType, item.archive.entityId, item.archive.documentKind);
+  const gedPolicy = authoritativePdfGedPolicy(item.archive.documentKind);
+  const changeReason = `Édition ${item.archive.documentVersion}; rendu ${item.archive.renderVersion}; instantané ${item.archive.snapshotSha256}`;
+  let documentId: string;
+  let versionId: string;
+  if (existingDocumentId) {
+    const version = await repoAddVersion(tx, { document_id: existingDocumentId, blob_id: blob.id, original_name: item.archive.originalName, change_reason: changeReason, created_by: item.archive.actorUserId });
+    documentId = existingDocumentId;
+    versionId = version.version_id;
+  } else {
+    const created = await repoCreateDocumentWithVersion(tx, { class_key: gedPolicy.classKey, domain: PDF_DOMAIN, title: item.archive.title, description: `${item.archive.documentKind} — ${item.archive.entityType}:${item.archive.entityId}`, blob_id: blob.id, original_name: item.archive.originalName, change_reason: changeReason, created_by: item.archive.actorUserId });
+    documentId = created.document_id;
+    versionId = created.version_id;
+  }
+  await repoObsoletePreviousApplicable(tx, documentId, versionId);
+  await repoSetVersionStatus(tx, versionId, "APPLICABLE", item.archive.actorUserId);
+  await repoSetCurrentVersion(tx, documentId, versionId);
+  await repoAddLink(tx, { document_id: documentId, entity_type: item.archive.entityType, entity_id: item.archive.entityId, link_role: gedPolicy.linkRole, created_by: item.archive.actorUserId });
+  await repoLogAccess(tx, { document_id: documentId, version_id: versionId, event_type: gedPolicy.eventType, actor_id: item.archive.actorUserId, details: { entity_type: item.archive.entityType, entity_id: item.archive.entityId, document_kind: item.archive.documentKind, document_version: item.archive.documentVersion, source_revision: item.archive.sourceRevision, snapshot_sha256: item.archive.snapshotSha256, pdf_sha256: sha256, render_version: item.archive.renderVersion } });
+  await repoMarkAuthoritativePdfArchived(tx, { archiveId: item.archive.id, outboxId: item.outboxId, claimToken: item.claimToken, pdfSha256: sha256, pdfSizeBytes: exact.length, gedDocumentId: documentId, gedVersionId: versionId, actorUserId: item.archive.actorUserId });
+}
+
+/** A worker invokes this around each claimed item; failures remain durable and retryable. */
+export async function processAuthoritativePdfItem(
+  tx: Pick<PoolClient, "query">,
+  item: ArchiveQueueItem,
+  registry: AuthoritativePdfProducerRegistry,
+  observeOwnership?: (ownership: { sha256: string; ownership: VaultBlobOwnership }) => void
+): Promise<void> {
+  const producer = registry.get(item.archive.entityType, item.archive.documentKind);
+  // No dynamic entity/document value is retained in a failure record or log.
+  if (!producer) throw new Error("AUTHORITATIVE_PDF_PRODUCER_NOT_REGISTERED");
+  await archiveClaimedAuthoritativePdf(tx, item, await producer({ archive: item.archive }), observeOwnership);
+}
+
+/**
+ * Call only from a fresh, confirmed rollback/failure transaction. Keeping this
+ * separate avoids attempting an UPDATE after PostgreSQL has marked the archive
+ * transaction aborted.
+ */
+export async function recordAuthoritativePdfItemFailure(
+  tx: Pick<PoolClient, "query">,
+  item: ArchiveQueueItem,
+  error: unknown
+): Promise<void> {
+  // Keep outbox diagnostics operationally useful without persisting a renderer
+  // message, source value, storage path, or dynamic producer identifier.
+  const code = error instanceof HttpError && /^[A-Z][A-Z0-9_]{2,120}$/.test(error.code)
+    ? error.code
+    : error instanceof Error && /^AUTHORITATIVE_PDF_[A-Z0-9_]{2,100}$/.test(error.message)
+      ? error.message
+      : "AUTHORITATIVE_PDF_ARCHIVE_FAILED";
+  await repoMarkAuthoritativePdfFailure(
+    tx,
+    { outboxId: item.outboxId, claimToken: item.claimToken, message: code }
+  );
+}
+
+async function cleanupArchiveBlobAfterConfirmedRollback(ownership: { sha256: string; ownership: VaultBlobOwnership } | null): Promise<void> {
+  if (!ownership || ownership.ownership.kind === "deduplicated") return;
+  await withGedBlobSha256Coordination(ownership.sha256, async (tx) => {
+    const reference = await repoGetGedBlobReferenceState(tx, ownership.sha256);
+    if (!reference.blob_present && reference.reference_count === 0) await cleanupOwnedVaultBlob(ownership.ownership);
+  });
+}
+
+/** Processes one already-claimed job with commit/rollback-safe vault compensation. */
+export async function runClaimedAuthoritativePdfArchive(
+  item: ArchiveQueueItem,
+  registry: AuthoritativePdfProducerRegistry
+): Promise<void> {
+  let ownership: { sha256: string; ownership: VaultBlobOwnership } | null = null;
+  try {
+    await withGedTransaction(
+      (tx) => processAuthoritativePdfItem(tx, item, registry, (value) => { ownership = value; }),
+      { afterConfirmedRollback: () => cleanupArchiveBlobAfterConfirmedRollback(ownership) }
+    );
+  } catch (error) {
+    // A lost COMMIT acknowledgement deliberately remains PROCESSING for
+    // reconciliation/reclaim; marking it FAILED could duplicate a committed PDF.
+    if (error instanceof HttpError && error.code === "GED_COMMIT_UNCERTAIN") throw error;
+    const failureTx = await import("../../config/database").then((module) => module.default.connect());
+    try {
+      await failureTx.query("BEGIN");
+      await recordAuthoritativePdfItemFailure(failureTx, item, error);
+      await failureTx.query("COMMIT");
+    } catch (failureError) {
+      try { await failureTx.query("ROLLBACK"); } catch { /* preserve original failure */ }
+      throw failureError;
+    } finally { failureTx.release(); }
+    throw error;
+  }
+}
+
+/**
+ * Reads exact archived bytes after the entity adapter has authorized access.
+ * The GED audit is committed before opening the vault, so a failed/blocked byte
+ * read is still forensically visible without exposing a physical locator.
+ */
+export async function readOfficialPdfBytes(params: {
+  entityType: string; entityId: string; documentKind: string; archiveId: string; actorUserId: number | null;
+  eventType: "AUTHORITATIVE_PDF_PREVIEWED" | "AUTHORITATIVE_PDF_DOWNLOADED" | "AUTHORITATIVE_PDF_SENT";
+}): Promise<{ bytes: Buffer; filename: string; sha256: string }> {
+  const database = (await import("../../config/database")).default;
+  const record = await repoGetAuthoritativePdf(database, params.entityType, params.entityId, params.archiveId, params.documentKind);
+  if (!record) throw new HttpError(404, "OFFICIAL_DOCUMENT_NOT_FOUND", "Document officiel introuvable.");
+  if (record.state !== "ARCHIVED" || !record.gedVersionId || !record.pdfSha256) {
+    throw new HttpError(409, "OFFICIAL_DOCUMENT_NOT_READY", "Le document officiel est en cours de génération.");
+  }
+  const reference = await repoInternalGetVersionContentRef(record.gedVersionId);
+  if (!reference || reference.document_id !== record.gedDocumentId || reference.sha256 !== record.pdfSha256 || reference.mime_type !== "application/pdf") {
+    throw new HttpError(409, "OFFICIAL_DOCUMENT_INTEGRITY", "Le document officiel ne peut pas être restitué de manière vérifiée.");
+  }
+  await repoLogAccess(database, { document_id: record.gedDocumentId, version_id: record.gedVersionId, event_type: params.eventType, actor_id: params.actorUserId, details: { entity_type: params.entityType, entity_id: params.entityId, archive_id: record.id, pdf_sha256: record.pdfSha256 } });
+  const bytes = await readBlob(reference.storage_key, record.pdfSha256).catch(() => {
+    throw new HttpError(503, "OFFICIAL_DOCUMENT_UNAVAILABLE", "Le document officiel est temporairement indisponible.");
+  });
+  if (bytes.byteLength !== record.pdfSizeBytes) throw new HttpError(409, "OFFICIAL_DOCUMENT_INTEGRITY", "Le document officiel ne peut pas être restitué de manière vérifiée.");
+  return { bytes, filename: record.originalName, sha256: record.pdfSha256 };
+}
+
+export async function readLatestOfficialPdfBytes(params: Omit<Parameters<typeof readOfficialPdfBytes>[0], "archiveId">): Promise<{ bytes: Buffer; filename: string; sha256: string }> {
+  const database = (await import("../../config/database")).default;
+  const record = await repoFindLatestAuthoritativePdfForEntity(database, params.entityType, params.entityId, params.documentKind);
+  if (!record) throw new HttpError(409, "OFFICIAL_DOCUMENT_NOT_READY", "Le document officiel est en cours de génération.");
+  return readOfficialPdfBytes({ ...params, archiveId: record.id });
+}
+
+/** Print is an intent audit, deliberately byte-free. */
+export async function recordOfficialPdfPrintIntent(params: { entityType: string; entityId: string; documentKind: string; archiveId: string; actorUserId: number | null }): Promise<void> {
+  const database = (await import("../../config/database")).default;
+  const record = await repoGetAuthoritativePdf(database, params.entityType, params.entityId, params.archiveId, params.documentKind);
+  if (!record) throw new HttpError(404, "OFFICIAL_DOCUMENT_NOT_FOUND", "Document officiel introuvable.");
+  if (record.state !== "ARCHIVED" || !record.gedDocumentId || !record.gedVersionId) {
+    throw new HttpError(409, "OFFICIAL_DOCUMENT_NOT_READY", "Le document officiel est en cours de génération.");
+  }
+  await repoLogAccess(database, { document_id: record.gedDocumentId, version_id: record.gedVersionId, event_type: "AUTHORITATIVE_PDF_PRINT_INTENT", actor_id: params.actorUserId, details: { entity_type: params.entityType, entity_id: params.entityId, archive_id: record.id } });
+}

--- a/src/shared/authoritative-documents/authoritative-document.types.ts
+++ b/src/shared/authoritative-documents/authoritative-document.types.ts
@@ -1,0 +1,40 @@
+/** Shared, server-side contract for an official generated PDF. */
+export type AuthoritativePdfCreationInput = Readonly<{
+  entityType: string;
+  entityId: string;
+  documentKind: string;
+  /** Human-facing, monotonic archive edition number; independent of renderer implementation. */
+  documentVersion: number;
+  renderVersion: string;
+  /** Stable producer key, e.g. `commande-client:42:creation:v1`. */
+  idempotencyKey: string;
+  title: string;
+  originalName: string;
+  /** Server-derived aggregate revision that a browser can round-trip on reissue. */
+  sourceRevision: string;
+  sourceSnapshot: Record<string, unknown>;
+  actorUserId: number | null;
+}>;
+
+export type AuthoritativePdfArchiveRecord = AuthoritativePdfCreationInput & {
+  id: string;
+  /** Durable queue chronology; never inferred from PDF issuance time. */
+  createdAt: string;
+  snapshotSha256: string;
+  pdfSha256: string | null;
+  pdfSizeBytes: number | null;
+  gedDocumentId: string | null;
+  gedVersionId: string | null;
+  archivedAt: string | null;
+};
+
+export type AuthoritativePdfProducer = (input: {
+  archive: AuthoritativePdfArchiveRecord;
+}) => Promise<Buffer>;
+
+export type ArchiveQueueItem = {
+  outboxId: string;
+  /** Fresh UUID for this lease; prevents a reclaimed worker from finalizing a newer claim. */
+  claimToken: string;
+  archive: AuthoritativePdfArchiveRecord;
+};

--- a/src/shared/authoritative-documents/authoritative-document.worker.ts
+++ b/src/shared/authoritative-documents/authoritative-document.worker.ts
@@ -1,0 +1,91 @@
+import pool from "../../config/database";
+import { renderSupplierPurchaseOrderOfficialPdf } from "../../module/commande-fournisseur/services/commande-fournisseur-official-pdf";
+import { renderDevisOfficialPdf } from "../../module/devis/services/devis-official-pdf";
+import { renderCommandeArOfficialPdf } from "../../module/commande-client/services/commande-ar.service";
+import { renderInternalCreationSnapshotPdf } from "./internal-creation-snapshot-pdf";
+import { repoClaimAuthoritativePdfWork } from "./authoritative-document.repository";
+import { AuthoritativePdfProducerRegistry, runClaimedAuthoritativePdfArchive } from "./authoritative-document.service";
+
+function parseInterval(raw: string | undefined): number {
+  const value = Number.parseInt(raw ?? "30000", 10);
+  return Number.isSafeInteger(value) && value >= 5_000 && value <= 300_000 ? value : 30_000;
+}
+
+/** Explicit producer list prevents an arbitrary entity type from becoming renderable. */
+export function createAuthoritativePdfProducerRegistry(): AuthoritativePdfProducerRegistry {
+  const registry = new AuthoritativePdfProducerRegistry();
+  registry.register("commande-fournisseur", "SUPPLIER_PURCHASE_ORDER", renderSupplierPurchaseOrderOfficialPdf);
+  registry.register("devis", "CUSTOMER_QUOTE", renderDevisOfficialPdf);
+  registry.register("commande-client", "CUSTOMER_ORDER_ACKNOWLEDGEMENT", renderCommandeArOfficialPdf);
+  registry.register("client", "CLIENT_CREATION_SNAPSHOT", renderInternalCreationSnapshotPdf);
+  registry.register("fournisseur", "SUPPLIER_CREATION_SNAPSHOT", renderInternalCreationSnapshotPdf);
+  registry.register("commande-client", "CUSTOMER_ORDER_CREATION_SNAPSHOT", renderInternalCreationSnapshotPdf);
+  registry.register("ordre-fabrication", "OF_CREATION_SNAPSHOT", renderInternalCreationSnapshotPdf);
+  registry.register("piece-technique", "TECHNICAL_PIECE_CREATION_SNAPSHOT", renderInternalCreationSnapshotPdf);
+  registry.register("affaire", "AFFAIR_CREATION_SNAPSHOT", renderInternalCreationSnapshotPdf);
+  registry.register("stock-article", "STOCK_ARTICLE_CREATION_SNAPSHOT", renderInternalCreationSnapshotPdf);
+  return registry;
+}
+
+export async function runAuthoritativePdfArchiveWorkerOnce(
+  registry: AuthoritativePdfProducerRegistry = createAuthoritativePdfProducerRegistry(),
+  workerId = `pdf-worker:${process.pid}`
+): Promise<number> {
+  const client = await pool.connect();
+  let items;
+  try {
+    await client.query("BEGIN");
+    items = await repoClaimAuthoritativePdfWork(client, workerId, 8);
+    await client.query("COMMIT");
+  } catch (error) {
+    try { await client.query("ROLLBACK"); } catch { /* connection released below */ }
+    throw error;
+  } finally { client.release(); }
+  let completed = 0;
+  let failed = 0;
+  let commitUncertain = 0;
+  for (const item of items) {
+    try {
+      await runClaimedAuthoritativePdfArchive(item, registry);
+      completed += 1;
+    } catch (error) {
+      // `GED_COMMIT_UNCERTAIN` intentionally remains leased for reconcile /
+      // stale-lease recovery. Every other item must still get its own chance.
+      if (error instanceof Error && (error as { code?: string }).code === "GED_COMMIT_UNCERTAIN") commitUncertain += 1;
+      else failed += 1;
+    }
+  }
+  if (failed || commitUncertain) {
+    // Aggregate-only operational signal: no archive id, path, source snapshot,
+    // or renderer exception is emitted to application logs.
+    console.error(JSON.stringify({
+      type: "authoritative_pdf_archive_worker_item_failures",
+      claimed: items.length,
+      completed,
+      failed,
+      commit_uncertain: commitUncertain,
+    }));
+  }
+  return items.length;
+}
+
+/** Bounded serial worker; failures remain in the durable outbox for retry. */
+export function startAuthoritativePdfArchiveMaintenance(): () => void {
+  const registry = createAuthoritativePdfProducerRegistry();
+  const workerId = `pdf-worker:${process.pid}`;
+  let running = false;
+  const cycle = async () => {
+    if (running) return;
+    running = true;
+    try { await runAuthoritativePdfArchiveWorkerOnce(registry, workerId); }
+    catch (error) {
+      // Never expose DB paths or PDF source values in logs; durable outbox has
+      // the per-item sanitized failure message for operators.
+      console.error(JSON.stringify({ type: "authoritative_pdf_archive_worker_failed", code: (error as { code?: string } | null)?.code ?? "UNKNOWN" }));
+    } finally { running = false; }
+  };
+  void cycle();
+  const timer = setInterval(() => void cycle(), parseInterval(process.env.CERP_AUTHORITATIVE_PDF_ARCHIVE_INTERVAL_MS));
+  timer.unref?.();
+  return () => clearInterval(timer);
+}

--- a/src/shared/authoritative-documents/creation-snapshot-http.ts
+++ b/src/shared/authoritative-documents/creation-snapshot-http.ts
@@ -1,0 +1,166 @@
+import type { Request, RequestHandler, Response } from "express";
+
+import db from "../../config/database";
+import { asyncHandler } from "../../utils/asyncHandler";
+import { HttpError } from "../../utils/httpError";
+import { setSecureDownloadHeaders } from "../uploads/secure-download";
+import { assertAuthoritativePdfFilename } from "./authoritative-document.filename";
+import {
+  getOfficialDocumentGenerationEnvelope,
+  readOfficialPdfBytes,
+  recordOfficialPdfPrintIntent,
+} from "./authoritative-document.service";
+
+/**
+ * The factory is deliberately an internal adapter, not a catch-all HTTP route.
+ * Each aggregate wires a fixed kind and its own existing read/export middleware.
+ */
+export const CREATION_SNAPSHOT_DOCUMENT_KINDS = [
+  "CLIENT_CREATION_SNAPSHOT",
+  "SUPPLIER_CREATION_SNAPSHOT",
+  "CUSTOMER_ORDER_CREATION_SNAPSHOT",
+  "OF_CREATION_SNAPSHOT",
+  "TECHNICAL_PIECE_CREATION_SNAPSHOT",
+  "AFFAIR_CREATION_SNAPSHOT",
+  "STOCK_ARTICLE_CREATION_SNAPSHOT",
+] as const;
+
+export type CreationSnapshotDocumentKind = (typeof CREATION_SNAPSHOT_DOCUMENT_KINDS)[number];
+
+export type CreationSnapshotHandlers = Readonly<{
+  metadata: RequestHandler;
+  preview: RequestHandler;
+  download: RequestHandler;
+  printIntent: RequestHandler;
+}>;
+
+type CreationSnapshotHandlerConfig = Readonly<{
+  /** Fixed module-owned aggregate namespace (never derived from a request). */
+  entityType: "client" | "fournisseur" | "commande-client" | "ordre-fabrication" | "piece-technique" | "affaire" | "stock-article";
+  /** Fixed module-owned internal document kind (never derived from a request). */
+  documentKind: CreationSnapshotDocumentKind;
+  /** Parses the module's existing `:id` semantics and returns its canonical string form. */
+  parseEntityId: (req: Request) => string;
+  /**
+   * Must use the aggregate's existing read/scope path. Returning false intentionally
+   * gives the same 404 for a missing or out-of-scope root before any archive lookup.
+   */
+  canReadEntity: (entityId: string, req: Request) => Promise<boolean>;
+  /** Fixed collection URL used only to construct browser links in the metadata envelope. */
+  baseUrl: (entityId: string) => string;
+}>;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function noStore(res: Response): void {
+  res.setHeader("Cache-Control", "private, no-store, max-age=0");
+  res.setHeader("Pragma", "no-cache");
+}
+
+function actorUserId(req: Request): number {
+  const id = req.user?.id;
+  if (typeof id !== "number" || !Number.isSafeInteger(id) || id < 1) {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+  }
+  return id;
+}
+
+function archiveId(req: Request): string {
+  const id = req.params.documentId;
+  if (typeof id !== "string" || !UUID_RE.test(id)) {
+    throw new HttpError(400, "INVALID_ROUTE_PARAM", "documentId must be a UUID");
+  }
+  return id;
+}
+
+function assertSafeEntityId(value: string): string {
+  const entityId = value.trim();
+  if (!entityId || entityId.length > 160 || /[\u0000-\u001f\u007f/?#\\]/.test(entityId)) {
+    throw new HttpError(400, "INVALID_ROUTE_PARAM", "id must be a valid route parameter");
+  }
+  return entityId;
+}
+
+function assertSafeBaseUrl(value: string): string {
+  if (!value.startsWith("/") || value.startsWith("//") || value.includes("?") || value.includes("#") || /[\r\n]/.test(value)) {
+    throw new Error("CREATION_SNAPSHOT_BASE_URL_INVALID");
+  }
+  return value;
+}
+
+async function resolveReadableEntity(config: CreationSnapshotHandlerConfig, req: Request): Promise<string> {
+  const entityId = assertSafeEntityId(config.parseEntityId(req));
+  if (!(await config.canReadEntity(entityId, req))) {
+    // Do not disclose whether an entity exists when an adapter scopes it away.
+    throw new HttpError(404, "CREATION_SNAPSHOT_ENTITY_NOT_FOUND", "Ressource introuvable.");
+  }
+  return entityId;
+}
+
+/**
+ * Builds the four fixed, read-only creation-snapshot handlers for one aggregate.
+ * There is intentionally no issue/reissue handler: creation snapshots are queued only
+ * from the aggregate's business create transaction.
+ */
+export function createCreationSnapshotHandlers(config: CreationSnapshotHandlerConfig): CreationSnapshotHandlers {
+  const baseUrlFor = (entityId: string) => assertSafeBaseUrl(config.baseUrl(entityId));
+
+  const metadata: RequestHandler = asyncHandler(async (req, res) => {
+    // Routes are authenticated too, but retain the guard here so a future mount
+    // cannot accidentally turn archive state into an unauthenticated oracle.
+    actorUserId(req);
+    const entityId = await resolveReadableEntity(config, req);
+    noStore(res);
+    res.json(
+      await getOfficialDocumentGenerationEnvelope({
+        tx: db,
+        entityType: config.entityType,
+        entityId,
+        documentKind: config.documentKind,
+        baseUrl: baseUrlFor(entityId),
+      })
+    );
+  });
+
+  const sendPdf = (download: boolean): RequestHandler =>
+    asyncHandler(async (req, res) => {
+      const actorId = actorUserId(req);
+      const documentId = archiveId(req);
+      const entityId = await resolveReadableEntity(config, req);
+      const file = await readOfficialPdfBytes({
+        entityType: config.entityType,
+        entityId,
+        documentKind: config.documentKind,
+        archiveId: documentId,
+        actorUserId: actorId,
+        eventType: download ? "AUTHORITATIVE_PDF_DOWNLOADED" : "AUTHORITATIVE_PDF_PREVIEWED",
+      });
+      // The archive writer enforces this invariant. Check it again at the browser
+      // boundary so a malformed historical row can never become a response header.
+      assertAuthoritativePdfFilename(file.filename);
+      setSecureDownloadHeaders(res, {
+        filename: file.filename,
+        mimeType: "application/pdf",
+        download,
+      });
+      res.setHeader("Content-Length", String(file.bytes.byteLength));
+      res.send(file.bytes);
+    });
+
+  const printIntent: RequestHandler = asyncHandler(async (req, res) => {
+    const actorId = actorUserId(req);
+    const documentId = archiveId(req);
+    const entityId = await resolveReadableEntity(config, req);
+    await recordOfficialPdfPrintIntent({
+      entityType: config.entityType,
+      entityId,
+      documentKind: config.documentKind,
+      archiveId: documentId,
+      actorUserId: actorId,
+    });
+    noStore(res);
+    res.status(204).send();
+  });
+
+  return { metadata, preview: sendPdf(false), download: sendPdf(true), printIntent };
+}

--- a/src/shared/authoritative-documents/internal-creation-snapshot-pdf.ts
+++ b/src/shared/authoritative-documents/internal-creation-snapshot-pdf.ts
@@ -1,0 +1,99 @@
+import { renderCerpDocument, type CerpLineRow } from "../pdf/cerp-document";
+import { issuerIdentityLine, issuerLegalMentions } from "../pdf/legal-mentions";
+import type { AuthoritativePdfArchiveRecord } from "./authoritative-document.types";
+import type { InternalCreationSnapshot } from "./internal-creation-snapshot";
+
+export type { InternalCreationSnapshot } from "./internal-creation-snapshot";
+
+const clean = (value: unknown, max = 2_000): string | null =>
+  typeof value === "string" && value.trim().length > 0 && value.trim().length <= max ? value.trim() : null;
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+};
+
+const invalidSnapshot = (): never => { throw new Error("INTERNAL_CREATION_SNAPSHOT_INVALID"); };
+
+/** Strictly accepts the small, server-composed snapshot grammar; no browser payload is rendered. */
+export function parseInternalCreationSnapshot(archive: AuthoritativePdfArchiveRecord): InternalCreationSnapshot {
+  if (!isPlainRecord(archive.sourceSnapshot)) invalidSnapshot();
+  const source = archive.sourceSnapshot as Partial<InternalCreationSnapshot>;
+  const summary = source.summary;
+  const sections = source.sections;
+  if (source.type !== "INTERNAL_CREATION_SNAPSHOT" || !clean(source.entity_label, 120) || !clean(source.reference, 160) || !isPlainRecord(source.issuer)) invalidSnapshot();
+  if (!Array.isArray(summary) || !Array.isArray(sections)) {
+    throw new Error("INTERNAL_CREATION_SNAPSHOT_INVALID");
+  }
+  if (summary.length > 12 || sections.length > 24) invalidSnapshot();
+  for (const item of summary) {
+    if (!isPlainRecord(item) || !clean(item.label, 80) || (item.value !== null && !clean(item.value, 500))) invalidSnapshot();
+  }
+  for (const section of sections) {
+    if (!isPlainRecord(section) || !clean(section.title, 120) || (!section.rows && !section.table && !section.notes)) invalidSnapshot();
+    if (section.rows) {
+      if (!Array.isArray(section.rows) || section.rows.length > 80) invalidSnapshot();
+      for (const row of section.rows) {
+        if (!isPlainRecord(row) || !clean(row.label, 100) || (row.value !== null && !clean(row.value, 1_000))) invalidSnapshot();
+      }
+    }
+    if (section.table) {
+      if (!isPlainRecord(section.table) || !Array.isArray(section.table.columns) || !Array.isArray(section.table.rows) || section.table.columns.length === 0 || section.table.columns.length > 8 || section.table.rows.length > 250) invalidSnapshot();
+      const keys = new Set<string>();
+      for (const column of section.table.columns) {
+        if (!isPlainRecord(column)) throw new Error("INTERNAL_CREATION_SNAPSHOT_INVALID");
+        const key = column.key;
+        if (typeof key !== "string" || !/^[a-z][a-z0-9_]{0,31}$/.test(key) || !clean(column.label, 80) || keys.has(key)) {
+          throw new Error("INTERNAL_CREATION_SNAPSHOT_INVALID");
+        }
+        keys.add(key);
+      }
+      for (const row of section.table.rows) {
+        if (!isPlainRecord(row)) invalidSnapshot();
+        const rowKeys = Object.keys(row);
+        if (rowKeys.length !== keys.size || rowKeys.some((key) => !keys.has(key))) invalidSnapshot();
+        for (const key of keys) {
+          const value = row[key];
+          if (value !== null && !clean(value, 1_000)) invalidSnapshot();
+        }
+      }
+    }
+    if (section.notes !== undefined && section.notes !== null && !clean(section.notes, 20_000)) invalidSnapshot();
+  }
+  return source as InternalCreationSnapshot;
+}
+
+export async function renderInternalCreationSnapshotPdf({ archive }: { archive: AuthoritativePdfArchiveRecord }): Promise<Buffer> {
+  const source = parseInternalCreationSnapshot(archive);
+  const createdAt = new Date(archive.createdAt);
+  if (Number.isNaN(createdAt.getTime())) throw new Error("INTERNAL_CREATION_SNAPSHOT_CREATED_AT_INVALID");
+  return renderCerpDocument({
+    documentType: "Instantané interne", name: source.reference, code: source.reference,
+    subtitle: `Création archivée le ${createdAt.toLocaleDateString("fr-FR")}`,
+    status: "BROUILLON", monogramName: source.entity_label, generatedAt: createdAt.toLocaleDateString("fr-FR"),
+    flag: "INTERNE / BROUILLON", watermark: "INTERNE / BROUILLON",
+    footerNote: `Instantané interne GED — non opposable — SHA-256 ${archive.snapshotSha256.slice(0, 16)}…`,
+    legalIdentity: issuerIdentityLine(source.issuer) ?? "Croix Rousse Precision",
+    legalMentions: issuerLegalMentions(source.issuer),
+    title: `${source.entity_label} — ${source.reference}`, subject: "INTERNE / BROUILLON — instantané de création non opposable", creationDate: createdAt,
+  }, (ctx) => {
+    ctx.legalStrip([...source.summary]);
+    for (const section of source.sections) {
+      ctx.section(section.title);
+      if (section.rows?.length) {
+        const top = ctx.y;
+        let bottom = top;
+        const columns = Math.min(3, Math.max(1, section.rows.length));
+        section.rows.forEach((row, index) => { bottom = Math.max(bottom, ctx.field(row.label, row.value, 38 + (index % columns) * (520 / columns), 500 / columns)); });
+        ctx.y = bottom + 8;
+      }
+      if (section.table) {
+        const columns = section.table.columns.map((column) => ({ key: column.key, label: column.label, flex: 1 }));
+        const rows: CerpLineRow[] = section.table.rows.map((row) => ({ cells: Object.fromEntries(section.table!.columns.map((column) => [column.key, row[column.key] ?? "—"])) }));
+        ctx.linesTable({ columns, rows, emptyLabel: "Aucune donnée." });
+      }
+      if (section.notes) ctx.notes(section.notes);
+    }
+  });
+}

--- a/src/shared/authoritative-documents/internal-creation-snapshot.ts
+++ b/src/shared/authoritative-documents/internal-creation-snapshot.ts
@@ -1,0 +1,74 @@
+import type { LegalParty } from "../pdf/legal-mentions";
+
+export type InternalCreationSnapshot = Readonly<{
+  type: "INTERNAL_CREATION_SNAPSHOT";
+  entity_label: string;
+  reference: string;
+  issuer: LegalParty;
+  summary: ReadonlyArray<{ label: string; value: string | null }>;
+  sections: ReadonlyArray<{
+    title: string;
+    rows?: ReadonlyArray<{ label: string; value: string | null }>;
+    table?: { columns: ReadonlyArray<{ key: string; label: string }>; rows: ReadonlyArray<Record<string, string | null>> };
+    notes?: string | null;
+  }>;
+}>;
+
+const text = (value: unknown, max: number): string | null => {
+  if (value === null || value === undefined) return null;
+  const result = String(value).trim();
+  return result ? result.slice(0, max) : null;
+};
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+};
+
+/**
+ * Builds the only generic creation-snapshot grammar accepted by the renderer.
+ * Callers pass server-read values; this helper deliberately has no request DTO.
+ */
+export function buildInternalCreationSnapshot(input: {
+  entityLabel: string; reference: string; issuer?: LegalParty;
+  summary?: ReadonlyArray<{ label: string; value: unknown }>;
+  sections?: ReadonlyArray<{
+    title: string; rows?: ReadonlyArray<{ label: string; value: unknown }>;
+    table?: { columns: ReadonlyArray<{ key: string; label: string }>; rows: ReadonlyArray<Record<string, unknown>> };
+    notes?: unknown;
+  }>;
+}): InternalCreationSnapshot {
+  const entity_label = text(input.entityLabel, 120);
+  const reference = text(input.reference, 160);
+  if (!entity_label || !reference) throw new Error("INTERNAL_CREATION_SNAPSHOT_INPUT_INVALID");
+  const summary = (input.summary ?? []).slice(0, 12).flatMap((item) => {
+    const label = text(item.label, 80); return label ? [{ label, value: text(item.value, 500) }] : [];
+  });
+  const sections = (input.sections ?? []).slice(0, 24).flatMap((section) => {
+    const title = text(section.title, 120); if (!title) return [];
+    const rows = section.rows?.slice(0, 80).flatMap((row) => { const label = text(row.label, 100); return label ? [{ label, value: text(row.value, 1_000) }] : []; });
+    const seenColumnKeys = new Set<string>();
+    const columns = section.table?.columns.slice(0, 8).flatMap((column) => {
+      const key = text(column.key, 32) ?? "";
+      const label = text(column.label, 80) ?? "";
+      if (!/^[a-z][a-z0-9_]{0,31}$/.test(key) || !label || seenColumnKeys.has(key)) return [];
+      seenColumnKeys.add(key);
+      return [{ key, label }];
+    }) ?? [];
+    const table = section.table && columns.length > 0
+      ? {
+          columns,
+          // Persist only declared cells. This keeps malformed runtime input and
+          // accidental extra object keys out of the immutable archive grammar.
+          rows: section.table.rows.slice(0, 250).map((row) => {
+            const source = isPlainRecord(row) ? row : {};
+            return Object.fromEntries(columns.map((column) => [column.key, text(source[column.key], 1_000)]));
+          }),
+        }
+      : undefined;
+    const notes = text(section.notes, 20_000);
+    return rows?.length || table || notes ? [{ title, ...(rows?.length ? { rows } : {}), ...(table ? { table } : {}), ...(notes ? { notes } : {}) }] : [];
+  });
+  return { type: "INTERNAL_CREATION_SNAPSHOT", entity_label, reference, issuer: input.issuer ?? { legal_name: "Croix Rousse Precision" }, summary, sections };
+}

--- a/src/shared/authoritative-documents/stock-article-creation-snapshot.ts
+++ b/src/shared/authoritative-documents/stock-article-creation-snapshot.ts
@@ -1,0 +1,59 @@
+import { authoritativePdfFilename } from "./authoritative-document.filename";
+import type { AuthoritativePdfCreationInput } from "./authoritative-document.types";
+import { buildInternalCreationSnapshot } from "./internal-creation-snapshot";
+
+/** Narrow server-side grammar for root stock-article creation archives. */
+export type StockArticleCreationSnapshotInput = Readonly<{
+  id: string;
+  code: string;
+  designation: string;
+  articleType: string;
+  articleCategory: string;
+  familyCode: string;
+  unit: string | null;
+  status: string;
+  stockManaged: boolean;
+  lotTracking: boolean;
+  isActive: boolean;
+  sourceRevision: string;
+  actorUserId: number | null;
+}>;
+
+/** Builds a generic internal snapshot without exposing procurement notes or file paths. */
+export function buildStockArticleCreationSnapshotInput(
+  input: StockArticleCreationSnapshotInput
+): AuthoritativePdfCreationInput {
+  return {
+    entityType: "stock-article",
+    entityId: input.id,
+    documentKind: "STOCK_ARTICLE_CREATION_SNAPSHOT",
+    documentVersion: 1,
+    renderVersion: "internal-creation-snapshot-v1",
+    idempotencyKey: `stock-article:${input.id}:creation:v1`,
+    title: `Instantané de création — article ${input.code}`,
+    originalName: authoritativePdfFilename(["article", input.code, "creation"]),
+    sourceRevision: input.sourceRevision,
+    sourceSnapshot: buildInternalCreationSnapshot({
+      entityLabel: "Article de stock",
+      reference: input.code,
+      summary: [
+        { label: "Code", value: input.code },
+        { label: "Désignation", value: input.designation },
+        { label: "Catégorie", value: input.articleCategory },
+        { label: "Statut initial", value: input.status },
+      ],
+      sections: [{
+        title: "Classification initiale",
+        rows: [
+          { label: "Type", value: input.articleType },
+          { label: "Famille", value: input.familyCode },
+          { label: "Unité", value: input.unit },
+          { label: "Gestion de stock", value: input.stockManaged ? "Oui" : "Non" },
+          { label: "Suivi par lot", value: input.lotTracking ? "Oui" : "Non" },
+          { label: "Actif", value: input.isActive ? "Oui" : "Non" },
+        ],
+      }],
+    }),
+    actorUserId: input.actorUserId,
+  };
+}

--- a/src/shared/authoritative-documents/technical-piece-creation-snapshot.ts
+++ b/src/shared/authoritative-documents/technical-piece-creation-snapshot.ts
@@ -1,0 +1,66 @@
+import { authoritativePdfFilename } from "./authoritative-document.filename";
+import type { AuthoritativePdfCreationInput } from "./authoritative-document.types";
+import { buildInternalCreationSnapshot } from "./internal-creation-snapshot";
+
+/**
+ * Server-side input only. This deliberately has no request DTO or upload fields:
+ * a technical-piece creation snapshot is an internal GED record, not the
+ * controlled technical dossier or a copy of a customer-supplied file.
+ */
+export type TechnicalPieceCreationSnapshotInput = Readonly<{
+  id: string;
+  code: string;
+  designation: string;
+  clientId: string | null;
+  clientName: string | null;
+  status: string;
+  sourceRevision: string;
+  actorUserId: number | null;
+  articleId?: string | null;
+  familyId?: string | null;
+  pieceVersion?: number | null;
+  planReference?: string | null;
+  externalIndex?: string | null;
+  internalVersion?: number | null;
+  copiedFromCode?: string | null;
+}>;
+
+/** Builds the immutable PDF archive input from a server-read technical root. */
+export function buildTechnicalPieceCreationSnapshotInput(
+  input: TechnicalPieceCreationSnapshotInput
+): AuthoritativePdfCreationInput {
+  return {
+    entityType: "piece-technique",
+    entityId: input.id,
+    documentKind: "TECHNICAL_PIECE_CREATION_SNAPSHOT",
+    documentVersion: 1,
+    renderVersion: "internal-creation-snapshot-v1",
+    idempotencyKey: `piece-technique:${input.id}:creation:v1`,
+    title: `Instantané de création — pièce technique ${input.code}`,
+    originalName: authoritativePdfFilename(["piece-technique", input.code, "creation"]),
+    sourceRevision: input.sourceRevision,
+    sourceSnapshot: buildInternalCreationSnapshot({
+      entityLabel: "Pièce technique",
+      reference: input.code,
+      summary: [
+        { label: "Code", value: input.code },
+        { label: "Désignation", value: input.designation },
+        { label: "Client", value: input.clientName ?? input.clientId },
+        { label: "Statut initial", value: input.status },
+      ],
+      sections: [{
+        title: "Références techniques initiales",
+        rows: [
+          { label: "Version pièce", value: input.pieceVersion ?? 1 },
+          { label: "Référence plan", value: input.planReference ?? null },
+          { label: "Indice externe", value: input.externalIndex ?? null },
+          { label: "Version interne", value: input.internalVersion ?? null },
+          { label: "Article lié", value: input.articleId ?? null },
+          { label: "Matière / famille", value: input.familyId ?? null },
+          { label: "Copie de", value: input.copiedFromCode ?? null },
+        ],
+      }],
+    }),
+    actorUserId: input.actorUserId,
+  };
+}

--- a/src/shared/pdf/cerp-document.ts
+++ b/src/shared/pdf/cerp-document.ts
@@ -151,6 +151,54 @@ export function toPdfSafeText(value: string): string {
   return out
 }
 
+/**
+ * PDFKit's automatic page breaking cannot keep a shaded note background and
+ * the reserved legal footer in sync. Wrap deterministic display lines first so
+ * `notes()` can paint page-bounded chunks itself.
+ */
+function wrapTextLines(doc: PDFKit.PDFDocument, value: string, width: number): string[] {
+  const out: string[] = []
+  const splitLongWord = (word: string): string[] => {
+    const chunks: string[] = []
+    let chunk = ""
+    for (const character of word) {
+      const candidate = `${chunk}${character}`
+      if (chunk && doc.widthOfString(candidate) > width) {
+        chunks.push(chunk)
+        chunk = character
+      } else chunk = candidate
+    }
+    if (chunk) chunks.push(chunk)
+    return chunks
+  }
+
+  for (const paragraph of value.split(/\r?\n/)) {
+    const words = paragraph.trim().split(/\s+/).filter(Boolean)
+    if (!words.length) {
+      out.push("")
+      continue
+    }
+    let line = ""
+    for (const word of words) {
+      const candidate = line ? `${line} ${word}` : word
+      if (doc.widthOfString(candidate) <= width) {
+        line = candidate
+        continue
+      }
+      if (line) out.push(line)
+      if (doc.widthOfString(word) <= width) {
+        line = word
+        continue
+      }
+      const chunks = splitLongWord(word)
+      out.push(...chunks.slice(0, -1))
+      line = chunks[chunks.length - 1] ?? ""
+    }
+    if (line) out.push(line)
+  }
+  return out.length ? out : [""]
+}
+
 /** Monogramme de repli : 1 a 2 lettres, jamais vide. */
 export function monogramFromName(name: string | null | undefined): string {
   const cleaned = typeof name === "string" ? name.trim() : ""
@@ -479,14 +527,18 @@ export class CerpDocumentContext {
         this.doc.font(column.key === metaColumn ? "Helvetica-Bold" : "Helvetica").fontSize(BODY_SIZE)
         return this.doc.heightOfString(toPdfSafeText(row.cells[column.key] ?? ""), { width: widthOf(column) })
       })
-      let rowHeight = Math.max(12, ...heights)
+      let rowHeight = Math.ceil(Math.max(12, ...heights))
       if (row.meta) {
         const metaWidth = widthOf(columns.find((column) => column.key === metaColumn) ?? columns[0])
         this.doc.font("Helvetica").fontSize(7.6)
-        rowHeight += 1 + this.doc.heightOfString(toPdfSafeText(row.meta), { width: metaWidth })
+        rowHeight += 1 + Math.ceil(this.doc.heightOfString(toPdfSafeText(row.meta), { width: metaWidth }))
       }
 
-      if (this.cursor + rowHeight + 12 > this.bottomLimit) {
+      // PDFKit decides automatic text page-breaks with floating-point line metrics.
+      // Keep an explicit guard beyond the measured row so it can never add a page
+      // halfway through a metadata-bearing row and bypass our repeated table header.
+      const pageBreakGuard = 8
+      if (this.cursor + rowHeight + 12 + pageBreakGuard > this.bottomLimit) {
         this.doc.addPage()
         this.cursor = MARGIN_TOP
         drawHead()
@@ -542,16 +594,36 @@ export class CerpDocumentContext {
   notes(text: string): void {
     const inner = CONTENT_WIDTH - 26
     this.doc.font("Helvetica").fontSize(9.2)
-    const height = this.doc.heightOfString(toPdfSafeText(text), { width: inner }) + 22
+    const safe = toPdfSafeText(text)
+    const lineHeight = this.doc.currentLineHeight(true)
+    const lines = wrapTextLines(this.doc, safe, inner)
+    const padding = 11
+    let offset = 0
 
-    this.ensureSpace(Math.min(height, 120))
-    this.doc.save()
-    this.doc.rect(MARGIN_X, this.cursor, CONTENT_WIDTH, height).fill(CERP_DOC_COLORS.wash)
-    this.doc.restore()
+    // A single shaded note block used to reserve at most 120pt while painting
+    // its full height. Long operational notes could therefore run into a
+    // footer. Render measured lines in page-sized blocks instead.
+    while (offset < lines.length) {
+      const minimum = padding * 2 + lineHeight
+      this.ensureSpace(minimum)
+      const capacity = Math.max(1, Math.floor((this.bottomLimit - this.cursor - padding * 2) / lineHeight))
+      const chunk = lines.slice(offset, offset + capacity)
+      const height = padding * 2 + chunk.length * lineHeight
 
-    this.doc.fillColor(CERP_DOC_COLORS.ink)
-    this.doc.text(toPdfSafeText(text), MARGIN_X + 13, this.cursor + 11, { width: inner })
-    this.cursor += height
+      this.doc.save()
+      this.doc.rect(MARGIN_X, this.cursor, CONTENT_WIDTH, height).fill(CERP_DOC_COLORS.wash)
+      this.doc.restore()
+      this.doc.font("Helvetica").fontSize(9.2).fillColor(CERP_DOC_COLORS.ink)
+      chunk.forEach((line, index) => {
+        this.doc.text(line, MARGIN_X + 13, this.cursor + padding + index * lineHeight, { width: inner, lineBreak: false })
+      })
+      this.cursor += height
+      offset += chunk.length
+      if (offset < lines.length) {
+        this.doc.addPage()
+        this.cursor = MARGIN_TOP
+      }
+    }
   }
 
   /** Paire libelle / valeur, alignee sur la grille des champs. */

--- a/src/shared/pdf/format-fr.ts
+++ b/src/shared/pdf/format-fr.ts
@@ -6,7 +6,9 @@
  * s'impriment aussi sur le bon de livraison et l'accuse de reception, qui ne peuvent pas
  * dependre du module facturation.
  *
- * **Aucun chiffre n'est modifie** : seuls les separateurs changent.
+ * Monetary values are canonicalised to two decimal places at the rendering
+ * boundary. Database numerics arrive as strings, but legacy float paths can
+ * otherwise leak tails such as `6172.799999999999` into a legal document.
  */
 
 /** Date ISO en date francaise : `22/07/2026`. */
@@ -32,18 +34,25 @@ export function percent(value: string): string {
  * telles quelles, avec le code ISO — sur une facture francaise, et alors que les documents
  * rendus dans le navigateur affichent deja `10 465,20 €` pour la meme entreprise.
  *
- * Une chaine qui n'est pas un nombre est rendue telle quelle plutot que d'etre perdue.
+ * Une chaine qui n'est pas un nombre est rejetee : un montant ambigu ne doit
+ * jamais atteindre un PDF archive.
  */
-export function money(amount: string, currency: string): string {
+export function money(amount: string | number, currency: string): string {
   const raw = String(amount ?? "").trim()
   const symbol = currency === "EUR" ? "€" : currency
 
   const match = raw.match(/^(-?)(\d+)(?:[.,](\d+))?$/)
-  if (!match) return `${raw} ${symbol}`.trim()
+  if (!match) throw new Error("PDF_MONEY_INVALID")
 
-  const [, sign, whole, decimals] = match
-  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, " ")
-  return `${sign}${grouped}${decimals ? `,${decimals}` : ""} ${symbol}`
+  const [, sign, whole, decimalPart = ""] = match
+  // Work in cents with BigInt so a 15+ digit ERP amount and a JS float tail
+  // are rounded deterministically without introducing another IEEE-754 error.
+  let cents = BigInt(whole) * 100n + BigInt(decimalPart.slice(0, 2).padEnd(2, "0"))
+  if (decimalPart.length > 2 && decimalPart[2] >= "5") cents += 1n
+  const integer = (cents / 100n).toString()
+  const decimals = (cents % 100n).toString().padStart(2, "0")
+  const grouped = integer.replace(/\B(?=(\d{3})+(?!\d))/g, " ")
+  return `${sign}${grouped},${decimals} ${symbol}`
 }
 
 /**

--- a/src/swagger/generated-route-inventory.ts
+++ b/src/swagger/generated-route-inventory.ts
@@ -8,7 +8,7 @@ export type GeneratedRouteContract = {
   rbac: readonly string[];
 };
 
-export const GENERATED_ROUTE_SOURCE_SHA256 = "b3b69bab92eec4e2f23670abaa0a2202e8337d3268429e92e945a267e9ba7107";
+export const GENERATED_ROUTE_SOURCE_SHA256 = "f7ef2c7fd490b1828a5cd8a0c34e09ebbaa631784f0ff2ce7b3620014756af96";
 export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
@@ -1466,7 +1466,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/affaires",
-    "source": "src/module/affaire/routes/affaire.routes.ts:56",
+    "source": "src/module/affaire/routes/affaire.routes.ts:60",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1484,7 +1484,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/affaires",
-    "source": "src/module/affaire/routes/affaire.routes.ts:62",
+    "source": "src/module/affaire/routes/affaire.routes.ts:72",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1502,7 +1502,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/affaires/{id}",
-    "source": "src/module/affaire/routes/affaire.routes.ts:58",
+    "source": "src/module/affaire/routes/affaire.routes.ts:68",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1520,7 +1520,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/affaires/{id}",
-    "source": "src/module/affaire/routes/affaire.routes.ts:63",
+    "source": "src/module/affaire/routes/affaire.routes.ts:73",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1538,7 +1538,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/affaires/{id}/archive",
-    "source": "src/module/affaire/routes/affaire.routes.ts:66",
+    "source": "src/module/affaire/routes/affaire.routes.ts:76",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1555,8 +1555,80 @@ export const GENERATED_ROUTE_INVENTORY = [
   },
   {
     "method": "get",
+    "path": "/affaires/{id}/creation-snapshot",
+    "source": "src/module/affaire/routes/affaire.routes.ts:64",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAffaireCapability(read)",
+      "getAffaireCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAffaireCapability(read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/affaires/{id}/creation-snapshot/{documentId}/download",
+    "source": "src/module/affaire/routes/affaire.routes.ts:66",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAffaireCapability(read)",
+      "downloadAffaireCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAffaireCapability(read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/affaires/{id}/creation-snapshot/{documentId}/preview",
+    "source": "src/module/affaire/routes/affaire.routes.ts:65",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAffaireCapability(read)",
+      "previewAffaireCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAffaireCapability(read)"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/affaires/{id}/creation-snapshot/{documentId}/print-intents",
+    "source": "src/module/affaire/routes/affaire.routes.ts:67",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAffaireCapability(read)",
+      "printAffaireCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAffaireCapability(read)"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/affaires/{id}/operations",
-    "source": "src/module/affaire/routes/affaire.routes.ts:57",
+    "source": "src/module/affaire/routes/affaire.routes.ts:61",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1574,7 +1646,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/affaires/{id}/transition",
-    "source": "src/module/affaire/routes/affaire.routes.ts:64",
+    "source": "src/module/affaire/routes/affaire.routes.ts:74",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1592,7 +1664,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/affaires/command-center",
-    "source": "src/module/affaire/routes/affaire.routes.ts:55",
+    "source": "src/module/affaire/routes/affaire.routes.ts:59",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1610,7 +1682,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/affaires/preview",
-    "source": "src/module/affaire/routes/affaire.routes.ts:61",
+    "source": "src/module/affaire/routes/affaire.routes.ts:71",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2540,7 +2612,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/clients",
-    "source": "src/module/client/routes/client.routes.ts:31",
+    "source": "src/module/client/routes/client.routes.ts:35",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2556,7 +2628,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/clients",
-    "source": "src/module/client/routes/client.routes.ts:30",
+    "source": "src/module/client/routes/client.routes.ts:34",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2574,7 +2646,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/clients/{clientId}/addresses",
-    "source": "src/module/client/routes/client.routes.ts:37",
+    "source": "src/module/client/routes/client.routes.ts:41",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2590,7 +2662,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/clients/{clientId}/contacts",
-    "source": "src/module/client/routes/client.routes.ts:35",
+    "source": "src/module/client/routes/client.routes.ts:39",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2606,7 +2678,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/clients/{clientId}/contacts",
-    "source": "src/module/client/routes/client.routes.ts:36",
+    "source": "src/module/client/routes/client.routes.ts:40",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2624,7 +2696,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/clients/{id}",
-    "source": "src/module/client/routes/client.routes.ts:52",
+    "source": "src/module/client/routes/client.routes.ts:61",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2642,7 +2714,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/clients/{id}",
-    "source": "src/module/client/routes/client.routes.ts:38",
+    "source": "src/module/client/routes/client.routes.ts:47",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2658,7 +2730,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/clients/{id}",
-    "source": "src/module/client/routes/client.routes.ts:48",
+    "source": "src/module/client/routes/client.routes.ts:57",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2676,7 +2748,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/clients/{id}/archive",
-    "source": "src/module/client/routes/client.routes.ts:54",
+    "source": "src/module/client/routes/client.routes.ts:63",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2694,7 +2766,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/clients/{id}/contact",
-    "source": "src/module/client/routes/client.routes.ts:57",
+    "source": "src/module/client/routes/client.routes.ts:66",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2711,8 +2783,72 @@ export const GENERATED_ROUTE_INVENTORY = [
   },
   {
     "method": "get",
+    "path": "/clients/{id}/creation-snapshot",
+    "source": "src/module/client/routes/client.routes.ts:43",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "getClientCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/clients/{id}/creation-snapshot/{documentId}/download",
+    "source": "src/module/client/routes/client.routes.ts:45",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "downloadClientCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/clients/{id}/creation-snapshot/{documentId}/preview",
+    "source": "src/module/client/routes/client.routes.ts:44",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "previewClientCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/clients/{id}/creation-snapshot/{documentId}/print-intents",
+    "source": "src/module/client/routes/client.routes.ts:46",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "printClientCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/clients/analytics",
-    "source": "src/module/client/routes/client.routes.ts:32",
+    "source": "src/module/client/routes/client.routes.ts:36",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2728,7 +2864,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/clients/duplicate-check",
-    "source": "src/module/client/routes/client.routes.ts:34",
+    "source": "src/module/client/routes/client.routes.ts:38",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2760,7 +2896,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/commandes",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:104",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:121",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2775,7 +2911,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:101",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:118",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2792,7 +2928,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/commandes-fournisseurs",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:63",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:69",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2809,7 +2945,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes-fournisseurs",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:66",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:72",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2826,7 +2962,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/commandes-fournisseurs/{id}",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:72",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:78",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2843,7 +2979,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/commandes-fournisseurs/{id}",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:73",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:79",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2860,7 +2996,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes-fournisseurs/{id}/accuse",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:81",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:87",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2877,7 +3013,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes-fournisseurs/{id}/documents",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:83",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:89",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2894,7 +3030,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/commandes-fournisseurs/{id}/documents/{documentId}",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:84",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:90",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2911,7 +3047,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes-fournisseurs/{id}/duplicate",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:87",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:103",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2928,7 +3064,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes-fournisseurs/{id}/lignes",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:75",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:81",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2945,7 +3081,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/commandes-fournisseurs/{id}/lignes/{ligneId}",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:78",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:84",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2962,7 +3098,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/commandes-fournisseurs/{id}/lignes/{ligneId}",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:77",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:83",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2979,7 +3115,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes-fournisseurs/{id}/lignes/reorder",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:76",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:82",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2994,9 +3130,111 @@ export const GENERATED_ROUTE_INVENTORY = [
     ]
   },
   {
+    "method": "get",
+    "path": "/commandes-fournisseurs/{id}/official-documents",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:95",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "listOfficialDocuments"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/commandes-fournisseurs/{id}/official-documents",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:96",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "queueOfficialDocument"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/commandes-fournisseurs/{id}/official-documents/{documentId}",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:97",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "getOfficialDocument"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/commandes-fournisseurs/{id}/official-documents/{documentId}/download",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:99",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "downloadOfficialDocument"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/commandes-fournisseurs/{id}/official-documents/{documentId}/preview",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:98",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "previewOfficialDocument"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/commandes-fournisseurs/{id}/official-documents/{documentId}/print-intents",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:100",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "printOfficialDocument"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
     "method": "post",
     "path": "/commandes-fournisseurs/{id}/receptions/resync",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:86",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:102",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3013,7 +3251,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes-fournisseurs/{id}/transition",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:80",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:86",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3030,7 +3268,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/commandes-fournisseurs/kpis",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:64",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:70",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3047,7 +3285,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes-fournisseurs/propositions/confirm",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:70",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:76",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3064,7 +3302,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes-fournisseurs/propositions/preview",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:69",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:75",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3081,7 +3319,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes-fournisseurs/totaux/simulate",
-    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:67",
+    "source": "src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts:73",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3098,7 +3336,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/commandes/{id}",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:166",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:190",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3114,7 +3352,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/commandes/{id}",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:107",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:124",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3130,7 +3368,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/commandes/{id}",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:163",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:187",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3146,9 +3384,135 @@ export const GENERATED_ROUTE_INVENTORY = [
     ]
   },
   {
+    "method": "get",
+    "path": "/commandes/{id}/acknowledgements",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:205",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "listAcknowledgements"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/commandes/{id}/acknowledgements",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:206",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "createAcknowledgement"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/commandes/{id}/acknowledgements/{documentId}",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:207",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "getAcknowledgement"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/commandes/{id}/acknowledgements/{documentId}/download",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:209",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "downloadAcknowledgement"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/commandes/{id}/acknowledgements/{documentId}/preview",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:208",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "previewAcknowledgement"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/commandes/{id}/acknowledgements/{documentId}/print-intents",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:210",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "printAcknowledgement"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/commandes/{id}/acknowledgements/{documentId}/send",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:211",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "sendAcknowledgement"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
     "method": "post",
     "path": "/commandes/{id}/affaires/generate",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:200",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:234",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3164,7 +3528,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/affaires/preview",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:197",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:231",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3181,7 +3545,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/analyze-stock",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:188",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:222",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3198,7 +3562,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/ar/generate",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:172",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:196",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3215,7 +3579,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/ar/send",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:180",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:214",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3231,8 +3595,84 @@ export const GENERATED_ROUTE_INVENTORY = [
   },
   {
     "method": "get",
+    "path": "/commandes/{id}/creation-snapshot",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:128",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "validate(idParamSchema)",
+      "getCommandeCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/commandes/{id}/creation-snapshot/{documentId}/download",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:130",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "validate(idParamSchema)",
+      "downloadCommandeCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/commandes/{id}/creation-snapshot/{documentId}/preview",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:129",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "validate(idParamSchema)",
+      "previewCommandeCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/commandes/{id}/creation-snapshot/{documentId}/print-intents",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:131",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireAcknowledgementExport",
+      "validate(idParamSchema)",
+      "printCommandeCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireAcknowledgementExport"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/commandes/{id}/documents/{docId}/file",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:124",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:148",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3248,7 +3688,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/duplicate",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:203",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:237",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3264,7 +3704,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/generate-affaires",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:191",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:225",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3281,7 +3721,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/generate-affaires/confirm",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:194",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:228",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3297,7 +3737,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/commandes/{id}/releases",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:128",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:152",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3313,7 +3753,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/releases",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:131",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:155",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3329,7 +3769,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/commandes/{id}/releases/{releaseId}",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:140",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:164",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3345,7 +3785,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/commandes/{id}/releases/{releaseId}",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:134",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:158",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3361,7 +3801,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/commandes/{id}/releases/{releaseId}",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:137",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:161",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3377,7 +3817,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/releases/{releaseId}/lines",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:146",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:170",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3393,7 +3833,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/commandes/{id}/releases/{releaseId}/lines/{lineId}",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:156",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:180",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3409,7 +3849,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/commandes/{id}/releases/{releaseId}/lines/{lineId}",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:149",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:173",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3425,7 +3865,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/releases/{releaseId}/status",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:143",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:167",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3441,7 +3881,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/status",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:169",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:193",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3458,7 +3898,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/commandes/{id}/workflow",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:110",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:134",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3475,7 +3915,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/commandes/{id}/workflow/actions",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:121",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:145",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3492,7 +3932,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/commandes/{id}/workflow/checkpoints/{checkpointCode}",
-    "source": "src/module/commande-client/routes/commande-client.routes.ts:113",
+    "source": "src/module/commande-client/routes/commande-client.routes.ts:137",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3590,7 +4030,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/devis",
-    "source": "src/module/devis/routes/devis.routes.ts:101",
+    "source": "src/module/devis/routes/devis.routes.ts:107",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3607,7 +4047,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/devis",
-    "source": "src/module/devis/routes/devis.routes.ts:108",
+    "source": "src/module/devis/routes/devis.routes.ts:120",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3626,7 +4066,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/devis/{id}",
-    "source": "src/module/devis/routes/devis.routes.ts:112",
+    "source": "src/module/devis/routes/devis.routes.ts:124",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3643,7 +4083,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/devis/{id}",
-    "source": "src/module/devis/routes/devis.routes.ts:104",
+    "source": "src/module/devis/routes/devis.routes.ts:110",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3660,7 +4100,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/devis/{id}",
-    "source": "src/module/devis/routes/devis.routes.ts:111",
+    "source": "src/module/devis/routes/devis.routes.ts:123",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3679,7 +4119,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/devis/{id}/commande-draft",
-    "source": "src/module/devis/routes/devis.routes.ts:106",
+    "source": "src/module/devis/routes/devis.routes.ts:112",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3696,7 +4136,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/devis/{id}/convert-to-commande",
-    "source": "src/module/devis/routes/devis.routes.ts:109",
+    "source": "src/module/devis/routes/devis.routes.ts:121",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3713,7 +4153,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/devis/{id}/documents/{docId}/file",
-    "source": "src/module/devis/routes/devis.routes.ts:107",
+    "source": "src/module/devis/routes/devis.routes.ts:113",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3728,9 +4168,111 @@ export const GENERATED_ROUTE_INVENTORY = [
     ]
   },
   {
+    "method": "get",
+    "path": "/devis/{id}/official-documents",
+    "source": "src/module/devis/routes/devis.routes.ts:114",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "listDevisOfficialDocuments"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/devis/{id}/official-documents",
+    "source": "src/module/devis/routes/devis.routes.ts:115",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "queueDevisOfficialDocument"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/devis/{id}/official-documents/{documentId}",
+    "source": "src/module/devis/routes/devis.routes.ts:116",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "getDevisOfficialDocument"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/devis/{id}/official-documents/{documentId}/download",
+    "source": "src/module/devis/routes/devis.routes.ts:118",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "downloadDevisOfficialDocument"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/devis/{id}/official-documents/{documentId}/preview",
+    "source": "src/module/devis/routes/devis.routes.ts:117",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "previewDevisOfficialDocument"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/devis/{id}/official-documents/{documentId}/print-intents",
+    "source": "src/module/devis/routes/devis.routes.ts:119",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireCapability(export)",
+      "printDevisOfficialDocument"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireCapability(export)"
+    ]
+  },
+  {
     "method": "post",
     "path": "/devis/{id}/revise",
-    "source": "src/module/devis/routes/devis.routes.ts:110",
+    "source": "src/module/devis/routes/devis.routes.ts:122",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3749,7 +4291,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/devis/{id}/versions",
-    "source": "src/module/devis/routes/devis.routes.ts:105",
+    "source": "src/module/devis/routes/devis.routes.ts:111",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3766,7 +4308,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/devis/by-article-devis-code/{code}",
-    "source": "src/module/devis/routes/devis.routes.ts:103",
+    "source": "src/module/devis/routes/devis.routes.ts:109",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -3783,7 +4325,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/devis/by-article/{articleId}",
-    "source": "src/module/devis/routes/devis.routes.ts:102",
+    "source": "src/module/devis/routes/devis.routes.ts:108",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4629,7 +5171,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:49",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:53",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4645,7 +5187,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/fournisseurs",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:56",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:65",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4663,7 +5205,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs/{id}",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:52",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:61",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4679,7 +5221,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/fournisseurs/{id}",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:57",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:66",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4697,7 +5239,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs/{id}/adresses",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:69",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:78",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4713,7 +5255,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/fournisseurs/{id}/adresses",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:70",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:79",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4731,7 +5273,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/fournisseurs/{id}/adresses/{adresseId}",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:72",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:81",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4749,7 +5291,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/fournisseurs/{id}/adresses/{adresseId}",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:71",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:80",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4767,7 +5309,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/fournisseurs/{id}/archive",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:59",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:68",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4785,7 +5327,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs/{id}/catalogue",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:80",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:89",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4801,7 +5343,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/fournisseurs/{id}/catalogue",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:81",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:90",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4819,7 +5361,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/fournisseurs/{id}/catalogue/{catalogueId}",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:83",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:92",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4837,7 +5379,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/fournisseurs/{id}/catalogue/{catalogueId}",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:82",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:91",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4855,7 +5397,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs/{id}/contacts",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:63",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:72",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4871,7 +5413,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/fournisseurs/{id}/contacts",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:64",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:73",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4889,7 +5431,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/fournisseurs/{id}/contacts/{contactId}",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:66",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:75",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4907,7 +5449,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/fournisseurs/{id}/contacts/{contactId}",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:65",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:74",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4923,9 +5465,73 @@ export const GENERATED_ROUTE_INVENTORY = [
     ]
   },
   {
+    "method": "get",
+    "path": "/fournisseurs/{id}/creation-snapshot",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:57",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "getFournisseurCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/fournisseurs/{id}/creation-snapshot/{documentId}/download",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:59",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "downloadFournisseurCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/fournisseurs/{id}/creation-snapshot/{documentId}/preview",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:58",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "previewFournisseurCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/fournisseurs/{id}/creation-snapshot/{documentId}/print-intents",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:60",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "printFournisseurCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
     "method": "post",
     "path": "/fournisseurs/{id}/deactivate",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:58",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:67",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4943,7 +5549,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs/{id}/documents",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:86",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:95",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4959,7 +5565,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/fournisseurs/{id}/documents",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:87",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:96",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4978,7 +5584,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/fournisseurs/{id}/documents/{docId}",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:88",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:97",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4996,7 +5602,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs/{id}/documents/{docId}/download",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:89",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:98",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -5012,7 +5618,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "put",
     "path": "/fournisseurs/{id}/domaines",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:60",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:69",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -5030,7 +5636,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs/{id}/events",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:53",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:62",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -5046,7 +5652,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs/{id}/homologations",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:75",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:84",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -5062,7 +5668,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/fournisseurs/{id}/homologations",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:76",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:85",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -5080,7 +5686,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/fournisseurs/{id}/homologations/{homologationId}",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:77",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:86",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -5098,7 +5704,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs/domaines",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:51",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:55",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -5114,7 +5720,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/fournisseurs/doublons",
-    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:50",
+    "source": "src/module/fournisseurs/routes/fournisseurs.routes.ts:54",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8711,7 +9317,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:182",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:186",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8727,7 +9333,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:151",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:155",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8744,7 +9350,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/pieces-techniques/{id}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:190",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:200",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8763,7 +9369,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/{id}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:188",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:198",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8780,7 +9386,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/pieces-techniques/{id}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:189",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:199",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8798,7 +9404,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/achats",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:232",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:242",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8816,7 +9422,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/pieces-techniques/{id}/achats/{achatId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:234",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:244",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8833,7 +9439,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/pieces-techniques/{id}/achats/{achatId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:233",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:243",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8851,7 +9457,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/achats/reorder",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:235",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:245",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8869,7 +9475,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/{id}/affaires",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:237",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:247",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8886,7 +9492,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/affaires",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:238",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:248",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8904,7 +9510,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/pieces-techniques/{id}/affaires/{affaireId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:239",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:249",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8921,7 +9527,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/{id}/arborescence",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:184",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:188",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8938,7 +9544,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/{id}/article-principal",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:196",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:206",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8955,7 +9561,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/create-or-link-article-fabrique",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:197",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:207",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8971,8 +9577,76 @@ export const GENERATED_ROUTE_INVENTORY = [
   },
   {
     "method": "get",
+    "path": "/pieces-techniques/{id}/creation-snapshot",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:194",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "validate(idParamSchema)",
+      "getPieceTechniqueCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/pieces-techniques/{id}/creation-snapshot/{documentId}/download",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:196",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "validate(idParamSchema)",
+      "downloadPieceTechniqueCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/pieces-techniques/{id}/creation-snapshot/{documentId}/preview",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:195",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "validate(idParamSchema)",
+      "previewPieceTechniqueCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/pieces-techniques/{id}/creation-snapshot/{documentId}/print-intents",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:197",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "validate(idParamSchema)",
+      "printPieceTechniqueCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/pieces-techniques/{id}/document-dossier",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:185",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:189",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -8989,7 +9663,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/{id}/document-dossier/pdf",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:186",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:190",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9006,7 +9680,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/{id}/documents",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:241",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:251",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9023,7 +9697,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/documents",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:242",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:252",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9041,7 +9715,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/pieces-techniques/{id}/documents/{docId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:243",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:253",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9058,7 +9732,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/{id}/documents/{docId}/file",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:244",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:254",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9075,7 +9749,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/duplicate",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:192",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:202",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9092,7 +9766,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/nomenclature",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:222",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:232",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9110,7 +9784,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/pieces-techniques/{id}/nomenclature/{lineId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:224",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:234",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9127,7 +9801,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/pieces-techniques/{id}/nomenclature/{lineId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:223",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:233",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9145,7 +9819,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/nomenclature/reorder",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:225",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:235",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9163,7 +9837,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/operations",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:227",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:237",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9181,7 +9855,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/pieces-techniques/{id}/operations/{opId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:229",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:239",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9198,7 +9872,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/pieces-techniques/{id}/operations/{opId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:228",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:238",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9216,7 +9890,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/operations/reorder",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:230",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:240",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9234,7 +9908,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/piece-critique",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:187",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:191",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9252,7 +9926,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/status",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:193",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:203",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9270,7 +9944,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/{id}/versions",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:200",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:210",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9287,7 +9961,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/versions",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:201",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:211",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9305,7 +9979,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/pieces-techniques/{id}/versions/{versionId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:202",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:212",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9323,7 +9997,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/{id}/versions/{versionId}/completeness",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:206",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:216",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9341,7 +10015,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/versions/{versionId}/create-next",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:205",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:215",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9359,7 +10033,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/{id}/versions/{versionId}/publish",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:204",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:214",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9379,7 +10053,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/pieces-techniques/{id}/versions/{versionId}/status",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:203",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:213",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9399,7 +10073,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/{id}/versions/{versionId}/tool-requirements",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:216",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:226",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9417,7 +10091,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "put",
     "path": "/pieces-techniques/{id}/versions/{versionId}/tool-requirements",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:211",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:221",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9435,7 +10109,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/by-affaire/{affaireId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:183",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:187",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9452,7 +10126,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/code-preview",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:150",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:154",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9468,7 +10142,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/document-policy/{clientId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:167",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:171",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9485,7 +10159,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "put",
     "path": "/pieces-techniques/document-policy/{clientId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:168",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:172",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9505,7 +10179,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/document-types",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:158",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:162",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9521,7 +10195,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/document-types",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:159",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:163",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9540,7 +10214,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/pieces-techniques/document-types/{code}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:160",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:164",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9560,7 +10234,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/drafts",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:175",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:179",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9576,7 +10250,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/pieces-techniques/drafts",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:176",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:180",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9593,7 +10267,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/pieces-techniques/drafts/{draftId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:179",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:183",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9610,7 +10284,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/drafts/{draftId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:177",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:181",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9627,7 +10301,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "put",
     "path": "/pieces-techniques/drafts/{draftId}",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:178",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:182",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9645,7 +10319,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/permissions",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:157",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:161",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9661,7 +10335,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/summary",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:154",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:158",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -9677,7 +10351,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/pieces-techniques/versions/{versionId}/document-requirements",
-    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:180",
+    "source": "src/module/pieces-techniques/routes/pieces-techniques.routes.ts:184",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10657,7 +11331,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/groups",
-    "source": "src/module/production/routes/production.routes.ts:229",
+    "source": "src/module/production/routes/production.routes.ts:239",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10675,7 +11349,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/groups",
-    "source": "src/module/production/routes/production.routes.ts:230",
+    "source": "src/module/production/routes/production.routes.ts:240",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10693,7 +11367,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/groups/{id}",
-    "source": "src/module/production/routes/production.routes.ts:231",
+    "source": "src/module/production/routes/production.routes.ts:241",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10711,7 +11385,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/groups/{id}",
-    "source": "src/module/production/routes/production.routes.ts:232",
+    "source": "src/module/production/routes/production.routes.ts:242",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10729,7 +11403,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/groups/{id}/link",
-    "source": "src/module/production/routes/production.routes.ts:233",
+    "source": "src/module/production/routes/production.routes.ts:243",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10747,7 +11421,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/groups/{id}/unlink",
-    "source": "src/module/production/routes/production.routes.ts:234",
+    "source": "src/module/production/routes/production.routes.ts:244",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10765,7 +11439,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machine-models",
-    "source": "src/module/production/routes/production.routes.ts:172",
+    "source": "src/module/production/routes/production.routes.ts:176",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10783,7 +11457,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machine-models/{id}",
-    "source": "src/module/production/routes/production.routes.ts:173",
+    "source": "src/module/production/routes/production.routes.ts:177",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10801,7 +11475,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machine-models/{id}/capabilities",
-    "source": "src/module/production/routes/production.routes.ts:174",
+    "source": "src/module/production/routes/production.routes.ts:178",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10819,7 +11493,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machine-models/{id}/documents",
-    "source": "src/module/production/routes/production.routes.ts:175",
+    "source": "src/module/production/routes/production.routes.ts:179",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10837,7 +11511,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines",
-    "source": "src/module/production/routes/production.routes.ts:177",
+    "source": "src/module/production/routes/production.routes.ts:181",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10855,7 +11529,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines",
-    "source": "src/module/production/routes/production.routes.ts:196",
+    "source": "src/module/production/routes/production.routes.ts:200",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10874,7 +11548,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/production/machines/{id}",
-    "source": "src/module/production/routes/production.routes.ts:199",
+    "source": "src/module/production/routes/production.routes.ts:203",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10892,7 +11566,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}",
-    "source": "src/module/production/routes/production.routes.ts:194",
+    "source": "src/module/production/routes/production.routes.ts:198",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10910,7 +11584,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/machines/{id}",
-    "source": "src/module/production/routes/production.routes.ts:198",
+    "source": "src/module/production/routes/production.routes.ts:202",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10929,7 +11603,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/capabilities",
-    "source": "src/module/production/routes/production.routes.ts:188",
+    "source": "src/module/production/routes/production.routes.ts:192",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10947,7 +11621,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/context",
-    "source": "src/module/production/routes/production.routes.ts:178",
+    "source": "src/module/production/routes/production.routes.ts:182",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10965,7 +11639,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/documents",
-    "source": "src/module/production/routes/production.routes.ts:189",
+    "source": "src/module/production/routes/production.routes.ts:193",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -10983,7 +11657,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/documents",
-    "source": "src/module/production/routes/production.routes.ts:191",
+    "source": "src/module/production/routes/production.routes.ts:195",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11001,7 +11675,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/production/machines/{id}/documents/{documentId}",
-    "source": "src/module/production/routes/production.routes.ts:193",
+    "source": "src/module/production/routes/production.routes.ts:197",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11019,7 +11693,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/documents/{documentId}/download",
-    "source": "src/module/production/routes/production.routes.ts:192",
+    "source": "src/module/production/routes/production.routes.ts:196",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11037,7 +11711,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/documents/upload",
-    "source": "src/module/production/routes/production.routes.ts:190",
+    "source": "src/module/production/routes/production.routes.ts:194",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11056,7 +11730,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/maintenance/events",
-    "source": "src/module/production/routes/production.routes.ts:185",
+    "source": "src/module/production/routes/production.routes.ts:189",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11074,7 +11748,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/maintenance/events",
-    "source": "src/module/production/routes/production.routes.ts:186",
+    "source": "src/module/production/routes/production.routes.ts:190",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11092,7 +11766,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/maintenance/plans",
-    "source": "src/module/production/routes/production.routes.ts:182",
+    "source": "src/module/production/routes/production.routes.ts:186",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11110,7 +11784,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/maintenance/plans",
-    "source": "src/module/production/routes/production.routes.ts:183",
+    "source": "src/module/production/routes/production.routes.ts:187",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11128,7 +11802,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/machines/{id}/maintenance/plans/{planId}",
-    "source": "src/module/production/routes/production.routes.ts:184",
+    "source": "src/module/production/routes/production.routes.ts:188",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11146,7 +11820,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/machines/{id}/onboarding",
-    "source": "src/module/production/routes/production.routes.ts:197",
+    "source": "src/module/production/routes/production.routes.ts:201",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11165,7 +11839,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/reactivate",
-    "source": "src/module/production/routes/production.routes.ts:187",
+    "source": "src/module/production/routes/production.routes.ts:191",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11183,7 +11857,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/unavailability",
-    "source": "src/module/production/routes/production.routes.ts:179",
+    "source": "src/module/production/routes/production.routes.ts:183",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11201,7 +11875,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/unavailability",
-    "source": "src/module/production/routes/production.routes.ts:180",
+    "source": "src/module/production/routes/production.routes.ts:184",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11219,7 +11893,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/production/machines/{id}/unavailability/{unavailabilityId}",
-    "source": "src/module/production/routes/production.routes.ts:181",
+    "source": "src/module/production/routes/production.routes.ts:185",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11237,7 +11911,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/onboarding",
-    "source": "src/module/production/routes/production.routes.ts:195",
+    "source": "src/module/production/routes/production.routes.ts:199",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11698,7 +12372,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs",
-    "source": "src/module/production/routes/production.routes.ts:210",
+    "source": "src/module/production/routes/production.routes.ts:214",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11714,7 +12388,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs",
-    "source": "src/module/production/routes/production.routes.ts:216",
+    "source": "src/module/production/routes/production.routes.ts:226",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11732,7 +12406,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}",
-    "source": "src/module/production/routes/production.routes.ts:215",
+    "source": "src/module/production/routes/production.routes.ts:225",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11748,7 +12422,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/ofs/{id}",
-    "source": "src/module/production/routes/production.routes.ts:217",
+    "source": "src/module/production/routes/production.routes.ts:227",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11764,9 +12438,73 @@ export const GENERATED_ROUTE_INVENTORY = [
     ]
   },
   {
+    "method": "get",
+    "path": "/production/ofs/{id}/creation-snapshot",
+    "source": "src/module/production/routes/production.routes.ts:221",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "getOfCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/production/ofs/{id}/creation-snapshot/{documentId}/download",
+    "source": "src/module/production/routes/production.routes.ts:223",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "downloadOfCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/production/ofs/{id}/creation-snapshot/{documentId}/preview",
+    "source": "src/module/production/routes/production.routes.ts:222",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "previewOfCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/production/ofs/{id}/creation-snapshot/{documentId}/print-intents",
+    "source": "src/module/production/routes/production.routes.ts:224",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "printOfCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
+    ]
+  },
+  {
     "method": "patch",
     "path": "/production/ofs/{id}/operations/{opId}",
-    "source": "src/module/production/routes/production.routes.ts:219",
+    "source": "src/module/production/routes/production.routes.ts:229",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11784,7 +12522,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs/{id}/operations/{opId}/time-logs/start",
-    "source": "src/module/production/routes/production.routes.ts:220",
+    "source": "src/module/production/routes/production.routes.ts:230",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11802,7 +12540,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs/{id}/operations/{opId}/time-logs/stop",
-    "source": "src/module/production/routes/production.routes.ts:221",
+    "source": "src/module/production/routes/production.routes.ts:231",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11820,7 +12558,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/ofs/{id}/operations/reorder",
-    "source": "src/module/production/routes/production.routes.ts:218",
+    "source": "src/module/production/routes/production.routes.ts:228",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11838,7 +12576,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs/{id}/receipt",
-    "source": "src/module/production/routes/production.routes.ts:225",
+    "source": "src/module/production/routes/production.routes.ts:235",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11856,7 +12594,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}/receipt-context",
-    "source": "src/module/production/routes/production.routes.ts:224",
+    "source": "src/module/production/routes/production.routes.ts:234",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11874,7 +12612,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}/technical-snapshot",
-    "source": "src/module/production/routes/production.routes.ts:214",
+    "source": "src/module/production/routes/production.routes.ts:218",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11890,7 +12628,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}/traceability",
-    "source": "src/module/production/routes/production.routes.ts:226",
+    "source": "src/module/production/routes/production.routes.ts:236",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11908,7 +12646,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}/tree",
-    "source": "src/module/production/routes/production.routes.ts:213",
+    "source": "src/module/production/routes/production.routes.ts:217",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11924,7 +12662,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs/generate",
-    "source": "src/module/production/routes/production.routes.ts:212",
+    "source": "src/module/production/routes/production.routes.ts:216",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11942,7 +12680,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs/generate/preview",
-    "source": "src/module/production/routes/production.routes.ts:211",
+    "source": "src/module/production/routes/production.routes.ts:215",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11960,7 +12698,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/operators",
-    "source": "src/module/production/routes/production.routes.ts:237",
+    "source": "src/module/production/routes/production.routes.ts:247",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11978,7 +12716,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/pointages",
-    "source": "src/module/production/routes/production.routes.ts:238",
+    "source": "src/module/production/routes/production.routes.ts:248",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11996,7 +12734,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/pointages",
-    "source": "src/module/production/routes/production.routes.ts:241",
+    "source": "src/module/production/routes/production.routes.ts:251",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12014,7 +12752,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/pointages/{id}",
-    "source": "src/module/production/routes/production.routes.ts:240",
+    "source": "src/module/production/routes/production.routes.ts:250",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12032,7 +12770,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/pointages/{id}",
-    "source": "src/module/production/routes/production.routes.ts:244",
+    "source": "src/module/production/routes/production.routes.ts:254",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12050,7 +12788,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/pointages/{id}/start",
-    "source": "src/module/production/routes/production.routes.ts:242",
+    "source": "src/module/production/routes/production.routes.ts:252",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12068,7 +12806,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/pointages/{id}/stop",
-    "source": "src/module/production/routes/production.routes.ts:243",
+    "source": "src/module/production/routes/production.routes.ts:253",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12086,7 +12824,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/pointages/{id}/validate",
-    "source": "src/module/production/routes/production.routes.ts:245",
+    "source": "src/module/production/routes/production.routes.ts:255",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12104,7 +12842,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/pointages/kpis",
-    "source": "src/module/production/routes/production.routes.ts:239",
+    "source": "src/module/production/routes/production.routes.ts:249",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12122,7 +12860,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/postes",
-    "source": "src/module/production/routes/production.routes.ts:202",
+    "source": "src/module/production/routes/production.routes.ts:206",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12138,7 +12876,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/postes",
-    "source": "src/module/production/routes/production.routes.ts:204",
+    "source": "src/module/production/routes/production.routes.ts:208",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12154,7 +12892,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/production/postes/{id}",
-    "source": "src/module/production/routes/production.routes.ts:206",
+    "source": "src/module/production/routes/production.routes.ts:210",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12172,7 +12910,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/postes/{id}",
-    "source": "src/module/production/routes/production.routes.ts:203",
+    "source": "src/module/production/routes/production.routes.ts:207",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12188,7 +12926,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/postes/{id}",
-    "source": "src/module/production/routes/production.routes.ts:205",
+    "source": "src/module/production/routes/production.routes.ts:209",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16013,7 +16751,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/analytics",
-    "source": "src/module/stock/routes/stock.routes.ts:126",
+    "source": "src/module/stock/routes/stock.routes.ts:130",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16031,7 +16769,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/article-categories",
-    "source": "src/module/stock/routes/stock.routes.ts:137",
+    "source": "src/module/stock/routes/stock.routes.ts:141",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16049,7 +16787,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/article-families",
-    "source": "src/module/stock/routes/stock.routes.ts:139",
+    "source": "src/module/stock/routes/stock.routes.ts:143",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16067,7 +16805,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/article-families",
-    "source": "src/module/stock/routes/stock.routes.ts:140",
+    "source": "src/module/stock/routes/stock.routes.ts:144",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16085,7 +16823,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/articles",
-    "source": "src/module/stock/routes/stock.routes.ts:147",
+    "source": "src/module/stock/routes/stock.routes.ts:151",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16103,7 +16841,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/articles",
-    "source": "src/module/stock/routes/stock.routes.ts:156",
+    "source": "src/module/stock/routes/stock.routes.ts:160",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16121,7 +16859,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/articles/{id}",
-    "source": "src/module/stock/routes/stock.routes.ts:157",
+    "source": "src/module/stock/routes/stock.routes.ts:166",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16139,7 +16877,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/stock/articles/{id}",
-    "source": "src/module/stock/routes/stock.routes.ts:158",
+    "source": "src/module/stock/routes/stock.routes.ts:167",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16157,7 +16895,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/articles/{id}/archive",
-    "source": "src/module/stock/routes/stock.routes.ts:160",
+    "source": "src/module/stock/routes/stock.routes.ts:169",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16174,8 +16912,80 @@ export const GENERATED_ROUTE_INVENTORY = [
   },
   {
     "method": "get",
+    "path": "/stock/articles/{id}/creation-snapshot",
+    "source": "src/module/stock/routes/stock.routes.ts:162",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireStockCapability(read)",
+      "getStockArticleCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireStockCapability(read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/stock/articles/{id}/creation-snapshot/{documentId}/download",
+    "source": "src/module/stock/routes/stock.routes.ts:164",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireStockCapability(read)",
+      "downloadStockArticleCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireStockCapability(read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/stock/articles/{id}/creation-snapshot/{documentId}/preview",
+    "source": "src/module/stock/routes/stock.routes.ts:163",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireStockCapability(read)",
+      "previewStockArticleCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireStockCapability(read)"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/stock/articles/{id}/creation-snapshot/{documentId}/print-intents",
+    "source": "src/module/stock/routes/stock.routes.ts:165",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireStockCapability(read)",
+      "printStockArticleCreationSnapshot"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireStockCapability(read)"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/stock/articles/{id}/definition-technique",
-    "source": "src/module/stock/routes/stock.routes.ts:196",
+    "source": "src/module/stock/routes/stock.routes.ts:205",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16193,7 +17003,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/articles/{id}/documents",
-    "source": "src/module/stock/routes/stock.routes.ts:200",
+    "source": "src/module/stock/routes/stock.routes.ts:209",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16211,7 +17021,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/articles/{id}/documents",
-    "source": "src/module/stock/routes/stock.routes.ts:201",
+    "source": "src/module/stock/routes/stock.routes.ts:210",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16230,7 +17040,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/stock/articles/{id}/documents/{docId}",
-    "source": "src/module/stock/routes/stock.routes.ts:202",
+    "source": "src/module/stock/routes/stock.routes.ts:211",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16248,7 +17058,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/articles/{id}/documents/{docId}/file",
-    "source": "src/module/stock/routes/stock.routes.ts:203",
+    "source": "src/module/stock/routes/stock.routes.ts:212",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16266,7 +17076,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/stock/articles/{id}/link-piece-technique",
-    "source": "src/module/stock/routes/stock.routes.ts:198",
+    "source": "src/module/stock/routes/stock.routes.ts:207",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16284,7 +17094,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/articles/{id}/link-piece-technique",
-    "source": "src/module/stock/routes/stock.routes.ts:197",
+    "source": "src/module/stock/routes/stock.routes.ts:206",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16302,7 +17112,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/articles/{id}/reactivate",
-    "source": "src/module/stock/routes/stock.routes.ts:161",
+    "source": "src/module/stock/routes/stock.routes.ts:170",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16320,7 +17130,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/articles/{id}/validate",
-    "source": "src/module/stock/routes/stock.routes.ts:159",
+    "source": "src/module/stock/routes/stock.routes.ts:168",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16338,7 +17148,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/articles/{id}/versions",
-    "source": "src/module/stock/routes/stock.routes.ts:162",
+    "source": "src/module/stock/routes/stock.routes.ts:171",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16356,7 +17166,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/articles/{id}/where-used",
-    "source": "src/module/stock/routes/stock.routes.ts:163",
+    "source": "src/module/stock/routes/stock.routes.ts:172",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16374,7 +17184,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/articles/code-preview",
-    "source": "src/module/stock/routes/stock.routes.ts:149",
+    "source": "src/module/stock/routes/stock.routes.ts:153",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16392,7 +17202,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/articles/export.csv",
-    "source": "src/module/stock/routes/stock.routes.ts:152",
+    "source": "src/module/stock/routes/stock.routes.ts:156",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16410,7 +17220,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/articles/kpis",
-    "source": "src/module/stock/routes/stock.routes.ts:148",
+    "source": "src/module/stock/routes/stock.routes.ts:152",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16428,7 +17238,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/articles/material-code-preview",
-    "source": "src/module/stock/routes/stock.routes.ts:151",
+    "source": "src/module/stock/routes/stock.routes.ts:155",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16446,7 +17256,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/articles/similaires",
-    "source": "src/module/stock/routes/stock.routes.ts:155",
+    "source": "src/module/stock/routes/stock.routes.ts:159",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16464,7 +17274,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/balances",
-    "source": "src/module/stock/routes/stock.routes.ts:249",
+    "source": "src/module/stock/routes/stock.routes.ts:258",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16482,7 +17292,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/emplacements",
-    "source": "src/module/stock/routes/stock.routes.ts:226",
+    "source": "src/module/stock/routes/stock.routes.ts:235",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16500,7 +17310,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/stock/emplacements/{id}",
-    "source": "src/module/stock/routes/stock.routes.ts:227",
+    "source": "src/module/stock/routes/stock.routes.ts:236",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16518,7 +17328,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/historical-imports",
-    "source": "src/module/stock/routes/stock.routes.ts:136",
+    "source": "src/module/stock/routes/stock.routes.ts:140",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16536,7 +17346,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/intelligence/overview",
-    "source": "src/module/stock/routes/stock.routes.ts:127",
+    "source": "src/module/stock/routes/stock.routes.ts:131",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16554,7 +17364,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/intelligence/policies",
-    "source": "src/module/stock/routes/stock.routes.ts:129",
+    "source": "src/module/stock/routes/stock.routes.ts:133",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16572,7 +17382,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/intelligence/simulate",
-    "source": "src/module/stock/routes/stock.routes.ts:128",
+    "source": "src/module/stock/routes/stock.routes.ts:132",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16590,7 +17400,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/inventory",
-    "source": "src/module/stock/routes/stock.routes.ts:135",
+    "source": "src/module/stock/routes/stock.routes.ts:139",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16608,7 +17418,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/inventory-sessions",
-    "source": "src/module/stock/routes/stock.routes.ts:165",
+    "source": "src/module/stock/routes/stock.routes.ts:174",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16626,7 +17436,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/inventory-sessions",
-    "source": "src/module/stock/routes/stock.routes.ts:166",
+    "source": "src/module/stock/routes/stock.routes.ts:175",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16644,7 +17454,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/inventory-sessions/{id}",
-    "source": "src/module/stock/routes/stock.routes.ts:167",
+    "source": "src/module/stock/routes/stock.routes.ts:176",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16662,7 +17472,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/inventory-sessions/{id}/approve",
-    "source": "src/module/stock/routes/stock.routes.ts:179",
+    "source": "src/module/stock/routes/stock.routes.ts:188",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16680,7 +17490,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/inventory-sessions/{id}/cancel",
-    "source": "src/module/stock/routes/stock.routes.ts:184",
+    "source": "src/module/stock/routes/stock.routes.ts:193",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16698,7 +17508,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/inventory-sessions/{id}/close",
-    "source": "src/module/stock/routes/stock.routes.ts:189",
+    "source": "src/module/stock/routes/stock.routes.ts:198",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16716,7 +17526,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/inventory-sessions/{id}/lines",
-    "source": "src/module/stock/routes/stock.routes.ts:168",
+    "source": "src/module/stock/routes/stock.routes.ts:177",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16734,7 +17544,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "put",
     "path": "/stock/inventory-sessions/{id}/lines",
-    "source": "src/module/stock/routes/stock.routes.ts:174",
+    "source": "src/module/stock/routes/stock.routes.ts:183",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16752,7 +17562,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/inventory-sessions/{id}/start",
-    "source": "src/module/stock/routes/stock.routes.ts:169",
+    "source": "src/module/stock/routes/stock.routes.ts:178",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16770,7 +17580,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/lots",
-    "source": "src/module/stock/routes/stock.routes.ts:233",
+    "source": "src/module/stock/routes/stock.routes.ts:242",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16788,7 +17598,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/lots",
-    "source": "src/module/stock/routes/stock.routes.ts:234",
+    "source": "src/module/stock/routes/stock.routes.ts:243",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16806,7 +17616,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/lots/{id}",
-    "source": "src/module/stock/routes/stock.routes.ts:240",
+    "source": "src/module/stock/routes/stock.routes.ts:249",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16824,7 +17634,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/stock/lots/{id}",
-    "source": "src/module/stock/routes/stock.routes.ts:241",
+    "source": "src/module/stock/routes/stock.routes.ts:250",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16842,7 +17652,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/lots/{id}/genealogy",
-    "source": "src/module/stock/routes/stock.routes.ts:247",
+    "source": "src/module/stock/routes/stock.routes.ts:256",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16860,7 +17670,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/lots/{id}/quality-status",
-    "source": "src/module/stock/routes/stock.routes.ts:242",
+    "source": "src/module/stock/routes/stock.routes.ts:251",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16878,7 +17688,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/lots/genealogy",
-    "source": "src/module/stock/routes/stock.routes.ts:235",
+    "source": "src/module/stock/routes/stock.routes.ts:244",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16896,7 +17706,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/magasins",
-    "source": "src/module/stock/routes/stock.routes.ts:209",
+    "source": "src/module/stock/routes/stock.routes.ts:218",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16914,7 +17724,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/magasins",
-    "source": "src/module/stock/routes/stock.routes.ts:211",
+    "source": "src/module/stock/routes/stock.routes.ts:220",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16932,7 +17742,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/magasins/{id}",
-    "source": "src/module/stock/routes/stock.routes.ts:212",
+    "source": "src/module/stock/routes/stock.routes.ts:221",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16950,7 +17760,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/stock/magasins/{id}",
-    "source": "src/module/stock/routes/stock.routes.ts:213",
+    "source": "src/module/stock/routes/stock.routes.ts:222",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16968,7 +17778,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/magasins/{id}/activate",
-    "source": "src/module/stock/routes/stock.routes.ts:219",
+    "source": "src/module/stock/routes/stock.routes.ts:228",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -16986,7 +17796,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/magasins/{id}/deactivate",
-    "source": "src/module/stock/routes/stock.routes.ts:214",
+    "source": "src/module/stock/routes/stock.routes.ts:223",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17004,7 +17814,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/magasins/{magasinId}/emplacements",
-    "source": "src/module/stock/routes/stock.routes.ts:220",
+    "source": "src/module/stock/routes/stock.routes.ts:229",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17022,7 +17832,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/magasins/kpis",
-    "source": "src/module/stock/routes/stock.routes.ts:210",
+    "source": "src/module/stock/routes/stock.routes.ts:219",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17040,7 +17850,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/matiere-etats",
-    "source": "src/module/stock/routes/stock.routes.ts:143",
+    "source": "src/module/stock/routes/stock.routes.ts:147",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17058,7 +17868,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/matiere-etats",
-    "source": "src/module/stock/routes/stock.routes.ts:144",
+    "source": "src/module/stock/routes/stock.routes.ts:148",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17076,7 +17886,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/matiere-nuances",
-    "source": "src/module/stock/routes/stock.routes.ts:141",
+    "source": "src/module/stock/routes/stock.routes.ts:145",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17094,7 +17904,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/matiere-nuances",
-    "source": "src/module/stock/routes/stock.routes.ts:142",
+    "source": "src/module/stock/routes/stock.routes.ts:146",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17112,7 +17922,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/matiere-sous-etats",
-    "source": "src/module/stock/routes/stock.routes.ts:145",
+    "source": "src/module/stock/routes/stock.routes.ts:149",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17130,7 +17940,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/matiere-sous-etats",
-    "source": "src/module/stock/routes/stock.routes.ts:146",
+    "source": "src/module/stock/routes/stock.routes.ts:150",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17148,7 +17958,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/movements",
-    "source": "src/module/stock/routes/stock.routes.ts:269",
+    "source": "src/module/stock/routes/stock.routes.ts:278",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17166,7 +17976,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/movements",
-    "source": "src/module/stock/routes/stock.routes.ts:271",
+    "source": "src/module/stock/routes/stock.routes.ts:280",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17184,7 +17994,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/movements/{id}",
-    "source": "src/module/stock/routes/stock.routes.ts:272",
+    "source": "src/module/stock/routes/stock.routes.ts:281",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17202,7 +18012,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/movements/{id}/cancel",
-    "source": "src/module/stock/routes/stock.routes.ts:284",
+    "source": "src/module/stock/routes/stock.routes.ts:293",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17220,7 +18030,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/movements/{id}/compensate",
-    "source": "src/module/stock/routes/stock.routes.ts:278",
+    "source": "src/module/stock/routes/stock.routes.ts:287",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17238,7 +18048,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/movements/{id}/compensation-preview",
-    "source": "src/module/stock/routes/stock.routes.ts:273",
+    "source": "src/module/stock/routes/stock.routes.ts:282",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17256,7 +18066,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/movements/{id}/documents",
-    "source": "src/module/stock/routes/stock.routes.ts:286",
+    "source": "src/module/stock/routes/stock.routes.ts:295",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17274,7 +18084,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/movements/{id}/documents",
-    "source": "src/module/stock/routes/stock.routes.ts:287",
+    "source": "src/module/stock/routes/stock.routes.ts:296",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17293,7 +18103,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/stock/movements/{id}/documents/{docId}",
-    "source": "src/module/stock/routes/stock.routes.ts:293",
+    "source": "src/module/stock/routes/stock.routes.ts:302",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17311,7 +18121,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/movements/{id}/documents/{docId}/file",
-    "source": "src/module/stock/routes/stock.routes.ts:298",
+    "source": "src/module/stock/routes/stock.routes.ts:307",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17329,7 +18139,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/movements/{id}/post",
-    "source": "src/module/stock/routes/stock.routes.ts:283",
+    "source": "src/module/stock/routes/stock.routes.ts:292",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17347,7 +18157,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/movements/preview",
-    "source": "src/module/stock/routes/stock.routes.ts:270",
+    "source": "src/module/stock/routes/stock.routes.ts:279",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17365,7 +18175,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/positions",
-    "source": "src/module/stock/routes/stock.routes.ts:134",
+    "source": "src/module/stock/routes/stock.routes.ts:138",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17383,7 +18193,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/reservations",
-    "source": "src/module/stock/routes/stock.routes.ts:251",
+    "source": "src/module/stock/routes/stock.routes.ts:260",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17401,7 +18211,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/reservations",
-    "source": "src/module/stock/routes/stock.routes.ts:252",
+    "source": "src/module/stock/routes/stock.routes.ts:261",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17419,7 +18229,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/reservations/{id}",
-    "source": "src/module/stock/routes/stock.routes.ts:257",
+    "source": "src/module/stock/routes/stock.routes.ts:266",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17437,7 +18247,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/reservations/{id}/consume",
-    "source": "src/module/stock/routes/stock.routes.ts:263",
+    "source": "src/module/stock/routes/stock.routes.ts:272",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17455,7 +18265,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/stock/reservations/{id}/release",
-    "source": "src/module/stock/routes/stock.routes.ts:258",
+    "source": "src/module/stock/routes/stock.routes.ts:267",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -17473,7 +18283,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/stock/units",
-    "source": "src/module/stock/routes/stock.routes.ts:138",
+    "source": "src/module/stock/routes/stock.routes.ts:142",
     "middleware": [
       "anonymous",
       "authenticateToken",


### PR DESCRIPTION
Adds immutable authoritative PDF archives, durable outbox processing, official supplier PO/quote/order-acknowledgement PDFs, automatic internal creation snapshots in GED for clients, suppliers, customer and supplier orders, root OFs, technical pieces, affairs and stock articles, read-only secured routes, migration support, and exhaustive transactional/mounted-route tests.

## Summary by Sourcery

Establish immutable, server-authoritative PDF archiving with durable GED delivery and automatic creation snapshots across the supported business workflows.

New Features:
- Add authoritative PDF archives and automatic internal creation snapshots for supported business entities and document workflows.
- Expose secured official-document and read-only creation-snapshot routes for preview, download, metadata, printing, and acknowledgement sending.

Bug Fixes:
- Ensure generated documents use immutable server-side snapshots and exact archived bytes instead of mutable or client-supplied data.
- Prevent stale workers, duplicate requests, unsafe filenames, invalid PDFs, malformed snapshots, and imprecise monetary values from producing inconsistent archives.

Enhancements:
- Introduce durable transactional outbox processing with idempotency, immutable archive records, content hashes, GED linking, retry handling, lease reclamation, and sanitized browser-facing status envelopes.
- Add server-side renderers and bounded PDF layouts for supplier purchase orders, quotes, acknowledgements, and internal creation snapshots.
- Cover creation, duplication, conversion, promotion, generation, and alternate lifecycle paths while excluding historical imports and child manufacturing orders.

Deployment:
- Add guarded, reversible migration support with read-only preflight and verification scripts for the authoritative PDF archive schema and GED classes.

Documentation:
- Document the authoritative PDF archive architecture, HTTP contracts, GED classification policies, transactional guarantees, and creation-snapshot route behavior in ADR-0081.
- Update route coverage and migration rehearsal inventories for the new endpoints and migration.

Tests:
- Add domain, renderer, worker, migration, HTTP, route-contract, mounted-route, and transactional tests covering archive integrity, security, idempotency, retries, and lifecycle coverage.