### PR TITLE
fix(ged): align stock-article parent identity with live UUID schema

### DIFF
--- a/docs/adr/ADR-0089-private-media-parent-authorization.md
+++ b/docs/adr/ADR-0089-private-media-parent-authorization.md
@@ -26,7 +26,7 @@ GED document-link aliases are accepted only through this closed map:
 | `AFFAIRE` | `AFFAIRE` | `affaires` | integer |
 | `ORDRE_FABRICATION`, `ORDRE-FABRICATION`, `OF` | `ORDRE_FABRICATION` | `production` | integer |
 | `PIECE_TECHNIQUE`, `PIECE-TECHNIQUE`, `PIECE_TECHNIQUE_VERSION` | same | `pieces-techniques` | UUID |
-| `STOCK_ARTICLE`, `STOCK-ARTICLE` | `STOCK_ARTICLE` | `stock` | integer |
+| `STOCK_ARTICLE`, `STOCK-ARTICLE` | `STOCK_ARTICLE` | `stock` | UUID |
 | `OUTIL` | `OUTIL` | `outillage` | integer |
 
 Operational media uses a separate closed owner map: machine → production,

--- a/src/module/ged/repository/ged.repository.ts
+++ b/src/module/ged/repository/ged.repository.ts
@@ -1210,7 +1210,7 @@ export async function repoInternalParentLinkExists(entityType: string, entityId:
     ORDRE_FABRICATION: { sql: "SELECT 1 FROM public.ordres_fabrication WHERE id = $1::bigint LIMIT 1", values: [entityId] },
     PIECE_TECHNIQUE: { sql: "SELECT 1 FROM public.pieces_techniques WHERE id = $1::uuid LIMIT 1", values: [entityId] },
     PIECE_TECHNIQUE_VERSION: { sql: "SELECT 1 FROM public.piece_technique_versions WHERE id = $1::uuid LIMIT 1", values: [entityId] },
-    STOCK_ARTICLE: { sql: "SELECT 1 FROM public.articles WHERE id = $1::bigint LIMIT 1", values: [entityId] },
+    STOCK_ARTICLE: { sql: "SELECT 1 FROM public.articles WHERE id = $1::uuid LIMIT 1", values: [entityId] },
     OUTIL: { sql: "SELECT 1 FROM public.gestion_outils_outil WHERE id_outil = $1::integer LIMIT 1", values: [entityId] },
   };
   const statement = statements[key];

--- a/src/module/ged/services/ged-parent-authorization.service.test.ts
+++ b/src/module/ged/services/ged-parent-authorization.service.test.ts
@@ -27,8 +27,6 @@ describe("GED parent-record download authorization", () => {
 
   it.each([
     ["AFFAIRE", "affaires", "AFFAIRE"],
-    ["STOCK_ARTICLE", "stock", "STOCK_ARTICLE"],
-    ["STOCK-ARTICLE", "stock", "STOCK_ARTICLE"],
   ])("accepts the live integer identity used by %s", async (entityType, moduleKey, canonicalType) => {
     mocks.links.mockResolvedValue([{ entity_type: entityType, entity_id: "42" }]);
     mocks.exists.mockResolvedValue(true);
@@ -40,6 +38,20 @@ describe("GED parent-record download authorization", () => {
       entityId: "42",
     });
     expect(mocks.exists).toHaveBeenCalledWith(canonicalType, "42");
+  });
+
+  it.each(["STOCK_ARTICLE", "STOCK-ARTICLE"])("accepts the live UUID identity used by %s", async (entityType) => {
+    const articleId = "22222222-2222-4222-8222-222222222222";
+    mocks.links.mockResolvedValue([{ entity_type: entityType, entity_id: articleId }]);
+    mocks.exists.mockResolvedValue(true);
+    mocks.profile.mockResolvedValue({ is_superadmin: false, modules: [{ module_key: "stock", allowed: true }] });
+
+    await expect(assertGedVersionParentReadable(7, documentId)).resolves.toEqual({
+      moduleKey: "stock",
+      entityType: "STOCK_ARTICLE",
+      entityId: articleId,
+    });
+    expect(mocks.exists).toHaveBeenCalledWith("STOCK_ARTICLE", articleId);
   });
 
   it.each([
@@ -72,7 +84,7 @@ describe("GED parent-record download authorization", () => {
   it.each([
     ["integer", "COMMANDE_CLIENT", "not-a-number"],
     ["integer", "AFFAIRE", "not-a-number"],
-    ["integer", "STOCK_ARTICLE", "not-a-number"],
+    ["uuid", "STOCK_ARTICLE", "not-a-uuid"],
     ["uuid", "FOURNISSEUR", "not-a-uuid"],
   ])("turns a malformed persisted %s parent id into the same opaque denial", async (_kind, entity_type, entity_id) => {
     mocks.links.mockResolvedValue([{ entity_type, entity_id }]);

--- a/src/module/ged/services/ged-parent-authorization.service.ts
+++ b/src/module/ged/services/ged-parent-authorization.service.ts
@@ -27,8 +27,8 @@ const PARENT_POLICIES: Readonly<Record<string, ParentPolicy>> = {
   PIECE_TECHNIQUE: { moduleKey: "pieces-techniques", canonicalType: "PIECE_TECHNIQUE", identity: "uuid" },
   "PIECE-TECHNIQUE": { moduleKey: "pieces-techniques", canonicalType: "PIECE_TECHNIQUE", identity: "uuid" },
   PIECE_TECHNIQUE_VERSION: { moduleKey: "pieces-techniques", canonicalType: "PIECE_TECHNIQUE_VERSION", identity: "uuid" },
-  STOCK_ARTICLE: { moduleKey: "stock", canonicalType: "STOCK_ARTICLE", identity: "integer" },
-  "STOCK-ARTICLE": { moduleKey: "stock", canonicalType: "STOCK_ARTICLE", identity: "integer" },
+  STOCK_ARTICLE: { moduleKey: "stock", canonicalType: "STOCK_ARTICLE", identity: "uuid" },
+  "STOCK-ARTICLE": { moduleKey: "stock", canonicalType: "STOCK_ARTICLE", identity: "uuid" },
   OUTIL: { moduleKey: "outillage", canonicalType: "OUTIL", identity: "integer" },
 };
 


### PR DESCRIPTION
Closes #620. Restores UUID validation and UUID query casting for STOCK_ARTICLE GED parent bindings while retaining integer AFFAIRE identities. Covers both stock-article aliases with live-shape regression tests. Validation: 27 focused tests and full TypeScript/OpenAPI/security production build.

## Summary by Sourcery

Restore UUID-based GED parent authorization for stock articles while retaining existing identity handling for other parent types.

Bug Fixes:
- Align GED STOCK_ARTICLE parent authorization with UUID identities used by the live schema.
- Preserve integer identity handling for AFFAIRE and other integer-based parent types.

Enhancements:
- Apply UUID validation and database query casting to both STOCK_ARTICLE aliases.
- Add regression coverage for UUID-based stock-article authorization and malformed identifiers.

Documentation:
- Update the private-media authorization ADR to document STOCK_ARTICLE identifiers as UUIDs.

Tests:
- Update GED parent-authorization tests to cover live stock-article UUID identities and opaque denial of invalid UUIDs.