### PR TITLE
fix(ged): authorize private bytes through live parent records

### DIFF
--- a/docs/adr/ADR-0089-private-media-parent-authorization.md
+++ b/docs/adr/ADR-0089-private-media-parent-authorization.md
@@ -1,0 +1,54 @@
+# ADR-0089 — Parent authorization for private GED and operational media
+
+## Status
+
+Accepted — issue #615.
+
+## Decision
+
+Possession of a GED version UUID or operational-media UUID is never an
+authorization grant. Before private bytes are opened, the delivery boundary
+must resolve exactly one current, supported business parent and apply that
+parent module's access profile. An absent, unsupported, malformed, stale,
+ambiguous, or inaccessible binding receives the same opaque `404` response.
+
+GED document-link aliases are accepted only through this closed map:
+
+| Link type(s) | Canonical parent | Module | Parent identity |
+| --- | --- | --- | --- |
+| `CLIENT` | `CLIENT` | `clients` | text |
+| `FOURNISSEUR` | `FOURNISSEUR` | `fournisseurs` | UUID |
+| `DEVIS` | `DEVIS` | `devis` | integer |
+| `FACTURE`, `AVOIR` | same | `facturation` | integer |
+| `BON_LIVRAISON`, `LIVRAISON` | `BON_LIVRAISON` | `livraisons` | UUID |
+| `COMMANDE_CLIENT`, `COMMANDE-CLIENT` | `COMMANDE_CLIENT` | `commandes-clients` | integer |
+| `COMMANDE_FOURNISSEUR`, `COMMANDE-FOURNISSEUR` | `COMMANDE_FOURNISSEUR` | `commandes-fournisseurs` | UUID |
+| `AFFAIRE` | `AFFAIRE` | `affaires` | integer |
+| `ORDRE_FABRICATION`, `ORDRE-FABRICATION`, `OF` | `ORDRE_FABRICATION` | `production` | integer |
+| `PIECE_TECHNIQUE`, `PIECE-TECHNIQUE`, `PIECE_TECHNIQUE_VERSION` | same | `pieces-techniques` | UUID |
+| `STOCK_ARTICLE`, `STOCK-ARTICLE` | `STOCK_ARTICLE` | `stock` | integer |
+| `OUTIL` | `OUTIL` | `outillage` | integer |
+
+Operational media uses a separate closed owner map: machine → production,
+client → clients, fournisseur → fournisseurs, tooling owners → outillage, and
+an active user avatar → chat. It also requires one binding, a live owner, and
+the correct binding module; reused assets are denied rather than selecting a
+visible owner.
+
+Both transports persist an append-only authorization receipt before any
+response byte. A failure to persist it fails closed. The post-finish completion
+event records a completed transfer only after the sender reports completion;
+an aborted or integrity-failed transfer is never reported as a download.
+
+## Consequences
+
+- Historical link vocabulary is not a compatibility bypass: it remains
+  unavailable until explicitly added to the reviewed map with a parent query
+  and module policy.
+- Parent existence is revalidated at each request. This narrows stale links
+  and prevents guessed UUIDs from being used as direct-object references.
+- The check happens before the storage key is resolved and private download
+  headers remain `private, no-store`, `nosniff`, and same-origin.
+- Authorization is module-scoped because the current access-control model is
+  module-scoped. A future per-record or tenant policy must replace (not weaken)
+  this boundary and preserve opaque denials.

--- a/src/__tests__/ged-download-audit.test.ts
+++ b/src/__tests__/ged-download-audit.test.ts
@@ -2,12 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   downloadVersion: vi.fn(),
+  recordVersionDownloadAuthorized: vi.fn(),
   recordVersionDownload: vi.fn(),
   sendSecureStoredFile: vi.fn(),
 }));
 
 vi.mock("../module/ged/services/ged.service", () => ({
   downloadVersion: mocks.downloadVersion,
+  recordVersionDownloadAuthorized: mocks.recordVersionDownloadAuthorized,
   recordVersionDownload: mocks.recordVersionDownload,
 }));
 
@@ -34,6 +36,7 @@ describe("GED download audit completion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.downloadVersion.mockResolvedValue(download);
+    mocks.recordVersionDownloadAuthorized.mockResolvedValue(undefined);
     mocks.recordVersionDownload.mockResolvedValue(undefined);
   });
 
