### PR TITLE
fix(ged): require proven vault storage before serving document writes

### DIFF
--- a/.env_exemple
+++ b/.env_exemple
@@ -7,6 +7,14 @@ CERP_INBOUND_ROOT=/srv/cerp/data/inbound
 CERP_EXPORTS_ROOT=/srv/cerp/data/exports
 CERP_TMP_ROOT=/srv/cerp/data/tmp
 CERP_IMAGES_ROOT=/srv/cerp/data/generated/images
+# Private content-addressed GED vault. In production the API will not listen
+# until this exact volume marker is readable and a bounded write/read/delete
+# probe succeeds inside the vault.
+CERP_GED_VAULT_ROOT=/mnt/data/cerp-ged/ged
+CERP_GED_SENTINEL=/mnt/data/cerp-ged/ged/.cerp-ged-volume
+CERP_GED_REQUIRE_SENTINEL=true
+# Optional outside production; production always enforces the startup probe.
+CERP_GED_STARTUP_PREFLIGHT=true
 # Explicit administrative boundary above service-owned roots. On HYPERBOX the
 # `/mnt/data` owner is trusted, but no arbitrary third-party ancestor is.
 CERP_UPLOAD_ADMIN_TRUST_ROOTS=/mnt/data

--- a/docs/http/openapi-route-coverage.json
+++ b/docs/http/openapi-route-coverage.json
@@ -1,9 +1,9 @@
 {
   "scope": "/api/v1",
-  "source_sha256": "f7ef2c7fd490b1828a5cd8a0c34e09ebbaa631784f0ff2ce7b3620014756af96",
-  "discovered_operations": 1128,
-  "documented_operations": 1128,
+  "source_sha256": "c165392634f171493289ff7503d126fab4defc6dde10cff72c8130e0bd75fd52",
+  "discovered_operations": 1129,
+  "documented_operations": 1129,
   "coverage_percent": 100,
-  "authenticated_operations": 1108,
+  "authenticated_operations": 1109,
   "public_operations": 20
 }

--- a/docs/runbooks/ged-vault-startup-and-degraded-mode.md
+++ b/docs/runbooks/ged-vault-startup-and-degraded-mode.md
@@ -1,0 +1,68 @@
+# Runbook opérateur — coffre GED au démarrage et mode dégradé
+
+## Invariant
+
+En production, l'API CERP n'ouvre aucun port tant que le coffre GED n'a pas
+prouvé les quatre propriétés suivantes : racine configurée, sentinelle de volume
+lisible, répertoires privés accessibles et écriture/lecture/suppression d'une
+sonde éphémère. `CERP_GED_REQUIRE_SENTINEL=false` ne désactive jamais ce contrôle
+en production.
+
+La sonde utilise un nom opaque dans `staging/`, 32 octets aléatoires, un `fsync`,
+une relecture exacte et une suppression. Aucun chemin physique n'est renvoyé au
+navigateur ou écrit dans les logs structurés.
+
+## Préparation du volume
+
+1. Monter le volume GED attendu avant de démarrer le conteneur API.
+2. Créer une fois la sentinelle dans `CERP_GED_VAULT_ROOT`, sous le compte
+   d'administration du stockage, puis la laisser lisible par le compte de
+   service. Un chemin extérieur à cette racine est refusé.
+3. Configurer `CERP_GED_VAULT_ROOT`, `CERP_GED_SENTINEL` et
+   `CERP_GED_REQUIRE_SENTINEL=true` avec des chemins absolus. La sentinelle
+   doit être un fichier régulier **dans** `CERP_GED_VAULT_ROOT` (par défaut,
+   `.cerp-ged-volume`) : un marqueur voisin ou sur un autre volume est refusé.
+4. Donner au compte de service les droits privés requis sur la racine GED ; ne
+   jamais configurer un répertoire local de repli.
+5. Vérifier qu'une sauvegarde GED et une sauvegarde PostgreSQL cohérentes sont
+   disponibles avant toute intervention sur un volume contenant des données.
+
+## Démarrage refusé
+
+Le processus journalise `startup_preflight_failed` avec un code et une empreinte
+d'erreur assainis, puis sort avec le code 1. Il ne faut pas contourner la
+sentinelle.
+
+1. Vérifier le montage et l'identité du volume hors du conteneur.
+2. Vérifier que la sentinelle est un fichier régulier lisible, pas un dossier ou
+   un lien de substitution.
+3. Vérifier lecture, écriture, synchronisation et suppression avec le compte de
+   service dans une zone de test dédiée du même volume.
+4. Corriger le montage ou les droits, puis redémarrer l'API.
+5. Attendre `critical_storage_preflight_succeeded`, puis exiger
+   `/health/ready` à HTTP 200 avec `checks.ged_storage.status=up` avant de rendre
+   l'instance disponible.
+
+## Panne après démarrage
+
+La readiness devient rouge et l'ERP affiche « Services de fichiers dégradés ».
+Les dépôts GED et les nouvelles émissions PDF manuelles sont désactivés côté UI
+et restent refusés côté serveur. Les PDF automatiques déjà acceptés restent dans
+la file durable avec un état `PENDING`, `PROCESSING` ou `FAILED`; ils ne sont
+jamais présentés comme « archivés dans la GED » sans octets, empreinte et liens
+GED validés dans la même transaction.
+
+Les consultations métier sans écriture documentaire peuvent continuer. Les
+versions déjà archivées ne doivent jamais être supprimées ou recréées pour
+« débloquer » l'interface.
+
+## Retour à la normale
+
+1. Restaurer le volume et ses droits sans déplacer ni réécrire les blobs.
+2. Vérifier `/health/ready` puis la bannière ERP ; les contrôles se rafraîchissent
+   automatiquement.
+3. Laisser le worker reprendre la file autoritative. Contrôler que chaque item
+   aboutit à `ARCHIVED` et possède ses identifiants GED avant de clore l'incident.
+4. Tester un dépôt propre isolé et un téléchargement authentifié/audité.
+5. Si l'intégrité DB/GED est incertaine, arrêter les writers et lancer le
+   rapprochement opérateur ; ne jamais marquer manuellement un item `ARCHIVED`.

--- a/src/__tests__/authoritative-document.domain.test.ts
+++ b/src/__tests__/authoritative-document.domain.test.ts
@@ -249,6 +249,27 @@ describe("authoritative PDF archive foundation (#612)", () => {
     });
   });
 
+  it("never exposes a failed vault attempt as a stored PDF", () => {
+    const failed = archiveItem({
+      // Defensive contract: even inconsistent residual fields cannot make a
+      // non-ARCHIVED outbox attempt look byte-complete to the browser.
+      pdfSha256: "c".repeat(64),
+      pdfSizeBytes: 987,
+      gedDocumentId: "33333333-3333-4333-8333-333333333333",
+      gedVersionId: "44444444-4444-4444-8444-444444444444",
+      archivedAt: "2026-08-23T10:01:00.000Z",
+    }).archive;
+
+    expect(officialDocumentGenerationEnvelope([
+      { ...failed, state: "FAILED" as const },
+    ], "/devis/1/official-documents")).toEqual({
+      state: "FAILED",
+      latest_document: null,
+      retryable: true,
+      failure_code: "OFFICIAL_DOCUMENT_GENERATION_FAILED",
+    });
+  });
+
   it("orders offset-form archive timestamps by instant rather than lexicographically", () => {
     const olderIssued = archiveItem({
       id: "11111111-1111-4111-8111-111111111111", createdAt: "2026-08-23T10:00:00+02:00",

--- a/src/__tests__/document-service-capabilities.test.ts
+++ b/src/__tests__/document-service-capabilities.test.ts
@@ -1,0 +1,82 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ collect: vi.fn() }));
+
+vi.mock("../shared/document-services/document-service-capabilities", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../shared/document-services/document-service-capabilities")>();
+  return { ...actual, collectDocumentServiceCapabilities: mocks.collect };
+});
+
+import { errorHandler } from "../middlewares/errorHandler";
+import { resolveModuleKeyForPath } from "../module/access-control/domain/module-catalog";
+import routes from "../shared/document-services/document-service-capabilities.routes";
+import { documentServiceCapabilitiesFromHealth } from "../shared/document-services/document-service-capabilities";
+
+const healthy = {
+  configured: true, root_present: true, sentinel_required: true, sentinel_present: true,
+  writable: true, healthy: true, detail: null,
+  capacity_bytes: 123, available_bytes: 45, used_ratio: 0.5, inode_total: 10, inode_free: 5,
+};
+
+function app(authenticated: boolean) {
+  const instance = express();
+  if (authenticated) instance.use((req, _res, next) => {
+    req.user = { id: 42, username: "operator", email: "operator@example.invalid", role: "ADV" };
+    next();
+  });
+  instance.use("/api/v1/service-status", routes);
+  instance.use(errorHandler);
+  return instance;
+}
+
+beforeEach(() => {
+  mocks.collect.mockReset();
+  mocks.collect.mockResolvedValue({
+    contract_version: 1,
+    status: "available",
+    document_writes_supported: true,
+    reason_code: null,
+    checked_at: "2026-08-23T12:00:00.000Z",
+  });
+});
+
+describe("shared document service capabilities (#618)", () => {
+  it("requires authentication without requiring GED module capability", async () => {
+    expect(resolveModuleKeyForPath("/api/v1/service-status/documents")).toBeNull();
+    expect(resolveModuleKeyForPath("/service-status/documents")).toBeNull();
+    await request(app(false)).get("/api/v1/service-status/documents").expect(401);
+    const response = await request(app(true)).get("/api/v1/service-status/documents").expect(200);
+    expect(response.body).toMatchObject({ contract_version: 1, document_writes_supported: true });
+    expect(mocks.collect).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns only a stable reason code and no physical or capacity metadata", () => {
+    const result = documentServiceCapabilitiesFromHealth({
+      ...healthy,
+      healthy: false,
+      writable: false,
+      detail: "private path /mnt/secret is read-only",
+    }, "2026-08-23T12:00:00.000Z");
+
+    expect(result).toEqual({
+      contract_version: 1,
+      status: "degraded",
+      document_writes_supported: false,
+      reason_code: "GED_VAULT_NOT_WRITABLE",
+      checked_at: "2026-08-23T12:00:00.000Z",
+    });
+    expect(JSON.stringify(result)).not.toContain("/mnt/secret");
+    expect(JSON.stringify(result)).not.toContain("capacity");
+  });
+
+  it("distinguishes missing configuration from a missing/wrong mounted volume", () => {
+    expect(documentServiceCapabilitiesFromHealth({
+      ...healthy, configured: false, root_present: false, sentinel_present: false, writable: false, healthy: false,
+    }).reason_code).toBe("GED_VAULT_NOT_CONFIGURED");
+    expect(documentServiceCapabilitiesFromHealth({
+      ...healthy, sentinel_present: false, writable: false, healthy: false,
+    }).reason_code).toBe("GED_VOLUME_NOT_READY");
+  });
+});