@@ -52,6 +55,7 @@ describe("GED download audit completion", () => {
     );
 
     expect(next).not.toHaveBeenCalled();
+    expect(mocks.recordVersionDownloadAuthorized).toHaveBeenCalledWith({ id: 7, role: "administrateur" }, download);
     expect(mocks.recordVersionDownload).not.toHaveBeenCalled();
   });
 
@@ -70,11 +74,27 @@ describe("GED download audit completion", () => {
     );
 
     expect(next).not.toHaveBeenCalled();
+    expect(mocks.recordVersionDownloadAuthorized).toHaveBeenCalledWith({ id: 7, role: "administrateur" }, download);
     expect(mocks.recordVersionDownload).toHaveBeenCalledTimes(1);
     expect(mocks.recordVersionDownload).toHaveBeenCalledWith(
       { id: 7, role: "administrateur" },
       download,
       "DOWNLOAD"
     );
+  });
+
+  it("fails closed before delivery when the durable authorization receipt cannot persist", async () => {
+    mocks.recordVersionDownloadAuthorized.mockRejectedValueOnce(new Error("audit unavailable"));
+    const next = vi.fn();
+    const response = { setHeader: vi.fn() };
+
+    await downloadVersion(
+      { params: { versionId: VERSION_ID }, user: { id: 7, role: "administrateur" } } as never,
+      response as never,
+      next
+    );
+
+    expect(mocks.sendSecureStoredFile).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/module/ged/controllers/ged.controller.ts
+++ b/src/module/ged/controllers/ged.controller.ts
@@ -218,6 +218,11 @@ export async function downloadVersion(req: Request, res: Response, next: NextFun
     const actor = actorFrom(req);
     const result = await service.downloadVersion(actor, versionId);
 
+    // This write is an authorization receipt, not a claimed successful
+    // transfer. It is intentionally before any response byte: if durable audit
+    // storage is unavailable, the private document stays unavailable.
+    await service.recordVersionDownloadAuthorized(actor, result);
+
     // `attachment` + `nosniff` : un document n'est jamais interprété par le
     // navigateur, quel que soit son type déclaré.
     res.setHeader("X-CERP-Document-SHA256", result.sha256);

--- a/src/module/ged/repository/ged.repository.ts
+++ b/src/module/ged/repository/ged.repository.ts
@@ -1169,6 +1169,60 @@ export async function repoInternalGetVersionContentRef(versionId: string): Promi
   }
 }
 
+/**
+ * Internal-only parent binding lookup used at the byte-delivery boundary.
+ * A GED document is deliberately not downloadable merely because a user has
+ * the global GED capability: its single business parent must be known and
+ * live. Unknown historical link vocabularies are resolved by the service as
+ * an opaque denial so this query must never be exposed through a controller.
+ */
+export async function repoInternalListDocumentParentLinks(documentId: string): Promise<Array<{
+  entity_type: string;
+  entity_id: string;
+}>> {
+  try {
+    const result = await pool.query<{ entity_type: string; entity_id: string }>(
+      `SELECT entity_type, entity_id
+         FROM public.ged_document_links
+        WHERE document_id = $1::uuid
+        ORDER BY created_at ASC, id ASC`,
+      [documentId]
+    );
+    return result.rows.map((row) => ({ entity_type: String(row.entity_type), entity_id: String(row.entity_id) }));
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+/** Closed, non-dynamic parent existence registry for byte authorization. */
+export async function repoInternalParentLinkExists(entityType: string, entityId: string): Promise<boolean> {
+  const key = entityType.trim().toUpperCase();
+  const statements: Record<string, { sql: string; values: unknown[] }> = {
+    CLIENT: { sql: "SELECT 1 FROM public.clients WHERE client_id = $1 LIMIT 1", values: [entityId] },
+    FOURNISSEUR: { sql: "SELECT 1 FROM public.fournisseurs WHERE id = $1::uuid LIMIT 1", values: [entityId] },
+    DEVIS: { sql: "SELECT 1 FROM public.devis WHERE id = $1::bigint LIMIT 1", values: [entityId] },
+    FACTURE: { sql: "SELECT 1 FROM public.facture WHERE id = $1 LIMIT 1", values: [entityId] },
+    AVOIR: { sql: "SELECT 1 FROM public.avoir WHERE id = $1 LIMIT 1", values: [entityId] },
+    BON_LIVRAISON: { sql: "SELECT 1 FROM public.bon_livraison WHERE id = $1::uuid LIMIT 1", values: [entityId] },
+    COMMANDE_CLIENT: { sql: "SELECT 1 FROM public.commande_client WHERE id = $1::bigint LIMIT 1", values: [entityId] },
+    COMMANDE_FOURNISSEUR: { sql: "SELECT 1 FROM public.commande_fournisseur WHERE id = $1::uuid LIMIT 1", values: [entityId] },
+    AFFAIRE: { sql: "SELECT 1 FROM public.affaire WHERE id = $1::bigint LIMIT 1", values: [entityId] },
+    ORDRE_FABRICATION: { sql: "SELECT 1 FROM public.ordres_fabrication WHERE id = $1::bigint LIMIT 1", values: [entityId] },
+    PIECE_TECHNIQUE: { sql: "SELECT 1 FROM public.pieces_techniques WHERE id = $1::uuid LIMIT 1", values: [entityId] },
+    PIECE_TECHNIQUE_VERSION: { sql: "SELECT 1 FROM public.piece_technique_versions WHERE id = $1::uuid LIMIT 1", values: [entityId] },
+    STOCK_ARTICLE: { sql: "SELECT 1 FROM public.articles WHERE id = $1::bigint LIMIT 1", values: [entityId] },
+    OUTIL: { sql: "SELECT 1 FROM public.gestion_outils_outil WHERE id_outil = $1::integer LIMIT 1", values: [entityId] },
+  };
+  const statement = statements[key];
+  if (!statement) return false;
+  try {
+    const result = await pool.query(statement.sql, statement.values);
+    return result.rowCount !== 0;
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
 /** Fresh-connection reconciliation used only after a COMMIT acknowledgement loss. */
 export async function repoIsVersionBlobCommitted(
   versionId: string,

--- a/src/module/ged/services/ged-parent-authorization.service.test.ts
+++ b/src/module/ged/services/ged-parent-authorization.service.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ links: vi.fn(), exists: vi.fn(), profile: vi.fn() }));
+vi.mock("../repository/ged.repository", () => ({
+  repoInternalListDocumentParentLinks: mocks.links,
+  repoInternalParentLinkExists: mocks.exists,
+}));
+vi.mock("../../access-control/services/access-control.service", () => ({ resolveAccessProfile: mocks.profile }));
+
+import { assertGedVersionParentReadable } from "./ged-parent-authorization.service";
+
+const documentId = "11111111-1111-4111-8111-111111111111";
+
+afterEach(() => vi.resetAllMocks());
+
+describe("GED parent-record download authorization", () => {
+  it("requires one supported, live parent and its current module grant", async () => {
+    mocks.links.mockResolvedValue([{ entity_type: "commande-client", entity_id: "42" }]);
+    mocks.exists.mockResolvedValue(true);
+    mocks.profile.mockResolvedValue({ is_superadmin: false, modules: [{ module_key: "commandes-clients", allowed: true }] });
+
+    await expect(assertGedVersionParentReadable(7, documentId)).resolves.toEqual({
+      moduleKey: "commandes-clients", entityType: "COMMANDE_CLIENT", entityId: "42",
+    });
+    expect(mocks.exists).toHaveBeenCalledWith("COMMANDE_CLIENT", "42");
+  });
+
+  it.each([
+    ["AFFAIRE", "affaires", "AFFAIRE"],
+    ["STOCK_ARTICLE", "stock", "STOCK_ARTICLE"],
+    ["STOCK-ARTICLE", "stock", "STOCK_ARTICLE"],
+  ])("accepts the live integer identity used by %s", async (entityType, moduleKey, canonicalType) => {
+    mocks.links.mockResolvedValue([{ entity_type: entityType, entity_id: "42" }]);
+    mocks.exists.mockResolvedValue(true);
+    mocks.profile.mockResolvedValue({ is_superadmin: false, modules: [{ module_key: moduleKey, allowed: true }] });
+
+    await expect(assertGedVersionParentReadable(7, documentId)).resolves.toEqual({
+      moduleKey,
+      entityType: canonicalType,
+      entityId: "42",
+    });
+    expect(mocks.exists).toHaveBeenCalledWith(canonicalType, "42");
+  });
+
+  it.each([
+    ["unlinked", []],
+    ["ambiguous", [{ entity_type: "CLIENT", entity_id: "c-1" }, { entity_type: "OUTIL", entity_id: "2" }]],
+    ["unsupported", [{ entity_type: "HISTORICAL_UNKNOWN", entity_id: "c-1" }]],
+  ])("returns the same opaque 404 for %s parent links", async (_case, links) => {
+    mocks.links.mockResolvedValue(links);
+    await expect(assertGedVersionParentReadable(7, documentId)).rejects.toMatchObject({ status: 404, code: "GED_VERSION_NOT_FOUND" });
+    expect(mocks.profile).not.toHaveBeenCalled();
+  });
+
+  it("does not disclose a foreign/deleted parent or a cross-module IDOR", async () => {
+    mocks.links.mockResolvedValue([{ entity_type: "ORDRE_FABRICATION", entity_id: "42" }]);
+    mocks.exists.mockResolvedValueOnce(false);
+    await expect(assertGedVersionParentReadable(7, documentId)).rejects.toMatchObject({ status: 404 });
+
+    mocks.exists.mockResolvedValueOnce(true);
+    mocks.profile.mockResolvedValueOnce({ is_superadmin: false, modules: [{ module_key: "clients", allowed: true }] });
+    await expect(assertGedVersionParentReadable(7, documentId)).rejects.toMatchObject({ status: 404, code: "GED_VERSION_NOT_FOUND" });
+  });
+
+  it("fails closed when the access-control profile cannot be resolved", async () => {
+    mocks.links.mockResolvedValue([{ entity_type: "CLIENT", entity_id: "c-1" }]);
+    mocks.exists.mockResolvedValue(true);
+    mocks.profile.mockResolvedValue(null);
+    await expect(assertGedVersionParentReadable(7, documentId)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it.each([
+    ["integer", "COMMANDE_CLIENT", "not-a-number"],
+    ["integer", "AFFAIRE", "not-a-number"],
+    ["integer", "STOCK_ARTICLE", "not-a-number"],
+    ["uuid", "FOURNISSEUR", "not-a-uuid"],
+  ])("turns a malformed persisted %s parent id into the same opaque denial", async (_kind, entity_type, entity_id) => {
+    mocks.links.mockResolvedValue([{ entity_type, entity_id }]);
+
+    await expect(assertGedVersionParentReadable(7, documentId)).rejects.toMatchObject({
+      status: 404,
+      code: "GED_VERSION_NOT_FOUND",
+    });
+    expect(mocks.exists).not.toHaveBeenCalled();
+    expect(mocks.profile).not.toHaveBeenCalled();
+  });
+});

--- a/src/module/ged/services/ged-parent-authorization.service.ts
+++ b/src/module/ged/services/ged-parent-authorization.service.ts
@@ -1,0 +1,77 @@
+import { resolveAccessProfile } from "../../access-control/services/access-control.service";
+import { HttpError } from "../../../utils/httpError";
+import { repoInternalListDocumentParentLinks, repoInternalParentLinkExists } from "../repository/ged.repository";
+
+type ParentIdentity = "text" | "integer" | "uuid";
+type ParentPolicy = Readonly<{ moduleKey: string; canonicalType: string; identity: ParentIdentity }>;
+
+// GED links are free-text for historical compatibility. Delivery is not: only
+// these explicitly reviewed parent shapes can authorize private bytes. Each
+// alias resolves to the exact canonical parent that is revalidated in SQL.
+const PARENT_POLICIES: Readonly<Record<string, ParentPolicy>> = {
+  CLIENT: { moduleKey: "clients", canonicalType: "CLIENT", identity: "text" },
+  FOURNISSEUR: { moduleKey: "fournisseurs", canonicalType: "FOURNISSEUR", identity: "uuid" },
+  DEVIS: { moduleKey: "devis", canonicalType: "DEVIS", identity: "integer" },
+  FACTURE: { moduleKey: "facturation", canonicalType: "FACTURE", identity: "integer" },
+  AVOIR: { moduleKey: "facturation", canonicalType: "AVOIR", identity: "integer" },
+  BON_LIVRAISON: { moduleKey: "livraisons", canonicalType: "BON_LIVRAISON", identity: "uuid" },
+  LIVRAISON: { moduleKey: "livraisons", canonicalType: "BON_LIVRAISON", identity: "uuid" },
+  COMMANDE_CLIENT: { moduleKey: "commandes-clients", canonicalType: "COMMANDE_CLIENT", identity: "integer" },
+  "COMMANDE-CLIENT": { moduleKey: "commandes-clients", canonicalType: "COMMANDE_CLIENT", identity: "integer" },
+  COMMANDE_FOURNISSEUR: { moduleKey: "commandes-fournisseurs", canonicalType: "COMMANDE_FOURNISSEUR", identity: "uuid" },
+  "COMMANDE-FOURNISSEUR": { moduleKey: "commandes-fournisseurs", canonicalType: "COMMANDE_FOURNISSEUR", identity: "uuid" },
+  AFFAIRE: { moduleKey: "affaires", canonicalType: "AFFAIRE", identity: "integer" },
+  ORDRE_FABRICATION: { moduleKey: "production", canonicalType: "ORDRE_FABRICATION", identity: "integer" },
+  "ORDRE-FABRICATION": { moduleKey: "production", canonicalType: "ORDRE_FABRICATION", identity: "integer" },
+  OF: { moduleKey: "production", canonicalType: "ORDRE_FABRICATION", identity: "integer" },
+  PIECE_TECHNIQUE: { moduleKey: "pieces-techniques", canonicalType: "PIECE_TECHNIQUE", identity: "uuid" },
+  "PIECE-TECHNIQUE": { moduleKey: "pieces-techniques", canonicalType: "PIECE_TECHNIQUE", identity: "uuid" },
+  PIECE_TECHNIQUE_VERSION: { moduleKey: "pieces-techniques", canonicalType: "PIECE_TECHNIQUE_VERSION", identity: "uuid" },
+  STOCK_ARTICLE: { moduleKey: "stock", canonicalType: "STOCK_ARTICLE", identity: "integer" },
+  "STOCK-ARTICLE": { moduleKey: "stock", canonicalType: "STOCK_ARTICLE", identity: "integer" },
+  OUTIL: { moduleKey: "outillage", canonicalType: "OUTIL", identity: "integer" },
+};
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const INTEGER = /^\d+$/;
+
+function opaqueNotFound(): never {
+  // Identical for absent, unlinked, ambiguous, stale and foreign documents.
+  throw new HttpError(404, "GED_VERSION_NOT_FOUND", "Version introuvable.");
+}
+
+function policyFor(entityType: string): ParentPolicy | null {
+  return PARENT_POLICIES[entityType.trim().toUpperCase()] ?? null;
+}
+
+function canonicalParentId(value: string, identity: ParentIdentity): string | null {
+  const id = value.trim();
+  if (!id) return null;
+  if (identity === "text") return id;
+  if (identity === "uuid") return UUID.test(id) ? id : null;
+  // PostgreSQL integer casts otherwise turn a malformed historical link into
+  // a visible 500. The parent-link boundary must treat that record exactly
+  // like an unknown or stale parent, before asking the repository anything.
+  return INTEGER.test(id) ? id : null;
+}
+
+/**
+ * Enforces one unambiguous live business parent and that parent's module ACL.
+ * This is intentionally a shared service boundary rather than controller
+ * convention: future GED transports must call it before resolving storage.
+ */
+export async function assertGedVersionParentReadable(actorUserId: number, documentId: string): Promise<{ moduleKey: string; entityType: string; entityId: string }> {
+  const links = await repoInternalListDocumentParentLinks(documentId);
+  if (links.length !== 1) opaqueNotFound();
+  const link = links[0];
+  const policy = policyFor(link.entity_type);
+  const entityId = policy ? canonicalParentId(link.entity_id, policy.identity) : null;
+  if (!policy || !entityId) opaqueNotFound();
+  if (!await repoInternalParentLinkExists(policy.canonicalType, entityId)) opaqueNotFound();
+
+  const profile = await resolveAccessProfile(actorUserId);
+  if (!profile || !(profile.is_superadmin || profile.modules.some((entry) => entry.module_key === policy.moduleKey && entry.allowed))) {
+    opaqueNotFound();
+  }
+  return { moduleKey: policy.moduleKey, entityType: policy.canonicalType, entityId };
+}

--- a/src/module/ged/services/ged.service.ts
+++ b/src/module/ged/services/ged.service.ts
@@ -67,6 +67,7 @@ import {
   GedCommitUncertainError,
   type GedUploadSessionInternal,
 } from "../repository/ged.repository";
+import { assertGedVersionParentReadable } from "./ged-parent-authorization.service";
 import type {
   GedAccessEvent,
   GedDocumentClass,
@@ -1137,6 +1138,11 @@ export async function downloadVersion(actor: GedActor, versionId: string): Promi
     assertGedCapability(actor.role, "upload");
   }
 
+  // Global GED capability is not a parent-record grant. Require one known,
+  // live parent and that module's current entitlement before storage is even
+  // resolved, so a guessed version UUID cannot become an IDOR primitive.
+  await assertGedVersionParentReadable(actor.id, ref.document_id);
+
   const blob = await resolveBlobForDownload(ref.storage_key);
 
   return {
@@ -1149,6 +1155,17 @@ export async function downloadVersion(actor: GedActor, versionId: string): Promi
     document_id: ref.document_id,
     version_id: ref.version_id,
   };
+}
+
+/** Durable receipt that must succeed before the controller sends any bytes. */
+export async function recordVersionDownloadAuthorized(actor: GedActor, result: DownloadResult): Promise<void> {
+  await repoLogAccess(pool, {
+    document_id: result.document_id,
+    version_id: result.version_id,
+    event_type: "READ",
+    actor_id: actor.id,
+    details: { delivery: "authorized", size_bytes: result.size_bytes },
+  });
 }
 
 export async function recordVersionDownload(
@@ -1164,5 +1181,5 @@ export async function recordVersionDownload(
     details: outcome === "DOWNLOAD"
       ? { size_bytes: result.size_bytes }
       : { expected_sha256: result.sha256 },
-  }).catch(() => undefined);
+  });
 }

--- a/src/module/operational-media/services/operational-media.service.test.ts
+++ b/src/module/operational-media/services/operational-media.service.test.ts
@@ -108,15 +108,13 @@ describe("operational media authorization", () => {
     await expect(authorizeOperationalMediaRead({ assetId, userId: 7 })).rejects.toMatchObject({ status: 404 });
   });
 
-  it("checks every reused binding independently and audits/returns the passing binding", async () => {
+  it("rejects reused bindings as ambiguous instead of selecting a visible parent", async () => {
     const client = activeMachine({ owner_type: "client", owner_id: "client-1", module_key: "clients" });
     const tool = activeMachine({ owner_type: "outil", owner_id: "24", module_key: "outillage" });
     mocks.find.mockResolvedValue([client, tool]);
-    mocks.profile.mockResolvedValue(allow("outillage"));
-    mocks.ownerExists.mockResolvedValue(true);
-    await expect(authorizeOperationalMediaRead({ assetId, userId: 7 })).resolves.toMatchObject({ asset: { owner_type: "outil", owner_id: "24" } });
-    expect(mocks.ownerExists).toHaveBeenCalledTimes(1);
-    expect(mocks.ownerExists).toHaveBeenCalledWith("outil", "24");
+    await expect(authorizeOperationalMediaRead({ assetId, userId: 7 })).rejects.toMatchObject({ status: 404, code: "MEDIA_NOT_FOUND" });
+    expect(mocks.profile).not.toHaveBeenCalled();
+    expect(mocks.ownerExists).not.toHaveBeenCalled();
   });
 
   it("permits a superadmin only after the parent binding itself exists", async () => {

--- a/src/module/operational-media/services/operational-media.service.ts
+++ b/src/module/operational-media/services/operational-media.service.ts
@@ -16,8 +16,8 @@ const ALLOWED_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "im
 type OwnerPolicy = Readonly<{ moduleKey: "production" | "clients" | "outillage" | "fournisseurs" }> | Readonly<{ authenticatedActiveUser: true }>;
 
 // This is intentionally a small, closed registry rather than a generic table
-// name derived from a binding. It protects the new asset authority from both
-// unknown owner types and the legacy storage-key fallback.
+// name derived from a binding. It protects the asset authority from unknown
+// owner types and the legacy storage-key fallback.
 const OWNER_POLICIES: Readonly<Record<OperationalMediaOwnerType, OwnerPolicy>> = {
   machine: { moduleKey: "production" },
   client: { moduleKey: "clients" },
@@ -54,24 +54,20 @@ export async function authorizeOperationalMediaRead(params: { assetId: string; u
   const assets = await findOperationalMediaAssets(params.assetId);
   // Non-disclosure: a caller must not be able to distinguish a missing asset
   // from one that belongs to another object/module.
-  if (!assets.length) throw new HttpError(404, "MEDIA_NOT_FOUND", "Média introuvable.");
-  let profile: Awaited<ReturnType<typeof resolveAccessProfile>> | undefined;
-  let asset: OperationalMediaAsset | undefined;
-  for (const candidate of assets) {
-    const policy = ownerPolicy(candidate);
-    if (!policy) continue;
-    if (!("authenticatedActiveUser" in policy)) {
-      profile ??= await resolveAccessProfile(params.userId);
-      if (!profileAllowsModule(profile, policy)) continue;
-    }
-    // Each binding is checked independently. This avoids picking the first
-    // module-visible binding when a physical blob was (legitimately or
-    // accidentally) reused by a different owner.
-    if (!await operationalMediaOwnerExists(candidate.owner_type as OperationalMediaOwnerType, candidate.owner_id)) continue;
-    asset = candidate;
-    break;
+  // A physical asset must have one, and only one, reviewed business parent.
+  // Selecting a visible row from a reused/ambiguous binding set would turn the
+  // shared route into an ownership-confusion primitive.
+  if (assets.length !== 1) throw new HttpError(404, "MEDIA_NOT_FOUND", "Média introuvable.");
+  const asset = assets[0];
+  const policy = ownerPolicy(asset);
+  if (!policy) {
+    throw new HttpError(404, "MEDIA_NOT_FOUND", "Média introuvable.");
   }
-  if (!asset) {
+  if (!("authenticatedActiveUser" in policy)) {
+    const profile = await resolveAccessProfile(params.userId);
+    if (!profileAllowsModule(profile, policy)) throw new HttpError(404, "MEDIA_NOT_FOUND", "Média introuvable.");
+  }
+  if (!await operationalMediaOwnerExists(asset.owner_type as OperationalMediaOwnerType, asset.owner_id)) {
     throw new HttpError(404, "MEDIA_NOT_FOUND", "Média introuvable.");
   }
   if (asset.status === "REVOKED") throw new HttpError(410, "MEDIA_REVOKED", "Ce média n'est plus disponible.");


### PR DESCRIPTION
Closes #615. Enforces exactly one supported/live business parent plus its current module grant before resolving GED or operational-media bytes; returns opaque 404s for unlinked, ambiguous, stale, malformed, unsupported, or cross-module access; adds durable pre-byte authorization receipts and completion/integrity audit; documents the closed parent map. Validation: 27 focused tests after schema-identity correction, TypeScript/OpenAPI production build, and independent adversarial review.

## Summary by Sourcery

Enforce parent-record authorization and fail-closed auditing for private GED and operational-media delivery.

Bug Fixes:
- Require GED downloads to resolve exactly one supported, live business parent with the corresponding module authorization before private bytes are accessed.
- Reject ambiguous operational-media ownership bindings instead of selecting a module-visible owner.

Enhancements:
- Add durable pre-delivery authorization receipts and completion/integrity audit handling that fails closed when authorization logging is unavailable.
- Use opaque 404 responses for invalid, stale, unsupported, malformed, unlinked, ambiguous, or cross-module parent access.

Documentation:
- Document the closed parent and owner authorization maps and private-media delivery guarantees in ADR-0089.

Tests:
- Expand GED and operational-media authorization coverage for ambiguous bindings, malformed or stale parents, cross-module access, and audit persistence failures.