--- a/src/__tests__/ged-startup-preflight.test.ts
+++ b/src/__tests__/ged-startup-preflight.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { preflightVaultStorage } from "../module/ged/services/ged-vault.service";
+import {
+  preflightCriticalStorageAtStartup,
+  requiresGedVaultStartupPreflight,
+} from "../shared/runtime/critical-storage-preflight";
+
+const originalEnvironment = { ...process.env };
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  process.env = { ...originalEnvironment };
+  await Promise.all(temporaryRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("GED production startup preflight (#618)", () => {
+  it("runs before generic root creation, route import and the HTTP listener", async () => {
+    const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+    const source = await fs.readFile(path.join(testDirectory, "..", "index.ts"), "utf8");
+    const critical = source.indexOf("await preflightCriticalStorageAtStartup()")
+    const genericRoots = source.indexOf("preflightSecureUploadStorageRoots()")
+    const routeImport = source.indexOf('import("./config/app")')
+    const listen = source.indexOf("httpServer.listen(")
+
+    expect(critical).toBeGreaterThan(-1)
+    expect(critical).toBeLessThan(genericRoots)
+    expect(genericRoots).toBeLessThan(routeImport)
+    expect(routeImport).toBeLessThan(listen)
+  });
+
+  it("cannot be disabled in production and aborts startup before success is reported", async () => {
+    const probe = vi.fn().mockRejectedValue(Object.assign(new Error("synthetic GED outage"), { code: "EROFS" }));
+    const environment = { NODE_ENV: "production", CERP_GED_STARTUP_PREFLIGHT: "false" } as NodeJS.ProcessEnv;
+
+    expect(requiresGedVaultStartupPreflight(environment)).toBe(true);
+    await expect(preflightCriticalStorageAtStartup(environment, { preflightGedVault: probe }))
+      .rejects.toThrow("synthetic GED outage");
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps ordinary tests optional but supports an exact opt-in rehearsal", async () => {
+    const probe = vi.fn().mockResolvedValue(undefined);
+    await expect(preflightCriticalStorageAtStartup({ NODE_ENV: "test" } as NodeJS.ProcessEnv, { preflightGedVault: probe }))
+      .resolves.toEqual({ ged_vault_required: false, ged_vault_ready: false });
+    expect(probe).not.toHaveBeenCalled();
+
+    await expect(preflightCriticalStorageAtStartup({ NODE_ENV: "test", CERP_GED_STARTUP_PREFLIGHT: "true" } as NodeJS.ProcessEnv, { preflightGedVault: probe }))
+      .resolves.toEqual({ ged_vault_required: true, ged_vault_ready: true });
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("proves sentinel readability plus real vault write, read and cleanup", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-ged-startup-"));
+    temporaryRoots.push(parent);
+    const vaultRoot = path.join(parent, "ged");
+    const sentinel = path.join(vaultRoot, ".cerp-ged-volume");
+    await fs.mkdir(vaultRoot, { recursive: true });
+    await fs.writeFile(sentinel, "cerp-ged-volume-v1\n");
+    process.env.NODE_ENV = "production";
+    process.env.CERP_GED_VAULT_ROOT = vaultRoot;
+    process.env.CERP_GED_SENTINEL = sentinel;
+    process.env.CERP_GED_REQUIRE_SENTINEL = "false";
+
+    await expect(preflightVaultStorage()).resolves.toBeUndefined();
+    expect(await fs.readdir(path.join(vaultRoot, "staging"))).toEqual([]);
+  });
+
+  it("rejects a directory masquerading as the production volume sentinel", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-ged-startup-"));
+    temporaryRoots.push(parent);
+    const vaultRoot = path.join(parent, "ged");
+    const fakeSentinel = path.join(vaultRoot, "fake-sentinel");
+    await fs.mkdir(vaultRoot, { recursive: true });
+    await fs.mkdir(fakeSentinel);
+    process.env.NODE_ENV = "production";
+    process.env.CERP_GED_VAULT_ROOT = vaultRoot;
+    process.env.CERP_GED_SENTINEL = fakeSentinel;
+
+    await expect(preflightVaultStorage()).rejects.toMatchObject({
+      status: 503,
+      code: "GED_VAULT_UNAVAILABLE",
+    });
+  });
+
+  it("never creates a missing configured vault root as a local fallback", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-ged-startup-"));
+    temporaryRoots.push(parent);
+    const missingVaultRoot = path.join(parent, "missing-mount");
+    process.env.NODE_ENV = "production";
+    process.env.CERP_GED_VAULT_ROOT = missingVaultRoot;
+    process.env.CERP_GED_SENTINEL = path.join(missingVaultRoot, ".cerp-ged-volume");
+
+    await expect(preflightVaultStorage()).rejects.toMatchObject({
+      status: 503,
+      code: "GED_VAULT_UNAVAILABLE",
+    });
+    await expect(fs.stat(missingVaultRoot)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects a readable sentinel outside the configured vault volume", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-ged-startup-"));
+    temporaryRoots.push(parent);
+    const vaultRoot = path.join(parent, "ged");
+    const outsideSentinel = path.join(parent, ".cerp-ged-volume");
+    await fs.mkdir(vaultRoot, { recursive: true });
+    await fs.writeFile(outsideSentinel, "wrong-volume\n");
+    process.env.NODE_ENV = "production";
+    process.env.CERP_GED_VAULT_ROOT = vaultRoot;
+    process.env.CERP_GED_SENTINEL = outsideSentinel;
+
+    await expect(preflightVaultStorage()).rejects.toMatchObject({
+      status: 503,
+      code: "GED_VAULT_UNAVAILABLE",
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { startElectronicInvoiceMaintenance } from "./module/facturation/electron
 import { startWebhookDeliveryMaintenance } from "./module/integrations/webhooks/webhook.service";
 import { startAuthoritativePdfArchiveMaintenance } from "./shared/authoritative-documents/authoritative-document.worker";
 import { createApplicationShutdown } from "./shared/runtime/application-shutdown";
+import { preflightCriticalStorageAtStartup } from "./shared/runtime/critical-storage-preflight";
 import { preflightSecureUploadStorageRoots } from "./shared/uploads/secure-upload";
 import { getUploadScannerStartupConfiguration } from "./shared/uploads/upload-scanner";
 import { initSocketServer, shutdownRealtimeSocketServer } from "./sockets/sockeServer";
@@ -25,6 +26,11 @@ installStructuredConsole();
 async function start(): Promise<void> {
   assertE2EIsolation();
   assertMfaStartupConfiguration();
+  // Run the GED identity/RW proof before the generic upload-root preflight:
+  // otherwise a missing mount could be replaced by a newly created directory
+  // on the system disk before the sentinel has been checked.
+  const criticalStorage = await preflightCriticalStorageAtStartup();
+  logger.info("critical_storage_preflight_succeeded", criticalStorage);
   // Run before importing routes: several upload middlewares allocate their
   // private quarantine during module initialization.
   const uploadRoots = preflightSecureUploadStorageRoots();

--- a/src/module/ged/services/ged-vault.service.ts
+++ b/src/module/ged/services/ged-vault.service.ts
@@ -82,32 +82,68 @@ export function isVaultConfigured(): boolean {
  * `CERP_GED_REQUIRE_SENTINEL=false` n'est acceptable qu'en développement.
  */
 function sentinelRequired(): boolean {
+  // A production process may never weaken the mount-identity check through a
+  // stale deployment variable. Without the marker, a missing volume can look
+  // like an empty writable directory on the system disk.
+  if (process.env.NODE_ENV === "production") return true;
   const raw = cleanEnv(process.env.CERP_GED_REQUIRE_SENTINEL);
-  if (raw === null) return process.env.NODE_ENV === "production";
+  if (raw === null) return false;
   return raw.toLowerCase() !== "false" && raw !== "0";
 }
 
 function sentinelPath(root: string): string {
   const configured = cleanEnv(process.env.CERP_GED_SENTINEL);
-  return configured ? path.resolve(configured) : path.join(root, "..", SENTINEL_DEFAULT_NAME);
+  return configured ? path.resolve(configured) : path.join(root, SENTINEL_DEFAULT_NAME);
+}
+
+function assertSentinelPathInsideRoot(root: string, marker: string): void {
+  if (!isPathInsideDirectory(root, marker)) {
+    throw new HttpError(
+      503,
+      "GED_VAULT_UNAVAILABLE",
+      "La sentinelle du coffre doit appartenir au volume documentaire configuré."
+    );
+  }
 }
 
 async function assertSentinel(root: string): Promise<void> {
   if (!sentinelRequired()) return;
+  let handle: FileHandle | null = null;
   try {
-    await fs.access(sentinelPath(root));
+    const marker = sentinelPath(root);
+    assertSentinelPathInsideRoot(root, marker);
+    const markerStat = await fs.lstat(marker);
+    if (!markerStat.isFile()) throw new Error("GED sentinel is not a regular file");
+    // Opening the marker proves that the process can read the mounted volume,
+    // not merely that a directory entry with the right name exists.
+    handle = await fs.open(marker, "r");
+    await handle.read(Buffer.alloc(1), 0, 1, 0);
   } catch {
     throw new HttpError(
       503,
       "GED_VAULT_UNAVAILABLE",
-      "Le volume documentaire attendu n'est pas monté (sentinelle absente)."
+      "Le volume documentaire attendu n'est pas monté ou sa sentinelle n'est pas lisible."
     );
+  } finally {
+    await handle?.close().catch(() => undefined);
   }
 }
 
 /** Prépare et vérifie la racine du coffre. Lève 503 plutôt que de se rabattre. */
 export async function ensureVaultReady(): Promise<string> {
   const root = getVaultRoot();
+  try {
+    const rootStat = await fs.stat(root);
+    if (!rootStat.isDirectory()) throw new Error("GED vault root is not a directory");
+  } catch {
+    // Never let directory creation turn an absent mount point into a local
+    // fallback. The configured root itself is an operator-owned prerequisite.
+    throw new HttpError(
+      503,
+      "GED_VAULT_UNAVAILABLE",
+      "La racine configurée du coffre est absente ou inaccessible."
+    );
+  }
   await assertSentinel(root);
   try {
     ensurePrivateUploadDirectory(path.join(root, VAULT_SUBDIR), root);
@@ -122,6 +158,55 @@ export async function ensureVaultReady(): Promise<string> {
     );
   }
   return root;
+}
+
+/**
+ * Real bounded read/write probe used at production startup and by readiness.
+ * Directory creation alone is not proof that an NFS/SMB mount is writable: a
+ * read-only or disconnected volume can retain the expected directory tree.
+ */
+async function probeVaultReadWrite(root: string): Promise<void> {
+  const stagingRoot = path.join(root, STAGING_SUBDIR);
+  const probePath = path.join(stagingRoot, `.cerp-rw-probe-${crypto.randomUUID()}`);
+  const expected = crypto.randomBytes(32);
+  let handle: FileHandle | null = null;
+  let primaryError: unknown = null;
+  try {
+    handle = await fs.open(probePath, "wx+", 0o600);
+    await handle.writeFile(expected);
+    await handle.sync();
+    const actual = await fs.readFile(probePath);
+    if (actual.length !== expected.length || !crypto.timingSafeEqual(actual, expected)) {
+      throw Object.assign(new Error("GED vault read/write probe mismatch"), { code: "EIO" });
+    }
+  } catch (error) {
+    primaryError = error;
+  } finally {
+    await handle?.close().catch((error) => { primaryError ??= error; });
+  }
+
+  let cleanupError: unknown = null;
+  try {
+    await fs.unlink(probePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") cleanupError = error;
+  }
+
+  if (primaryError || cleanupError) {
+    throw new HttpError(
+      503,
+      "GED_VAULT_UNAVAILABLE",
+      cleanupError
+        ? "Le coffre documentaire ne permet pas de nettoyer son contrôle de lecture/écriture."
+        : "Le coffre documentaire ne répond pas au contrôle de lecture/écriture."
+    );
+  }
+}
+
+/** Mandatory production startup gate. It returns no physical path. */
+export async function preflightVaultStorage(): Promise<void> {
+  const root = await ensureVaultReady();
+  await probeVaultReadWrite(root);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -686,8 +771,17 @@ export async function checkVaultHealth(): Promise<VaultHealth> {
   }
 
   try {
-    await fs.access(sentinelPath(root));
-    sentinelPresent = true;
+    const markerPath = sentinelPath(root);
+    assertSentinelPathInsideRoot(root, markerPath);
+    const marker = await fs.lstat(markerPath);
+    if (!marker.isFile()) throw new Error("GED sentinel is not a regular file");
+    const handle = await fs.open(markerPath, "r");
+    try {
+      await handle.read(Buffer.alloc(1), 0, 1, 0);
+      sentinelPresent = true;
+    } finally {
+      await handle.close();
+    }
   } catch {
     if (sentinelRequired() && detail === null) {
       detail = "Sentinelle de volume absente : le montage attendu n'est pas en place.";
@@ -696,7 +790,11 @@ export async function checkVaultHealth(): Promise<VaultHealth> {
 
   if (rootPresent) {
     try {
+      await assertSentinel(root);
       ensurePrivateUploadDirectory(path.join(root, VAULT_SUBDIR), root);
+      ensurePrivateUploadDirectory(path.join(root, STAGING_SUBDIR), root);
+      ensurePrivateUploadDirectory(path.join(root, QUARANTINE_SUBDIR), root);
+      await probeVaultReadWrite(root);
       writable = true;
     } catch {
       if (detail === null) detail = "Le coffre n'est pas accessible en écriture.";

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -73,6 +73,7 @@ import referenceDataRoutes from "../module/reference-data/routes/reference-data.
 import commercialReferencesRoutes from "../module/commercial-references/routes/commercial-references.routes"
 import { moduleAccessGate } from "../module/access-control/middlewares/module-access-gate"
 import { runWithAccountModuleAccessScope } from "../module/access-control/context/account-module-access.context"
+import documentServiceCapabilitiesRoutes from "../shared/document-services/document-service-capabilities.routes"
 const router = Router()
 
 router.use((_req, _res, next) => runWithAccountModuleAccessScope(next))
@@ -92,6 +93,11 @@ router.use(authenticateToken)
 // module métier pour qu'aucune surface future n'y échappe par oubli. Une fois le
 // module autorisé, les anciens gardes de rôle deviennent de simples compatibilités.
 router.use(moduleAccessGate)
+
+// Shared, authenticated and permission-safe dependency truth. It intentionally
+// sits outside the GED module gate so every business module that can produce an
+// archived PDF receives the same status without gaining access to GED content.
+router.use("/service-status", documentServiceCapabilitiesRoutes)
 
 // Shared authenticated endpoint; it resolves and enforces the owner module
 // from the opaque asset identity before a byte is read.

--- a/src/shared/document-services/document-service-capabilities.routes.ts
+++ b/src/shared/document-services/document-service-capabilities.routes.ts
@@ -1,0 +1,21 @@
+import { Router, type RequestHandler } from "express";
+
+import { HttpError } from "../../utils/httpError";
+import { collectDocumentServiceCapabilities } from "./document-service-capabilities";
+
+const router = Router();
+
+const getDocumentServiceCapabilities: RequestHandler = async (req, res, next) => {
+  try {
+    if (typeof req.user?.id !== "number") {
+      throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+    }
+    res.json(await collectDocumentServiceCapabilities());
+  } catch (error) {
+    next(error);
+  }
+};
+
+router.get("/documents", getDocumentServiceCapabilities);
+
+export default router;

--- a/src/shared/document-services/document-service-capabilities.ts
+++ b/src/shared/document-services/document-service-capabilities.ts
@@ -1,0 +1,40 @@
+import { checkVaultHealth, type VaultHealth } from "../../module/ged/services/ged-vault.service";
+
+export type DocumentServiceReasonCode =
+  | "GED_VAULT_NOT_CONFIGURED"
+  | "GED_VOLUME_NOT_READY"
+  | "GED_VAULT_NOT_WRITABLE";
+
+export type DocumentServiceCapabilities = Readonly<{
+  contract_version: 1;
+  status: "available" | "degraded";
+  document_writes_supported: boolean;
+  reason_code: DocumentServiceReasonCode | null;
+  checked_at: string;
+}>;
+
+export function documentServiceCapabilitiesFromHealth(
+  health: VaultHealth,
+  checkedAt = new Date().toISOString()
+): DocumentServiceCapabilities {
+  const reasonCode: DocumentServiceReasonCode | null = !health.configured
+    ? "GED_VAULT_NOT_CONFIGURED"
+    : !health.root_present || (health.sentinel_required && !health.sentinel_present)
+      ? "GED_VOLUME_NOT_READY"
+      : !health.healthy || !health.writable
+        ? "GED_VAULT_NOT_WRITABLE"
+        : null;
+  const supported = reasonCode === null;
+  return {
+    contract_version: 1,
+    status: supported ? "available" : "degraded",
+    document_writes_supported: supported,
+    reason_code: reasonCode,
+    checked_at: checkedAt,
+  };
+}
+
+/** Shared authenticated service truth; deliberately excludes paths/capacity. */
+export async function collectDocumentServiceCapabilities(): Promise<DocumentServiceCapabilities> {
+  return documentServiceCapabilitiesFromHealth(await checkVaultHealth());
+}

--- a/src/shared/runtime/critical-storage-preflight.ts
+++ b/src/shared/runtime/critical-storage-preflight.ts
@@ -1,0 +1,31 @@
+import { preflightVaultStorage } from "../../module/ged/services/ged-vault.service";
+
+type CriticalStoragePreflightDependencies = Readonly<{
+  preflightGedVault: () => Promise<void>;
+}>;
+
+function enabledOutsideProduction(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+/**
+ * Production cannot opt out. Non-production may opt in so operators and tests
+ * can rehearse the exact startup boundary without making every unit test own a
+ * filesystem mount.
+ */
+export function requiresGedVaultStartupPreflight(environment: NodeJS.ProcessEnv = process.env): boolean {
+  return environment.NODE_ENV === "production"
+    || enabledOutsideProduction(environment.CERP_GED_STARTUP_PREFLIGHT);
+}
+
+export async function preflightCriticalStorageAtStartup(
+  environment: NodeJS.ProcessEnv = process.env,
+  dependencies: CriticalStoragePreflightDependencies = { preflightGedVault: preflightVaultStorage }
+): Promise<{ ged_vault_required: boolean; ged_vault_ready: boolean }> {
+  const required = requiresGedVaultStartupPreflight(environment);
+  if (!required) return { ged_vault_required: false, ged_vault_ready: false };
+
+  await dependencies.preflightGedVault();
+  return { ged_vault_required: true, ged_vault_ready: true };
+}

--- a/src/swagger/generated-route-inventory.ts
+++ b/src/swagger/generated-route-inventory.ts
@@ -8,7 +8,7 @@ export type GeneratedRouteContract = {
   rbac: readonly string[];
 };
 
-export const GENERATED_ROUTE_SOURCE_SHA256 = "f7ef2c7fd490b1828a5cd8a0c34e09ebbaa631784f0ff2ce7b3620014756af96";
+export const GENERATED_ROUTE_SOURCE_SHA256 = "c165392634f171493289ff7503d126fab4defc6dde10cff72c8130e0bd75fd52";
 export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
@@ -16746,6 +16746,21 @@ export const GENERATED_ROUTE_INVENTORY = [
     "rbac": [
       "moduleAccessGate",
       "requireFinanceCapability(reporting_financial)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/service-status/documents",
+    "source": "src/shared/document-services/document-service-capabilities.routes.ts:19",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "getDocumentServiceCapabilities"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate"
     ]
   },
   {


### PR DESCRIPTION
Closes #618. Production startup now requires an existing in-volume sentinel and a real write/fsync/read/delete probe before the API listens; no missing mount can be recreated as a local fallback. Adds a bounded authenticated document-service capability contract, runtime health probing, fail-closed authoritative archive semantics, operator runbook, and generated OpenAPI inventory. Validation after rebase: 39 focused tests, broader independent GED review (79 tests), full backend regression (5,003 pass / 8 skipped), and production build.

## Summary by Sourcery

Require proven GED storage before production startup and fail closed when document writes or archival cannot be verified.

New Features:
- Expose an authenticated, bounded document-service capability contract for reporting whether document writes are available across business modules.

Bug Fixes:
- Prevent production startup from serving requests when the configured GED volume is missing, incorrectly mounted, lacks a valid in-volume sentinel, or fails a real write/read/sync/delete probe.
- Fail closed when document archival is unsuccessful so failed attempts are never presented as stored PDFs.

Enhancements:
- Continuously probe GED storage readiness and surface sanitized degraded-mode status without exposing physical paths or capacity metadata.
- Enforce authoritative archive semantics so documents are only considered archived with validated PDF bytes, hashes, and GED identifiers.

Deployment:
- Require operators to prepare and validate the mounted GED volume before production startup, with documented degraded-mode and recovery procedures.

Documentation:
- Add an operator runbook covering GED volume preparation, startup failures, degraded operation, and recovery.

Tests:
- Add focused coverage for production startup ordering, mandatory preflight behavior, sentinel validation, missing-volume fallback prevention, storage probing, capability responses, and failed archival semantics.

Chores:
- Refresh the generated OpenAPI route inventory for the new document-service status endpoint.