### PR TITLE
feat(quality): enforce operational release gates (#616)

### DIFF
--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -20,6 +20,7 @@ import {
   enqueueEntityChanged,
 } from "../../../shared/realtime/realtime-outbox.service";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import { assertOperationalLotQualityEligibility } from "../../qualite/repository/quality-operational-gate.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import { repoCreateAppNotifications, repoListUsersForCommandePlanningNotification } from "../../notifications/repository/notifications.repository";
 import { repoCreateLivraisonFromCommande } from "../../livraisons/repository/livraisons.repository";
@@ -5317,6 +5318,17 @@ export async function reserveCommandeStockForLaterDelivery(
   const reservationIds: string[] = [];
 
   for (const allocation of allocations) {
+    // Take the Quality lock before stock state locks.  All reservation writers
+    // share that order (Quality entitlement -> stock counters) to avoid a
+    // cross-workflow deadlock under simultaneous allocation.
+    if (allocation.lot_id) {
+      await assertOperationalLotQualityEligibility({
+        client: db,
+        lotId: allocation.lot_id,
+        qty: allocation.quantity,
+        purpose: "RESERVE",
+      });
+    }
     const stockLevel = await db.query<{
       qty_total: number;
       qty_reserved: number;

--- a/src/module/commande-client/repository/commande-stock-reservation.repository.test.ts
+++ b/src/module/commande-client/repository/commande-stock-reservation.repository.test.ts
@@ -57,6 +57,13 @@ describe("reserveCommandeStockForLaterDelivery", () => {
       if (text.includes("FROM public.stock_levels") && text.includes("FOR UPDATE")) {
         return { rows: [{ qty_total: 4, qty_reserved: 0, qty_depreciated: 0 }] };
       }
+      if (text.includes("FROM public.lots")) return { rows: [{ lot_code: "LOT-OLD", lot_status: "LIBERE", article_unit: "U" }] };
+      if (text.includes("FROM public.quality_control qc")) {
+        return { rows: [{ id: "99999999-9999-4999-8999-999999999999", qty_released: "4", qty_held: "0", qty_consumed: "0", unite: "U", pending: false }] };
+      }
+      if (text.includes("FROM public.stock_reservations") && text.includes("FOR SHARE")) return { rows: [] };
+      if (text.includes("FROM public.non_conformity nc")) return { rows: [{ total: 0 }] };
+      if (text.includes("FROM public.quality_release_decision")) return { rows: [] };
       if (text.includes("INSERT INTO public.stock_reservations")) {
         return { rows: [{ id: "66666666-6666-6666-8666-666666666666" }] };
       }

--- a/src/module/facturation/repository/facture-workflow.repository.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.ts
@@ -2,6 +2,7 @@ import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
+import { repoGetDeliveryQualityRelease } from "../../livraisons/repository/quality-release.repository";
 import {
   listIssuedInvoiceCommandeIds,
   syncCommandeAfterInvoiceIssue,
@@ -54,6 +55,60 @@ type BillingPolicyRow = {
   require_distinct_issuer: boolean;
   active: boolean;
 };
+
+type InvoiceQualityReleaseAudit = {
+  delivery_id: string;
+  state: "READY" | "DEROGATED" | "BLOCKED" | "UNKNOWN";
+  preview_sha256: string;
+  evidence_ids: string[];
+  derogation_ids: string[];
+};
+
+/**
+ * Legal issuance is deliberately re-evaluated inside its transaction.  An
+ * invoice cannot consume a legal sequence based solely on a preview that may
+ * predate a later quarantine, NC, expired concession, or policy change.
+ */
+async function assertInvoiceDeliveryQuality(
+  client: PoolClient,
+  factureId: number
+): Promise<InvoiceQualityReleaseAudit[]> {
+  const deliveries = await client.query<{ delivery_id: string }>(
+    `
+      SELECT DISTINCT source.source_id::text AS delivery_id
+      FROM public.facture_source_allocations source
+      WHERE source.facture_id = $1
+        AND source.source_type = 'DELIVERY_LINE'
+      ORDER BY source.source_id
+    `,
+    [factureId]
+  );
+  const audits: InvoiceQualityReleaseAudit[] = [];
+  for (const row of deliveries.rows) {
+    const release = await repoGetDeliveryQualityRelease(row.delivery_id, client);
+    const audit: InvoiceQualityReleaseAudit = {
+      delivery_id: row.delivery_id,
+      state: release.state,
+      preview_sha256: release.preview_sha256,
+      evidence_ids: release.required_evidence.map((document) => document.id),
+      derogation_ids: release.derogation_ids,
+    };
+    audits.push(audit);
+    if (release.state !== "READY" && release.state !== "DEROGATED") {
+      throw new HttpError(
+        409,
+        "QUALITY_INVOICE_NOT_ELIGIBLE",
+        "La facture ne peut pas être émise : une livraison source n'est pas libérée par la Qualité.",
+        {
+          delivery_id: row.delivery_id,
+          quality_release: audit,
+          blocks: release.reasons,
+        }
+      );
+    }
+  }
+  return audits;
+}
 
 type DeliverySourceRow = {
   source_id: string;
@@ -1169,6 +1224,7 @@ export async function repoIssueFacture(params: {
       );
     }
     assertFactureTransition(facture.statut, "ISSUED");
+    const qualityReleases = await assertInvoiceDeliveryQuality(client, params.factureId);
     const issueDate = new Date().toISOString().slice(0, 10);
     // Fail before consuming a legal sequence value: an immutable fiscal document must never
     // be issued without the complete legal version applicable on its issue date.
@@ -1337,6 +1393,7 @@ export async function repoIssueFacture(params: {
         legal_number: legal.legalNumber,
         document_checksum_sha256: artifact.checksumSha256,
         correlation_id: correlationId,
+        quality_releases: qualityReleases,
       },
     });
     const commandeIds = await listIssuedInvoiceCommandeIds(client, facture.id);

--- a/src/module/facturation/repository/facture-workflow.repository.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.ts
@@ -2,7 +2,7 @@ import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
-import { repoGetDeliveryQualityRelease } from "../../livraisons/repository/quality-release.repository";
+import { lockDeliveryQualityReleaseScope, repoGetDeliveryQualityRelease } from "../../livraisons/repository/quality-release.repository";
 import {
   listIssuedInvoiceCommandeIds,
   syncCommandeAfterInvoiceIssue,
@@ -85,6 +85,10 @@ async function assertInvoiceDeliveryQuality(
   );
   const audits: InvoiceQualityReleaseAudit[] = [];
   for (const row of deliveries.rows) {
+    // Must happen before evaluating and before allocating the legal number.
+    // It serializes the decision with delivery allocation/shipment changes and
+    // Quality writers that can insert a lot/delivery blocker.
+    await lockDeliveryQualityReleaseScope(client, row.delivery_id);
     const release = await repoGetDeliveryQualityRelease(row.delivery_id, client);
     const audit: InvoiceQualityReleaseAudit = {
       delivery_id: row.delivery_id,

--- a/src/module/livraisons/repository/livraisons-legacy-reservation-plan.test.ts
+++ b/src/module/livraisons/repository/livraisons-legacy-reservation-plan.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { buildLegacyShipmentReservationPlan } from "./livraisons.repository";
+
+describe("legacy shipment reservation consumption plan (#616)", () => {
+  it("keeps ACTIVE reservation-backed quantity out of the direct Quality debit", () => {
+    const plan = buildLegacyShipmentReservationPlan([
+      { allocation_id: "a", quantite: 4, reservation_id: "r-1", reservation_status: "ACTIVE", reservation_qty: 4 },
+      { allocation_id: "b", quantite: 3, reservation_id: null, reservation_status: null, reservation_qty: null },
+    ]);
+    expect(plan).toEqual({ committed_qty: 4, direct_qty: 3, reservation_ids: ["r-1"] });
+  });
+
+  it("aggregates multiple allocations for one reservation only when they consume it exactly", () => {
+    expect(buildLegacyShipmentReservationPlan([
+      { allocation_id: "a", quantite: 2, reservation_id: "r-1", reservation_status: "ACTIVE", reservation_qty: 5 },
+      { allocation_id: "b", quantite: 3, reservation_id: "r-1", reservation_status: "ACTIVE", reservation_qty: 5 },
+    ])).toEqual({ committed_qty: 5, direct_qty: 0, reservation_ids: ["r-1"] });
+  });
+
+  it("fails closed for a partial ACTIVE reservation instead of consuming another delivery's claim", () => {
+    expect(() => buildLegacyShipmentReservationPlan([
+      { allocation_id: "a", quantite: 2, reservation_id: "r-1", reservation_status: "ACTIVE", reservation_qty: 5 },
+    ])).toThrow(expect.objectContaining({ code: "RESERVATION_ALLOCATION_MISMATCH" }));
+  });
+});

--- a/src/module/livraisons/repository/livraisons-shipment.repository.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.ts
@@ -6,6 +6,7 @@ import { withRealtimeOutboxTransaction } from "../../../shared/realtime/realtime
 import { enqueueEntityChanged } from "../../../shared/realtime/realtime-outbox.service"
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
+import { assertOperationalLotQualityEligibility } from "../../qualite/repository/quality-operational-gate.repository"
 import { syncCommandeAfterShipment } from "../../commande-client/repository/commande-fulfillment.repository"
 import { hashStockCommand, normalizeIdempotencyKey } from "../../stock/domain/stock-command"
 import {
@@ -658,6 +659,20 @@ export async function prepareLivraisonInTransaction(
     stock_level_id: group.stock_level_id,
     stock_batch_id: group.stock_batch_id,
   }))
+  // Keep a single global lock order across all reservation writers: Quality
+  // entitlement first, then stock state. This prevents a delivery preparation
+  // racing a generic reservation from deadlocking on opposite lock order.
+  for (const group of groups) {
+    if (group.lot_id) {
+      await assertOperationalLotQualityEligibility({
+        client,
+        lotId: group.lot_id,
+        qty: group.quantity,
+        unit: group.unite,
+        purpose: "RESERVE",
+      })
+    }
+  }
   const states = await lockStockStates(client, targets)
   for (const group of groups) {
     const state = states.get(stockTargetKey(group))
@@ -1000,6 +1015,21 @@ export async function repoShipLivraison(
     }
 
     const groups = buildGroups(snapshot.allocations)
+    // The signed delivery-release aggregate is the shipping policy gate. Every
+    // allocation is already backed by an ACTIVE reservation, so the per-lot
+    // gate validates current Quality state without spending that entitlement a
+    // second time.
+    for (const group of groups) {
+      if (group.lot_id) {
+        await assertOperationalLotQualityEligibility({
+          client,
+          lotId: group.lot_id,
+          qty: 0,
+          unit: group.unite,
+          purpose: "RESERVE",
+        })
+      }
+    }
     const states = await lockStockStates(
       client,
       groups.map((group) => ({

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -14,6 +14,10 @@ import { HttpError } from "../../../utils/httpError"
 import { normalizeCommandeWorkflowStatus } from "../../commande-client/workflow/commande-client-workflow.definition"
 
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
+import {
+  assertOperationalLotQualityEligibility,
+  recordDirectLotQualityConsumption,
+} from "../../qualite/repository/quality-operational-gate.repository"
 import { isLivraisonTransitionAllowed } from "../domain/livraisons-policy"
 import {
   assertStockConsumptionAllowed,
@@ -1942,6 +1946,20 @@ async function repoUpdateLivraisonStatusLegacy(
            throw new HttpError(400, "INVALID_QTY", "Invalid allocated qty")
          }
 
+         // Legacy status-transition shipping posts its own OUT movement rather
+         // than delegating to the newer shipment repository. It therefore
+         // needs the same transaction-bound Quality gate before any stock
+         // level/batch lock or movement number is consumed.
+         const qualityDecision = g.lot_id
+           ? await assertOperationalLotQualityEligibility({
+             client: db,
+             lotId: g.lot_id,
+             qty: totalQty,
+             unit: g.unite,
+             purpose: "RESERVE",
+           })
+           : null
+
          const unitId = await resolveUnitIdForArticle(db, g.article_id, g.unite)
          const stockLevelId = await ensureStockLevel(db, {
            article_id: g.article_id,
@@ -2069,6 +2087,18 @@ async function repoUpdateLivraisonStatusLegacy(
            `,
            [movementId, userId]
          )
+
+         // This legacy path posts the physical OUT itself rather than calling
+         // stock.repoPostMovement. It therefore owns the same durable direct
+         // consumption write; otherwise every sequential legacy shipment
+         // could reuse the same quality-release quantity.
+         if (qualityDecision) {
+           await recordDirectLotQualityConsumption({
+             client: db,
+             decision: qualityDecision,
+             qty: totalQty,
+           })
+         }
 
          await insertStockMovementEvent(db, {
            movement_id: movementId,
@@ -2357,6 +2387,11 @@ export async function attachActiveCommandeReservationsToLivraison(
     let reservationId = reservation.reservation_id
 
     if (quantity + 1e-9 < Number(reservation.reservation_quantity)) {
+      // Splitting only reassigns an existing ACTIVE commitment; it neither
+      // creates nor consumes released quantity. Do not take the Quality lot
+      // lock while this function already holds the reservation row lock: the
+      // physical shipment rechecks Quality before posting, in the canonical
+      // lot -> reservation lock order.
       await db.query(
         `
           UPDATE public.stock_reservations

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -46,6 +46,57 @@ import type {
   UploadedDocument,
   UserLite,
 } from "../types/livraisons.types"
+
+type LegacyShipmentReservationAllocation = {
+  allocation_id: string
+  quantite: number
+  reservation_id: string | null
+  reservation_status: string | null
+  reservation_qty: string | number | null
+}
+
+/**
+ * A legacy allocation can point at an ACTIVE stock reservation or be a direct
+ * issue. Never turn a partial reservation into a full consumption: that would
+ * either erase another delivery's commitment or double-spend Quality capacity.
+ */
+export function buildLegacyShipmentReservationPlan(items: readonly LegacyShipmentReservationAllocation[]): {
+  committed_qty: number
+  direct_qty: number
+  reservation_ids: string[]
+} {
+  const reservations = new Map<string, { allocated: number; reserved: number }>()
+  let directQty = 0
+  for (const item of items) {
+    if (item.reservation_id && item.reservation_status === "ACTIVE") {
+      const reserved = Number(item.reservation_qty)
+      if (!Number.isFinite(reserved) || reserved <= 0) {
+        throw new HttpError(409, "RESERVATION_ALLOCATION_MISMATCH", "La réservation du BL est invalide.")
+      }
+      const existing = reservations.get(item.reservation_id)
+      if (existing && Math.abs(existing.reserved - reserved) > 1e-9) {
+        throw new HttpError(409, "RESERVATION_ALLOCATION_MISMATCH", "La réservation du BL est incohérente.")
+      }
+      reservations.set(item.reservation_id, { allocated: (existing?.allocated ?? 0) + item.quantite, reserved })
+    } else {
+      directQty += item.quantite
+    }
+  }
+  for (const reservation of reservations.values()) {
+    if (Math.abs(reservation.allocated - reservation.reserved) > 1e-9) {
+      throw new HttpError(
+        409,
+        "RESERVATION_ALLOCATION_MISMATCH",
+        "La quantité allouée ne correspond pas exactement à la réservation active du BL."
+      )
+    }
+  }
+  return {
+    committed_qty: [...reservations.values()].reduce((sum, reservation) => sum + reservation.allocated, 0),
+    direct_qty: directQty,
+    reservation_ids: [...reservations.keys()].sort(),
+  }
+}
 import type {
   CreateLivraisonAllocationBodyDTO,
   CreateLivraisonBodyDTO,
@@ -1843,6 +1894,9 @@ async function repoUpdateLivraisonStatusLegacy(
          lot_article_id: string | null
          lot_status: string | null
          stock_movement_line_id: string | null
+         reservation_id: string | null
+         reservation_status: string | null
+         reservation_qty: string | number | null
          quantite: string | number
          unite: string | null
        }
@@ -1857,11 +1911,15 @@ async function repoUpdateLivraisonStatusLegacy(
              lt.article_id::text AS lot_article_id,
              lt.lot_status,
              a.stock_movement_line_id::text AS stock_movement_line_id,
+             a.reservation_id::text AS reservation_id,
+             reservation.status::text AS reservation_status,
+             reservation.qty_reserved AS reservation_qty,
              a.quantite,
              a.unite
            FROM public.bon_livraison_ligne_allocations a
            JOIN public.bon_livraison_ligne l ON l.id = a.bon_livraison_ligne_id
            LEFT JOIN public.lots lt ON lt.id = a.lot_id
+           LEFT JOIN public.stock_reservations reservation ON reservation.id = a.reservation_id
            WHERE l.bon_livraison_id = $1::uuid
            ORDER BY a.created_at ASC, a.id ASC
          `,
@@ -1897,6 +1955,9 @@ async function repoUpdateLivraisonStatusLegacy(
          lot_id: string | null
          quantite: number
          unite: string | null
+         reservation_id: string | null
+         reservation_status: string | null
+         reservation_qty: string | number | null
        }
 
        type IssueGroup = {
@@ -1936,6 +1997,9 @@ async function repoUpdateLivraisonStatusLegacy(
            lot_id: a.lot_id ?? null,
            quantite: qty,
            unite,
+           reservation_id: a.reservation_id,
+           reservation_status: a.reservation_status,
+           reservation_qty: a.reservation_qty,
          })
          groups.set(key, g)
        }
@@ -1950,11 +2014,25 @@ async function repoUpdateLivraisonStatusLegacy(
          // than delegating to the newer shipment repository. It therefore
          // needs the same transaction-bound Quality gate before any stock
          // level/batch lock or movement number is consumed.
-         const qualityDecision = g.lot_id
+         const reservationPlan = buildLegacyShipmentReservationPlan(g.items)
+         // Reservation-backed quantities are already represented in the
+         // Quality commitment ledger. Validate current eligibility with zero
+         // incremental demand; only allocations without an ACTIVE reservation
+         // are a direct release-capacity debit.
+         if (g.lot_id && reservationPlan.committed_qty > 0) {
+           await assertOperationalLotQualityEligibility({
+             client: db,
+             lotId: g.lot_id,
+             qty: 0,
+             unit: g.unite,
+             purpose: "RESERVE",
+           })
+         }
+         const qualityDecision = g.lot_id && reservationPlan.direct_qty > 0
            ? await assertOperationalLotQualityEligibility({
              client: db,
              lotId: g.lot_id,
-             qty: totalQty,
+             qty: reservationPlan.direct_qty,
              unit: g.unite,
              purpose: "RESERVE",
            })
@@ -2096,8 +2174,44 @@ async function repoUpdateLivraisonStatusLegacy(
            await recordDirectLotQualityConsumption({
              client: db,
              decision: qualityDecision,
-             qty: totalQty,
+             qty: reservationPlan.direct_qty,
            })
+         }
+
+         if (reservationPlan.committed_qty > 0) {
+           const reserved = await db.query<{ id: string }>(
+             `
+               UPDATE public.stock_levels
+               SET qty_reserved = qty_reserved - $2,
+                   updated_at = now(),
+                   updated_by = $3
+               WHERE id = $1::uuid
+                 AND qty_reserved + 1e-9 >= $2
+               RETURNING id::text AS id
+             `,
+             [stockLevelId, reservationPlan.committed_qty, userId]
+           )
+           if (!reserved.rows[0]) throw new HttpError(409, "RESERVATION_STOCK_COUNTER_MISMATCH", "Le stock réservé du BL a été modifié concurremment.")
+           if (stockBatchId) {
+             const batch = await db.query<{ id: string }>(
+               `UPDATE public.stock_batches SET qty_reserved = qty_reserved - $2 WHERE id = $1::uuid AND qty_reserved + 1e-9 >= $2 RETURNING id::text AS id`,
+               [stockBatchId, reservationPlan.committed_qty]
+             )
+             if (!batch.rows[0]) throw new HttpError(409, "RESERVATION_STOCK_COUNTER_MISMATCH", "Le lot réservé du BL a été modifié concurremment.")
+           }
+           const consumed = await db.query<{ id: string }>(
+             `
+               UPDATE public.stock_reservations
+               SET status = 'CONSUMED', consumed_at = now(), consumed_by = $2,
+                   consumed_stock_movement_id = $3::uuid, updated_at = now(), updated_by = $2
+               WHERE id = ANY($1::uuid[]) AND status = 'ACTIVE'
+               RETURNING id::text AS id
+             `,
+             [reservationPlan.reservation_ids, userId, movementId]
+           )
+           if (consumed.rows.length !== reservationPlan.reservation_ids.length) {
+             throw new HttpError(409, "RESERVATION_CONCURRENTLY_CHANGED", "Une réservation du BL a été modifiée concurremment.")
+           }
          }
 
          await insertStockMovementEvent(db, {

--- a/src/module/livraisons/repository/quality-release.repository.ts
+++ b/src/module/livraisons/repository/quality-release.repository.ts
@@ -12,6 +12,27 @@ import {
 
 type Queryable = Pick<PoolClient, "query">
 
+/**
+ * Serializes a legal invoice's delivery-quality decision with shipment and
+ * Quality mutations. The delivery row lock closes allocation changes; the
+ * deterministic advisory keys close predicate races for a new NC/derogation
+ * that refers to an already-selected delivery lot.
+ */
+export async function lockDeliveryQualityReleaseScope(db: Queryable, bonLivraisonId: string): Promise<void> {
+  await db.query(`SELECT id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`, [bonLivraisonId]);
+  await db.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [`quality-delivery:${bonLivraisonId}`]);
+  const lots = await db.query<{ lot_id: string }>(`
+    SELECT DISTINCT a.lot_id::text AS lot_id
+    FROM public.bon_livraison_ligne_allocations a
+    JOIN public.bon_livraison_ligne line ON line.id = a.bon_livraison_ligne_id
+    WHERE line.bon_livraison_id = $1::uuid AND a.lot_id IS NOT NULL
+    ORDER BY a.lot_id::text
+  `, [bonLivraisonId]);
+  for (const row of lots.rows) {
+    await db.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [`quality-lot:${row.lot_id}`]);
+  }
+}
+
 type TargetRow = {
   target_key: string
   allocation_id: string

--- a/src/module/production/repository/production-receipts.repository.test.ts
+++ b/src/module/production/repository/production-receipts.repository.test.ts
@@ -28,6 +28,13 @@ function transactionClient(params: { activeCommandeReservation: number; plannedB
     if (text.includes("FROM public.stock_batches") && text.includes("FOR UPDATE")) {
       return { rows: [{ qty_total: 20, qty_reserved: 0 }] };
     }
+    if (text.includes("FROM public.lots")) return { rows: [{ lot_code: "LOT-616", lot_status: "LIBERE", article_unit: "U" }] };
+    if (text.includes("FROM public.quality_control qc")) {
+      return { rows: [{ id: "99999999-9999-4999-8999-999999999999", qty_released: "20", qty_held: "0", qty_consumed: "0", unite: "U", pending: false }] };
+    }
+    if (text.includes("FROM public.stock_reservations") && text.includes("FOR SHARE")) return { rows: [] };
+    if (text.includes("FROM public.non_conformity nc")) return { rows: [{ total: 0 }] };
+    if (text.includes("FROM public.quality_release_decision")) return { rows: [] };
     if (text.includes("SELECT id::text AS id") && text.includes("stock_batch_id")) return { rows: [] };
     if (text.includes("INSERT INTO public.stock_reservations")) return { rows: [{ id: "66666666-6666-6666-6666-666666666666" }] };
     return { rows: [] };

--- a/src/module/production/repository/production-receipts.repository.ts
+++ b/src/module/production/repository/production-receipts.repository.ts
@@ -12,6 +12,7 @@ import type { AuditContext } from "./production.repository";
 import { enqueueProductionOfChanged, productionRealtimeActionFromAudit } from "./production-realtime.repository";
 import type { OfReceiptBodyDTO } from "../validators/production.validators";
 import { ofStatutAllowsReceipt, type OfStatut } from "../domain/of-status";
+import { assertOperationalLotQualityEligibility } from "../../qualite/repository/quality-operational-gate.repository";
 
 export type OfReceiptContext = {
   of: {
@@ -194,6 +195,8 @@ export async function reserveProducedQtyForCommandeLine(
     lot_id: string;
     qty_ok: number;
     actor_user_id: number;
+    /** Caller already holds the canonical Quality lock for this lot. */
+    quality_gate_already_held?: boolean;
   }
 ): Promise<{ reservation_id: string; qty_reserved: number } | null> {
   if (!Number.isFinite(args.qty_ok) || args.qty_ok <= 0) return null;
@@ -243,6 +246,18 @@ export async function reserveProducedQtyForCommandeLine(
   const remainingToReserve = Math.max(0, orderedQty - alreadyReserved - alreadyPlannedForDelivery);
   const qtyToReserve = Math.min(args.qty_ok, remainingToReserve);
   if (qtyToReserve <= 0) return null;
+
+  // Automatic order-line reservation is still a stock reservation. Re-check
+  // its exact produced lot under the receipt transaction; a previously
+  // released existing lot may have been quarantined or exhausted meanwhile.
+  if (!args.quality_gate_already_held) {
+    await assertOperationalLotQualityEligibility({
+      client,
+      lotId: args.lot_id,
+      qty: qtyToReserve,
+      purpose: "RESERVE",
+    });
+  }
 
   const stockLevelRes = await client.query<{ qty_total: number; qty_reserved: number }>(
     `
@@ -854,6 +869,7 @@ export async function repoCreateOfReceipt(params: {
 
     let lotId: string;
     let lotCode: string;
+    let qualityDecision: Awaited<ReturnType<typeof assertOperationalLotQualityEligibility>> | null = null;
     if (params.body.lot_mode === "EXISTING") {
       const rawLotId = params.body.lot_id ?? null;
       if (!rawLotId) throw new HttpError(422, "LOT_REQUIRED", "Veuillez selectionner un lot");
@@ -878,9 +894,28 @@ export async function repoCreateOfReceipt(params: {
         );
       }
 
+      if (params.body.quality_status === "LIBERE") {
+        qualityDecision = await assertOperationalLotQualityEligibility({
+          client,
+          lotId: row.id,
+          qty: params.body.qty_ok,
+          purpose: "RESERVE",
+        });
+      }
+
       lotId = row.id;
       lotCode = row.lot_code;
     } else {
+      // A newly produced lot has no independent control/release evidence yet.
+      // It must enter the ledger in quarantine and be released afterwards by
+      // the Quality 360 workflow; accepting LIBERE here would be a bypass.
+      if (params.body.quality_status === "LIBERE") {
+        throw new HttpError(
+          409,
+          "QUALITY_RECEIPT_RELEASE_REQUIRES_CONTROL",
+          "Une nouvelle réception OF doit être mise en quarantaine jusqu'à la décision de libération Qualité."
+        );
+      }
       if (params.body.lot_number?.trim()) {
         throw new HttpError(400, "LOT_CODE_SERVER_MANAGED", "Le numéro de lot interne est attribué automatiquement.");
       }
@@ -1122,6 +1157,7 @@ export async function repoCreateOfReceipt(params: {
             lot_id: lotId,
             qty_ok: params.body.qty_ok,
             actor_user_id: params.audit.user_id,
+            quality_gate_already_held: qualityDecision !== null,
           })
         : null;
 
@@ -1228,6 +1264,7 @@ export async function repoCreateOfReceipt(params: {
         auto_reserved_qty: autoReservation?.qty_reserved ?? 0,
         non_conformity_id: nonConformityId,
         idempotency_key: params.idempotency_key,
+        quality_gate: qualityDecision,
       },
     });
 

--- a/src/module/qualite/repository/qualite.repository.ts
+++ b/src/module/qualite/repository/qualite.repository.ts
@@ -2426,6 +2426,15 @@ export async function repoCreateNonConformity(params: { body: CreateNonConformit
   const { body, audit } = params;
   const client = await pool.connect();
   const id = await withRealtimeOutboxTransaction(client, async (tx) => {
+    // Match invoice issuance scope ordering: delivery key before lot key. This
+    // makes a newly inserted NC visible-or-blocked, never invisible in the
+    // middle of an invoice quality decision.
+    if (body.bon_livraison_id) {
+      await tx.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [`quality-delivery:${body.bon_livraison_id}`]);
+    }
+    if (body.lot_id) {
+      await tx.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [`quality-lot:${body.lot_id}`]);
+    }
     // Share the canonical lot-first lock order with reservation, shipment and
     // direct-OUT gates. If an NC starts first, operational writes wait and see
     // the committed quarantine; if the write starts first, the NC follows it

--- a/src/module/qualite/repository/qualite.repository.ts
+++ b/src/module/qualite/repository/qualite.repository.ts
@@ -2426,6 +2426,20 @@ export async function repoCreateNonConformity(params: { body: CreateNonConformit
   const { body, audit } = params;
   const client = await pool.connect();
   const id = await withRealtimeOutboxTransaction(client, async (tx) => {
+    // Share the canonical lot-first lock order with reservation, shipment and
+    // direct-OUT gates. If an NC starts first, operational writes wait and see
+    // the committed quarantine; if the write starts first, the NC follows it
+    // in a well-defined order instead of becoming an invisible in-flight row.
+    const lockedLot = body.lot_id
+      ? await tx.query<{ lot_status: string | null }>(
+          `SELECT lot_status FROM public.lots WHERE id = $1::uuid FOR UPDATE`,
+          [body.lot_id]
+        )
+      : null;
+    if (body.lot_id && !lockedLot?.rows[0]) {
+      throw new HttpError(400, "INVALID_LOT", "Unknown lot_id");
+    }
+
     const ins = await tx.query<{ id: string; reference: string }>(
       `
         INSERT INTO non_conformity (
@@ -2497,14 +2511,7 @@ export async function repoCreateNonConformity(params: { body: CreateNonConformit
 
     const reference = ins.rows[0]?.reference ?? body.reference ?? null;
     if (body.lot_id) {
-      const lot = await tx.query<{ lot_status: string | null }>(
-        `SELECT lot_status FROM public.lots WHERE id = $1::uuid FOR UPDATE`,
-        [body.lot_id]
-      );
-      const row = lot.rows[0] ?? null;
-      if (!row) {
-        throw new HttpError(400, "INVALID_LOT", "Unknown lot_id");
-      }
+      const row = lockedLot!.rows[0]!;
       const current = row.lot_status ?? "LIBERE";
       if (current === "LIBERE") {
         const note = reference ? `NC ${reference} : mise en quarantaine` : "Mise en quarantaine (NC)";

--- a/src/module/qualite/repository/quality-operational-gate.postgres.integration.test.ts
+++ b/src/module/qualite/repository/quality-operational-gate.postgres.integration.test.ts
@@ -1,0 +1,184 @@
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  assertOperationalLotQualityEligibility,
+  recordDirectLotQualityConsumption,
+} from "./quality-operational-gate.repository";
+
+// This is intentionally opt-in: it talks to a real PostgreSQL instance and
+// refuses every database except the fresh, explicitly named #616 rehearsal DB.
+const DATABASE_URL = process.env.CERP_QUALITY_GATE_PG_URL;
+const TEST_DATABASE = "quality_gate_616_concurrency";
+const describePostgres = DATABASE_URL?.endsWith(`/${TEST_DATABASE}`) ? describe : describe.skip;
+
+const ARTICLE_ID = "00000000-0000-4000-8000-000000000616";
+const LOT_ID = "00000000-0000-4000-8000-000000000617";
+const CONTROL_ID = "00000000-0000-4000-8000-000000000618";
+
+async function client(): Promise<Client> {
+  if (!DATABASE_URL) throw new Error("CERP_QUALITY_GATE_PG_URL is required for this integration test");
+  const connection = new Client({ connectionString: DATABASE_URL });
+  await connection.connect();
+  return connection;
+}
+
+async function resetFixture(): Promise<void> {
+  const db = await client();
+  try {
+    await db.query(`
+      TRUNCATE public.stock_reservations, public.quality_release_decision,
+        public.quality_derogation, public.non_conformity_dispositions,
+        public.non_conformity, public.quality_control, public.lots,
+        public.articles RESTART IDENTITY CASCADE
+    `);
+    await db.query(`INSERT INTO public.articles (id, unite) VALUES ($1::uuid, 'PCS')`, [ARTICLE_ID]);
+    await db.query(`INSERT INTO public.lots (id, article_id, lot_code, lot_status) VALUES ($1::uuid, $2::uuid, 'LOT-616', 'LIBERE')`, [LOT_ID, ARTICLE_ID]);
+    await db.query(`
+      INSERT INTO public.quality_control (
+        id, lot_id, source_type, source_id, control_date, qty_released,
+        qty_held, qty_consumed, unite, validation_date, verdict
+      ) VALUES ($1::uuid, $2::uuid, 'LOT', $2::text, now(), 10, 0, 0, 'PCS', now(), 'CONFORME')
+    `, [CONTROL_ID, LOT_ID]);
+  } finally {
+    await db.end();
+  }
+}
+
+async function reserve(qty: number, locked?: () => void): Promise<void> {
+  const db = await client();
+  try {
+    await db.query("BEGIN");
+    await assertOperationalLotQualityEligibility({ client: db, lotId: LOT_ID, qty, unit: "PCS", purpose: "RESERVE" });
+    locked?.();
+    // Keep the first transaction open so the second contender must exercise
+    // PostgreSQL row-lock waiting rather than merely run after it.
+    await db.query("SELECT pg_sleep(0.15)");
+    await db.query(`INSERT INTO public.stock_reservations (lot_id, qty_reserved, status) VALUES ($1::uuid, $2, 'ACTIVE')`, [LOT_ID, qty]);
+    await db.query("COMMIT");
+  } catch (error) {
+    await db.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    await db.end();
+  }
+}
+
+async function directOut(qty: number, locked?: () => void): Promise<void> {
+  const db = await client();
+  try {
+    await db.query("BEGIN");
+    const decision = await assertOperationalLotQualityEligibility({ client: db, lotId: LOT_ID, qty, unit: "PCS", purpose: "RESERVE" });
+    locked?.();
+    await db.query("SELECT pg_sleep(0.15)");
+    await recordDirectLotQualityConsumption({ client: db, decision, qty });
+    await db.query("COMMIT");
+  } catch (error) {
+    await db.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    await db.end();
+  }
+}
+
+async function shipmentConsume(locked: () => void): Promise<void> {
+  const db = await client();
+  try {
+    await db.query("BEGIN");
+    // The shipment path has an existing ACTIVE reservation, so it verifies
+    // current Quality state with zero additional entitlement.
+    await assertOperationalLotQualityEligibility({ client: db, lotId: LOT_ID, qty: 0, unit: "PCS", purpose: "RESERVE" });
+    locked();
+    await db.query("SELECT pg_sleep(0.15)");
+    await db.query(`UPDATE public.stock_reservations SET status = 'CONSUMED' WHERE lot_id = $1::uuid`, [LOT_ID]);
+    await db.query("COMMIT");
+  } catch (error) {
+    await db.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    await db.end();
+  }
+}
+
+describePostgres("Quality 360 operational gate — real PostgreSQL concurrency (#616)", () => {
+  beforeAll(async () => {
+    if (!DATABASE_URL?.endsWith(`/${TEST_DATABASE}`)) throw new Error("Refusing non-#616 database");
+    const db = await client();
+    try {
+      await db.query(`
+        CREATE TABLE IF NOT EXISTS public.articles (id uuid PRIMARY KEY, unite text);
+        CREATE TABLE IF NOT EXISTS public.lots (id uuid PRIMARY KEY, article_id uuid NOT NULL, lot_code text NOT NULL, lot_status text NOT NULL);
+        CREATE TABLE IF NOT EXISTS public.quality_control (
+          id uuid PRIMARY KEY, lot_id uuid, source_type text, source_id text,
+          control_date timestamptz NOT NULL, qty_released numeric NOT NULL DEFAULT 0,
+          qty_held numeric NOT NULL DEFAULT 0, qty_consumed numeric NOT NULL DEFAULT 0,
+          unite text, validation_date timestamptz, verdict text, updated_at timestamptz NOT NULL DEFAULT now()
+        );
+        CREATE TABLE IF NOT EXISTS public.stock_reservations (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), lot_id uuid, qty_reserved numeric NOT NULL, status text NOT NULL);
+        CREATE TABLE IF NOT EXISTS public.non_conformity (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), lot_id uuid, status text NOT NULL);
+        CREATE TABLE IF NOT EXISTS public.non_conformity_dispositions (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), non_conformity_id uuid NOT NULL);
+        CREATE TABLE IF NOT EXISTS public.quality_derogation (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), status text NOT NULL, valid_to timestamptz);
+        CREATE TABLE IF NOT EXISTS public.quality_release_decision (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), quality_control_id uuid NOT NULL, derogation_id uuid NOT NULL, decided_at timestamptz NOT NULL DEFAULT now());
+      `);
+    } finally {
+      await db.end();
+    }
+  });
+
+  afterAll(async () => {
+    // Leave the named database in place but erase only this test's tables.
+    const db = await client();
+    try {
+      await db.query(`DROP TABLE IF EXISTS public.stock_reservations, public.quality_release_decision, public.quality_derogation, public.non_conformity_dispositions, public.non_conformity, public.quality_control, public.lots, public.articles CASCADE`);
+    } finally {
+      await db.end();
+    }
+  });
+
+  it("serializes concurrent reservation writers: one 7-unit claim wins and the second cannot over-spend 10 released", async () => {
+    await resetFixture();
+    let releaseFirst!: () => void;
+    const firstLocked = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const first = reserve(7, releaseFirst);
+    await firstLocked;
+    const second = reserve(7);
+    const results = await Promise.allSettled([first, second]);
+    expect(results.map((result) => result.status)).toEqual(["fulfilled", "rejected"]);
+    expect(results[1]).toMatchObject({ reason: { code: "QUALITY_NOT_ELIGIBLE" } });
+  }, 5_000);
+
+  it("serializes concurrent direct OUT writers and persists the winning debit", async () => {
+    await resetFixture();
+    let releaseFirst!: () => void;
+    const firstLocked = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const first = directOut(7, releaseFirst);
+    await firstLocked;
+    const second = directOut(7);
+    const results = await Promise.allSettled([first, second]);
+    expect(results.map((result) => result.status)).toEqual(["fulfilled", "rejected"]);
+    const db = await client();
+    try {
+      expect((await db.query<{ qty_consumed: string }>(`SELECT qty_consumed::text FROM public.quality_control WHERE id = $1::uuid`, [CONTROL_ID])).rows[0]?.qty_consumed).toBe("7");
+    } finally {
+      await db.end();
+    }
+  }, 5_000);
+
+  it("keeps a concurrent shipment-style consumed reservation committed, blocking direct OUT without a deadlock or double-spend", async () => {
+    await resetFixture();
+    const setup = await client();
+    try {
+      await setup.query(`INSERT INTO public.stock_reservations (lot_id, qty_reserved, status) VALUES ($1::uuid, 7, 'ACTIVE')`, [LOT_ID]);
+    } finally {
+      await setup.end();
+    }
+    let releaseShipment!: () => void;
+    const shipmentLocked = new Promise<void>((resolve) => { releaseShipment = resolve; });
+    const shipment = shipmentConsume(releaseShipment);
+    await shipmentLocked;
+    const direct = directOut(4);
+    const results = await Promise.allSettled([shipment, direct]);
+    expect(results.map((result) => result.status)).toEqual(["fulfilled", "rejected"]);
+    expect(results[1]).toMatchObject({ reason: { code: "QUALITY_NOT_ELIGIBLE" } });
+  }, 5_000);
+});

--- a/src/module/qualite/repository/quality-operational-gate.postgres.integration.test.ts
+++ b/src/module/qualite/repository/quality-operational-gate.postgres.integration.test.ts
@@ -5,6 +5,7 @@ import {
   assertOperationalLotQualityEligibility,
   recordDirectLotQualityConsumption,
 } from "./quality-operational-gate.repository";
+import { lockDeliveryQualityReleaseScope } from "../../livraisons/repository/quality-release.repository";
 
 // This is intentionally opt-in: it talks to a real PostgreSQL instance and
 // refuses every database except the fresh, explicitly named #616 rehearsal DB.
@@ -15,6 +16,8 @@ const describePostgres = DATABASE_URL?.endsWith(`/${TEST_DATABASE}`) ? describe 
 const ARTICLE_ID = "00000000-0000-4000-8000-000000000616";
 const LOT_ID = "00000000-0000-4000-8000-000000000617";
 const CONTROL_ID = "00000000-0000-4000-8000-000000000618";
+const DELIVERY_ID = "00000000-0000-4000-8000-000000000619";
+const DELIVERY_LINE_ID = "00000000-0000-4000-8000-000000000620";
 
 async function client(): Promise<Client> {
   if (!DATABASE_URL) throw new Error("CERP_QUALITY_GATE_PG_URL is required for this integration test");
@@ -27,7 +30,8 @@ async function resetFixture(): Promise<void> {
   const db = await client();
   try {
     await db.query(`
-      TRUNCATE public.stock_reservations, public.quality_release_decision,
+      TRUNCATE public.bon_livraison_ligne_allocations, public.bon_livraison_ligne,
+        public.bon_livraison, public.stock_reservations, public.quality_release_decision,
         public.quality_derogation, public.non_conformity_dispositions,
         public.non_conformity, public.quality_control, public.lots,
         public.articles RESTART IDENTITY CASCADE
@@ -119,6 +123,9 @@ describePostgres("Quality 360 operational gate — real PostgreSQL concurrency (
         CREATE TABLE IF NOT EXISTS public.non_conformity_dispositions (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), non_conformity_id uuid NOT NULL);
         CREATE TABLE IF NOT EXISTS public.quality_derogation (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), status text NOT NULL, valid_to timestamptz);
         CREATE TABLE IF NOT EXISTS public.quality_release_decision (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), quality_control_id uuid NOT NULL, derogation_id uuid NOT NULL, decided_at timestamptz NOT NULL DEFAULT now());
+        CREATE TABLE IF NOT EXISTS public.bon_livraison (id uuid PRIMARY KEY);
+        CREATE TABLE IF NOT EXISTS public.bon_livraison_ligne (id uuid PRIMARY KEY, bon_livraison_id uuid NOT NULL);
+        CREATE TABLE IF NOT EXISTS public.bon_livraison_ligne_allocations (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), bon_livraison_ligne_id uuid NOT NULL, lot_id uuid);
       `);
     } finally {
       await db.end();
@@ -129,7 +136,7 @@ describePostgres("Quality 360 operational gate — real PostgreSQL concurrency (
     // Leave the named database in place but erase only this test's tables.
     const db = await client();
     try {
-      await db.query(`DROP TABLE IF EXISTS public.stock_reservations, public.quality_release_decision, public.quality_derogation, public.non_conformity_dispositions, public.non_conformity, public.quality_control, public.lots, public.articles CASCADE`);
+      await db.query(`DROP TABLE IF EXISTS public.bon_livraison_ligne_allocations, public.bon_livraison_ligne, public.bon_livraison, public.stock_reservations, public.quality_release_decision, public.quality_derogation, public.non_conformity_dispositions, public.non_conformity, public.quality_control, public.lots, public.articles CASCADE`);
     } finally {
       await db.end();
     }
@@ -180,5 +187,30 @@ describePostgres("Quality 360 operational gate — real PostgreSQL concurrency (
     const results = await Promise.allSettled([shipment, direct]);
     expect(results.map((result) => result.status)).toEqual(["fulfilled", "rejected"]);
     expect(results[1]).toMatchObject({ reason: { code: "QUALITY_NOT_ELIGIBLE" } });
+  }, 5_000);
+
+  it("uses the same delivery then lot advisory order as an NC writer, so invoice-quality evaluation cannot race a new blocker", async () => {
+    await resetFixture();
+    const setup = await client();
+    try {
+      await setup.query(`INSERT INTO public.bon_livraison (id) VALUES ($1::uuid)`, [DELIVERY_ID]);
+      await setup.query(`INSERT INTO public.bon_livraison_ligne (id, bon_livraison_id) VALUES ($1::uuid, $2::uuid)`, [DELIVERY_LINE_ID, DELIVERY_ID]);
+      await setup.query(`INSERT INTO public.bon_livraison_ligne_allocations (bon_livraison_ligne_id, lot_id) VALUES ($1::uuid, $2::uuid)`, [DELIVERY_LINE_ID, LOT_ID]);
+    } finally { await setup.end(); }
+    const invoice = await client();
+    const writer = await client();
+    try {
+      await invoice.query("BEGIN");
+      await lockDeliveryQualityReleaseScope(invoice, DELIVERY_ID);
+      const writerWork = (async () => {
+        await writer.query("BEGIN");
+        await writer.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [`quality-delivery:${DELIVERY_ID}`]);
+        await writer.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [`quality-lot:${LOT_ID}`]);
+        await writer.query("COMMIT");
+      })();
+      await invoice.query("SELECT pg_sleep(0.15)");
+      await invoice.query("COMMIT");
+      await expect(writerWork).resolves.toBeUndefined();
+    } finally { await invoice.end(); await writer.end(); }
   }, 5_000);
 });

--- a/src/module/qualite/repository/quality-operational-gate.repository.test.ts
+++ b/src/module/qualite/repository/quality-operational-gate.repository.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assertOperationalLotQualityEligibility,
+  recordDirectLotQualityConsumption,
+} from "./quality-operational-gate.repository";
+
+const LOT_ID = "00000000-0000-4000-8000-000000000616";
+
+function queryClient(input: {
+  status?: "LIBERE" | "EN_ATTENTE" | "QUARANTAINE" | "BLOQUE";
+  released?: number;
+  consumed?: number;
+  pending?: boolean;
+  openNc?: number;
+  committed?: number;
+  articleUnit?: string | null;
+  controlUnit?: string | null;
+  concession?: { status: string; valid_to: string | null } | null;
+}) {
+  const query = vi.fn(async (sql: string) => {
+    if (sql.includes("FROM public.lots")) return { rows: [{ lot_code: "LOT-616", lot_status: input.status ?? "LIBERE", article_unit: input.articleUnit ?? "PCS" }] };
+    if (sql.includes("FROM public.quality_control qc")) {
+      return {
+        rows: [{ id: "00000000-0000-4000-8000-000000000001", qty_released: String(input.released ?? 10), qty_held: "0", qty_consumed: String(input.consumed ?? 0), unite: input.controlUnit ?? "PCS", pending: input.pending ?? false }],
+      };
+    }
+    if (sql.includes("FROM public.stock_reservations")) return input.committed ? { rows: [{ qty: String(input.committed) }] } : { rows: [] };
+    if (sql.includes("FROM public.non_conformity nc")) return { rows: [{ total: input.openNc ?? 0 }] };
+    if (sql.includes("FROM public.quality_release_decision")) {
+      return { rows: input.concession ? [{ decision_id: "00000000-0000-4000-8000-000000000002", derogation_id: "00000000-0000-4000-8000-000000000003" }] : [] };
+    }
+    if (sql.includes("FROM public.quality_derogation")) return { rows: input.concession ? [input.concession] : [] };
+    throw new Error(`Unexpected query: ${sql}`);
+  });
+  return { query };
+}
+
+describe("operational Quality 360 gate", () => {
+  it("allows a released, controlled lot and retains immutable evidence ids", async () => {
+    const client = queryClient({ released: 10 });
+    const decision = await assertOperationalLotQualityEligibility({
+      client: client as never,
+      lotId: LOT_ID,
+      qty: 5,
+      purpose: "RESERVE",
+    });
+    expect(decision.target.qty_released).toBe(10);
+    expect(decision.evidence.control_ids).toHaveLength(1);
+    expect(decision.evidence.release_decision_ids).toEqual([]);
+    const sql = client.query.mock.calls.map(([statement]) => String(statement));
+    expect(sql.find((statement) => statement.includes("FROM public.lots"))).toContain("FOR UPDATE");
+    const controlSql = sql.find((statement) => statement.includes("FROM public.quality_control qc"));
+    expect(controlSql).toContain("LIMIT 1");
+    expect(controlSql).toContain("FOR UPDATE");
+  });
+
+  it("keeps an approved, in-scope concession auditable without weakening the release ledger", async () => {
+    const decision = await assertOperationalLotQualityEligibility({
+      client: queryClient({ concession: { status: "APPROVED", valid_to: "2999-01-01T00:00:00.000Z" } }) as never,
+      lotId: LOT_ID, qty: 5, purpose: "RESERVE",
+    });
+    expect(decision.evidence.derogation_ids).toEqual(["00000000-0000-4000-8000-000000000003"]);
+  });
+
+  it.each([
+    [{ status: "QUARANTAINE" as const }, "LOT_QUARANTINE"],
+    [{ status: "BLOQUE" as const }, "LOT_NOT_RELEASED"],
+    [{ pending: true }, "MANDATORY_CONTROL_PENDING"],
+    [{ openNc: 1 }, "OPEN_NON_CONFORMITY"],
+    [{ released: 2 }, "QTY_NOT_RELEASED"],
+  ])("fails closed for %o", async (input, expectedCode) => {
+    await expect(assertOperationalLotQualityEligibility({
+      client: queryClient(input) as never, lotId: LOT_ID, qty: 5, purpose: "RESERVE",
+    })).rejects.toMatchObject({ code: "QUALITY_NOT_ELIGIBLE", details: { blocks: expect.arrayContaining([expect.objectContaining({ code: expectedCode })]) } });
+  });
+
+  it("fails an expired concession even when the quantity is released", async () => {
+    await expect(assertOperationalLotQualityEligibility({
+      client: queryClient({ concession: { status: "APPROVED", valid_to: "2000-01-01T00:00:00.000Z" } }) as never,
+      lotId: LOT_ID, qty: 5, purpose: "RESERVE",
+    })).rejects.toMatchObject({ code: "QUALITY_NOT_ELIGIBLE", details: { blocks: expect.arrayContaining([expect.objectContaining({ code: "DEROGATION_EXPIRED" })]) } });
+  });
+
+  it("treats active and already-consumed reservations as finite release commitments", async () => {
+    await expect(assertOperationalLotQualityEligibility({
+      client: queryClient({ released: 10, committed: 7 }) as never,
+      lotId: LOT_ID, qty: 5, purpose: "RESERVE",
+    })).rejects.toMatchObject({
+      code: "QUALITY_NOT_ELIGIBLE",
+      details: { blocks: expect.arrayContaining([expect.objectContaining({ code: "QTY_NOT_RELEASED" })]) },
+    });
+  });
+
+  it("rejects a stock write whose unit is incompatible with the lot article", async () => {
+    await expect(assertOperationalLotQualityEligibility({
+      client: queryClient({ articleUnit: "KG" }) as never,
+      lotId: LOT_ID, qty: 1, unit: "PCS", purpose: "RESERVE",
+    })).rejects.toMatchObject({ code: "QUALITY_UNIT_MISMATCH" });
+  });
+
+  it("persists a direct OUT against the locked current control so later unreserved OUTs cannot reuse capacity", async () => {
+    const query = vi.fn(async () => ({ rows: [{ id: "00000000-0000-4000-8000-000000000001" }] }));
+    const decision = {
+      purpose: "RESERVE" as const,
+      target: { object_type: "LOT" as const, object_id: LOT_ID, label: "LOT-616", qty_requested: 4, lot_status: "LIBERE" as const, qty_released: 10, qty_held: 0, qty_consumed: 0, open_nc_without_disposition: 0, pending_mandatory_controls: 0, derogation: null },
+      already_committed_qty: 0,
+      evaluated_at: "2026-08-23T00:00:00.000Z",
+      evidence: { control_ids: ["00000000-0000-4000-8000-000000000001"], release_decision_ids: [], derogation_ids: [] },
+    };
+    await recordDirectLotQualityConsumption({ client: { query } as never, decision, qty: 4 });
+    expect(query).toHaveBeenCalledWith(expect.stringContaining("SET qty_consumed = qty_consumed + $2"), ["00000000-0000-4000-8000-000000000001", 4]);
+  });
+
+  it("fails closed rather than recording direct consumption without an evaluated control", async () => {
+    await expect(recordDirectLotQualityConsumption({
+      client: { query: vi.fn() } as never,
+      decision: {
+        purpose: "RESERVE", target: { object_type: "LOT", object_id: LOT_ID, label: "LOT-616", qty_requested: 1, lot_status: "LIBERE", qty_released: 1, qty_held: 0, qty_consumed: 0, open_nc_without_disposition: 0, pending_mandatory_controls: 0, derogation: null },
+        already_committed_qty: 0, evaluated_at: "2026-08-23T00:00:00.000Z",
+        evidence: { control_ids: [], release_decision_ids: [], derogation_ids: [] },
+      },
+      qty: 1,
+    })).rejects.toMatchObject({ code: "QUALITY_CONTROL_MISSING" });
+  });
+});

--- a/src/module/qualite/repository/quality-operational-gate.repository.ts
+++ b/src/module/qualite/repository/quality-operational-gate.repository.ts
@@ -1,0 +1,243 @@
+// Canonical Quality 360 gate for operational writes (#616).
+//
+// This intentionally consumes the same pure eligibility evaluator as the
+// Quality API and shipment gate.  It performs all reads through the caller's
+// transaction, so a stock/production/finance write cannot commit against a
+// stale quality decision.
+
+import type { PoolClient } from "pg";
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  assertQualityEligibility,
+  evaluateQualityEligibility,
+  type EligibilityTarget,
+  type QualityEligibilityPurpose,
+} from "../domain/quality-release";
+
+type Queryable = Pick<PoolClient, "query">;
+
+export type OperationalQualityDecision = {
+  purpose: QualityEligibilityPurpose;
+  target: EligibilityTarget;
+  /**
+   * Reservations are commitments against the released quantity even before a
+   * physical issue is posted.  Keeping this explicit prevents the audit
+   * snapshot from pretending that a reservation is already consumed.
+   */
+  already_committed_qty: number;
+  evaluated_at: string;
+  evidence: {
+    control_ids: string[];
+    release_decision_ids: string[];
+    derogation_ids: string[];
+  };
+};
+
+const numeric = (value: unknown): number => {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+/**
+ * Evaluates a physical lot under the lock held by the business command. A
+ * missing control/release quantity remains a zero quantity and is therefore
+ * rejected by `assertQualityEligibility`; it is never converted into a pass.
+ */
+export async function assertOperationalLotQualityEligibility(params: {
+  client: Queryable;
+  lotId: string;
+  qty: number;
+  /** Physical movement/reservation unit when the caller has one. */
+  unit?: string | null;
+  purpose: QualityEligibilityPurpose;
+}): Promise<OperationalQualityDecision> {
+  const lotRes = await params.client.query<{
+    lot_code: string;
+    lot_status: EligibilityTarget["lot_status"];
+    article_unit: string | null;
+  }>(
+    `
+      SELECT lot.lot_code, lot.lot_status::text AS lot_status, article.unite AS article_unit
+      FROM public.lots lot
+      JOIN public.articles article ON article.id = lot.article_id
+      WHERE lot.id = $1::uuid
+      FOR UPDATE
+    `,
+    [params.lotId]
+  );
+  const lot = lotRes.rows[0] ?? null;
+  if (!lot) throw new HttpError(409, "QUALITY_LOT_NOT_FOUND", "Le lot à contrôler est introuvable.");
+
+  const controls = await params.client.query<{
+    id: string;
+    qty_released: string;
+    qty_held: string;
+    qty_consumed: string;
+    unite: string | null;
+    pending: boolean;
+  }>(
+    `
+      SELECT
+        qc.id::text AS id,
+        qc.qty_released::text AS qty_released,
+        qc.qty_held::text AS qty_held,
+        qc.qty_consumed::text AS qty_consumed,
+        qc.unite,
+        (qc.validation_date IS NULL OR COALESCE(qc.verdict, 'EN_ATTENTE') = 'EN_ATTENTE') AS pending
+      FROM public.quality_control qc
+      WHERE qc.lot_id = $1::uuid
+         OR (qc.source_type = 'LOT' AND qc.source_id = $1::text)
+      ORDER BY qc.control_date DESC, qc.id DESC
+      LIMIT 1
+      FOR UPDATE
+    `,
+    [params.lotId]
+  );
+  // One lot release is an entitlement, not an additive vote. Use the newest
+  // control exactly as the delivery-release aggregate does; summing historical
+  // controls for the same population would over-authorize physical stock.
+  const controlIds = controls.rows.map((row) => row.id);
+  const normalizedUnit = (value: string | null | undefined) => value?.trim().toUpperCase() || null;
+  const articleUnit = normalizedUnit(lot.article_unit);
+  const requestedUnit = normalizedUnit(params.unit);
+  if (requestedUnit && articleUnit && requestedUnit !== articleUnit) {
+    throw new HttpError(
+      409,
+      "QUALITY_UNIT_MISMATCH",
+      "L'unité du mouvement ne correspond pas à l'unité de l'article du lot.",
+      { lot_id: params.lotId, movement_unit: params.unit, article_unit: lot.article_unit }
+    );
+  }
+  const conflictingControl = controls.rows.find((row) => {
+    const controlUnit = normalizedUnit(row.unite);
+    return Boolean(controlUnit && articleUnit && controlUnit !== articleUnit);
+  });
+  if (conflictingControl) {
+    throw new HttpError(
+      409,
+      "QUALITY_CONTROL_UNIT_MISMATCH",
+      "La décision Qualité du lot utilise une unité incompatible avec l'article.",
+      { lot_id: params.lotId, article_unit: lot.article_unit, control_id: conflictingControl.id, control_unit: conflictingControl.unite }
+    );
+  }
+  // A quality release is a finite entitlement.  `quality_control.qty_consumed`
+  // is the formal ledger, but stock reservations are the operational
+  // commitment made before the physical issue.  Count both ACTIVE and
+  // CONSUMED reservations under the same control-row lock so two concurrent
+  // reservations cannot both spend the same released quantity.
+  const commitments = await params.client.query<{ qty: string }>(
+    `
+      SELECT qty_reserved::text AS qty
+      FROM public.stock_reservations
+      WHERE lot_id = $1::uuid
+        AND status IN ('ACTIVE', 'CONSUMED')
+      FOR SHARE
+    `,
+    [params.lotId]
+  );
+  const alreadyCommittedQty = commitments.rows.reduce((sum, row) => sum + numeric(row.qty), 0);
+  const nc = await params.client.query<{ total: number }>(
+    `
+      SELECT COUNT(*)::int AS total
+      FROM public.non_conformity nc
+      WHERE nc.lot_id = $1::uuid
+        AND nc.status::text NOT IN ('CLOSED', 'CANCELLED')
+        AND NOT EXISTS (
+          SELECT 1 FROM public.non_conformity_dispositions d WHERE d.non_conformity_id = nc.id
+        )
+    `,
+    [params.lotId]
+  );
+  const concessions = controlIds.length === 0
+    ? { rows: [] as Array<{ decision_id: string; derogation_id: string }> }
+    : await params.client.query<{ decision_id: string; derogation_id: string }>(
+      `
+        SELECT rd.id::text AS decision_id, rd.derogation_id::text AS derogation_id
+        FROM public.quality_release_decision rd
+        JOIN public.quality_derogation d ON d.id = rd.derogation_id
+        WHERE rd.quality_control_id = ANY($1::uuid[])
+        ORDER BY rd.decided_at DESC, rd.id DESC
+      `,
+      [controlIds]
+    );
+  const activeConcession = concessions.rows[0] ?? null;
+  const derogation = activeConcession
+    ? await params.client.query<{ status: string; valid_to: string | null }>(
+      `SELECT status, valid_to::text AS valid_to FROM public.quality_derogation WHERE id = $1::uuid`,
+      [activeConcession.derogation_id]
+    )
+    : { rows: [] as Array<{ status: string; valid_to: string | null }> };
+
+  const target: EligibilityTarget = {
+    object_type: "LOT",
+    object_id: params.lotId,
+    label: lot.lot_code,
+    qty_requested: params.qty,
+    lot_status: lot.lot_status,
+    qty_released: controls.rows.reduce((sum, row) => sum + numeric(row.qty_released), 0),
+    qty_held: controls.rows.reduce((sum, row) => sum + numeric(row.qty_held), 0),
+    qty_consumed: controls.rows.reduce((sum, row) => sum + numeric(row.qty_consumed), 0),
+    open_nc_without_disposition: Number(nc.rows[0]?.total ?? 0),
+    pending_mandatory_controls: controls.rows.filter((row) => row.pending).length,
+    derogation: derogation.rows[0] ?? null,
+  };
+  const at = new Date();
+  // Call the evaluator explicitly before asserting to preserve a single,
+  // inspectable decision snapshot for the enclosing audit record.
+  // Evaluate the requested write together with prior stock commitments.  The
+  // returned target remains truthful about this command's own requested
+  // quantity; the commitment is carried separately in the audit payload.
+  const evaluationTarget = {
+    ...target,
+    qty_requested: target.qty_requested + alreadyCommittedQty,
+  };
+  evaluateQualityEligibility(evaluationTarget, params.purpose, at);
+  assertQualityEligibility(evaluationTarget, params.purpose, at);
+  return {
+    purpose: params.purpose,
+    target,
+    already_committed_qty: alreadyCommittedQty,
+    evaluated_at: at.toISOString(),
+    evidence: {
+      control_ids: controlIds,
+      release_decision_ids: concessions.rows.map((row) => row.decision_id),
+      derogation_ids: concessions.rows.map((row) => row.derogation_id),
+    },
+  };
+}
+
+/**
+ * Records an unreserved physical OUT against the exact quality-control row
+ * whose entitlement was locked and evaluated.  Reserved flows deliberately
+ * do not call this: their ACTIVE/CONSUMED reservation remains the durable
+ * commitment ledger and charging both ledgers would double-count it.
+ */
+export async function recordDirectLotQualityConsumption(params: {
+  client: Queryable;
+  decision: OperationalQualityDecision;
+  qty: number;
+}): Promise<void> {
+  if (!Number.isFinite(params.qty) || params.qty <= 0) {
+    throw new HttpError(422, "QUALITY_MOVEMENT_QTY_INVALID", "Quantité de sortie invalide pour le contrôle Qualité.");
+  }
+  const controlId = params.decision.evidence.control_ids[0] ?? null;
+  if (!controlId) {
+    // The assertion cannot normally succeed without a current control, but do
+    // not silently turn an unexpected data shape into an unbounded release.
+    throw new HttpError(409, "QUALITY_CONTROL_MISSING", "Aucun contrôle Qualité ne peut enregistrer cette consommation.");
+  }
+  const updated = await params.client.query<{ id: string }>(
+    `
+      UPDATE public.quality_control
+      SET qty_consumed = qty_consumed + $2,
+          updated_at = now()
+      WHERE id = $1::uuid
+      RETURNING id::text AS id
+    `,
+    [controlId, params.qty]
+  );
+  if (!updated.rows[0]) {
+    throw new HttpError(409, "QUALITY_CONTROL_MISSING", "Le contrôle Qualité de la sortie est introuvable.");
+  }
+}

--- a/src/module/qualite/repository/quality-outbound-call-sites.contract.test.ts
+++ b/src/module/qualite/repository/quality-outbound-call-sites.contract.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { repoRoot } from "../../../__tests__/helpers/repo-paths";
+
+const source = (relativePath: string) => readFileSync(resolve(repoRoot, relativePath), "utf8");
+
+describe("Quality 360 direct OUT writer contract (#616)", () => {
+  it("keeps generic and both delivery OUT posting paths behind the operational lot gate", () => {
+    const stock = source("src/module/stock/repository/stock.repository.ts");
+    expect(stock).toContain("assertDirectOutMovementQualityEligibility");
+    expect(stock).toContain('m.movement_type === "OUT"');
+
+    const legacyDelivery = source("src/module/livraisons/repository/livraisons.repository.ts");
+    expect(legacyDelivery).toContain("assertOperationalLotQualityEligibility");
+    expect(legacyDelivery).toContain("recordDirectLotQualityConsumption");
+    const legacyInsertAt = legacyDelivery.indexOf("VALUES ($1,'OUT'::public.movement_type,'DRAFT'");
+    expect(legacyDelivery.lastIndexOf("await assertOperationalLotQualityEligibility", legacyInsertAt)).toBeGreaterThanOrEqual(0);
+
+    const shipment = source("src/module/livraisons/repository/livraisons-shipment.repository.ts");
+    const gateCalls = shipment.match(/await assertOperationalLotQualityEligibility/g) ?? [];
+    // Preparation spends the entitlement. Final shipment revalidates the
+    // already-reserved lot with zero incremental quantity.
+    expect(gateCalls).toHaveLength(2);
+    const shipmentGate = shipment.slice(shipment.indexOf("export async function repoShipLivraison"));
+    expect(shipmentGate).toMatch(/assertOperationalLotQualityEligibility\([\s\S]*?qty: 0,[\s\S]*?purpose: "RESERVE"/);
+  });
+
+  it("documents the sole direct posted OUT exception as a Quality-owned NC disposition", () => {
+    const quality = source("src/module/qualite/repository/qualite.repository.ts");
+    expect(quality).toContain("createPostedStockMovementForDisposition");
+    expect(quality).toContain("repoCreateNonConformityDisposition");
+    expect(quality).toContain('movement_type: "OUT" | "SCRAP"');
+  });
+
+  it("locks a lot before publishing an NC that can quarantine it", () => {
+    const quality = source("src/module/qualite/repository/qualite.repository.ts");
+    const createNc = quality.slice(
+      quality.indexOf("export async function repoCreateNonConformity"),
+      quality.indexOf("export async function repoPatchNonConformity"),
+    );
+    const lotLockAt = createNc.indexOf("SELECT lot_status FROM public.lots WHERE id = $1::uuid FOR UPDATE");
+    const insertAt = createNc.indexOf("INSERT INTO non_conformity");
+    expect(lotLockAt).toBeGreaterThanOrEqual(0);
+    expect(lotLockAt).toBeLessThan(insertAt);
+  });
+});

--- a/src/module/qualite/repository/quality-reservation-call-sites.contract.test.ts
+++ b/src/module/qualite/repository/quality-reservation-call-sites.contract.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { repoRoot } from "../../../__tests__/helpers/repo-paths";
+
+const reservationWriters = [
+  "src/module/stock/repository/stock-reservation.repository.ts",
+  "src/module/production/repository/production-receipts.repository.ts",
+  "src/module/commande-client/repository/commande-client.repository.ts",
+  "src/module/livraisons/repository/livraisons.repository.ts",
+  "src/module/livraisons/repository/livraisons-shipment.repository.ts",
+] as const;
+
+describe("Quality 360 stock-reservation writer contract (#616)", () => {
+  it("keeps every direct reservation writer behind the canonical operational gate", () => {
+    for (const relativePath of reservationWriters) {
+      const source = readFileSync(resolve(repoRoot, relativePath), "utf8");
+      expect(source, relativePath).toContain("assertOperationalLotQualityEligibility");
+      const insertAt = source.indexOf("INSERT INTO public.stock_reservations");
+      expect(insertAt, relativePath).toBeGreaterThanOrEqual(0);
+      const gateAt = source.lastIndexOf("await assertOperationalLotQualityEligibility", insertAt);
+      expect(gateAt, relativePath).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("does not charge an ACTIVE reservation a second time when it is consumed", () => {
+    const relativePath = "src/module/stock/repository/stock-reservation.repository.ts";
+    const source = readFileSync(resolve(repoRoot, relativePath), "utf8");
+    const consumeGate = source.slice(source.indexOf("async function transitionReservation"));
+    expect(consumeGate).toMatch(/RESERVATION_CONSUME[\s\S]*?assertOperationalLotQualityEligibility\([\s\S]*?qty: 0,/);
+  });
+});

--- a/src/module/stock/repository/stock-direct-out-quality-gate.repository.test.ts
+++ b/src/module/stock/repository/stock-direct-out-quality-gate.repository.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { qualityGate } = vi.hoisted(() => ({ qualityGate: vi.fn() }));
+
+vi.mock("../../qualite/repository/quality-operational-gate.repository", () => ({
+  assertOperationalLotQualityEligibility: qualityGate,
+}));
+
+import { assertDirectOutMovementQualityEligibility } from "./stock.repository";
+
+const LOT_A = "00000000-0000-4000-8000-000000000616";
+const LOT_B = "00000000-0000-4000-8000-000000000617";
+
+describe("direct OUT Quality 360 repository boundary", () => {
+  beforeEach(() => qualityGate.mockReset());
+
+  it("aggregates each physical lot and calls the gate before posting", async () => {
+    qualityGate.mockResolvedValue({});
+
+    await assertDirectOutMovementQualityEligibility({
+      client: { query: vi.fn() } as never,
+      lines: [
+        { lot_id: LOT_A, qty: 2, unite: "PCS" },
+        { lot_id: LOT_A, qty: 3, unite: "PCS" },
+        { lot_id: LOT_B, qty: 1, unite: "KG" },
+      ],
+    });
+
+    expect(qualityGate).toHaveBeenCalledTimes(2);
+    expect(qualityGate).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      lotId: LOT_A, qty: 5, unit: "PCS", purpose: "RESERVE",
+    }));
+    expect(qualityGate).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      lotId: LOT_B, qty: 1, unit: "KG", purpose: "RESERVE",
+    }));
+  });
+
+  it("fails before an OUT can post when Quality rejects the lot", async () => {
+    qualityGate.mockRejectedValueOnce(Object.assign(new Error("blocked"), { code: "QUALITY_NOT_ELIGIBLE" }));
+
+    await expect(assertDirectOutMovementQualityEligibility({
+      client: { query: vi.fn() } as never,
+      lines: [{ lot_id: LOT_A, qty: 1, unite: "PCS" }],
+    })).rejects.toMatchObject({ code: "QUALITY_NOT_ELIGIBLE" });
+  });
+
+  it("rejects mixed units for a single lot instead of summing incomparable quantities", async () => {
+    await expect(assertDirectOutMovementQualityEligibility({
+      client: { query: vi.fn() } as never,
+      lines: [{ lot_id: LOT_A, qty: 1, unite: "PCS" }, { lot_id: LOT_A, qty: 1, unite: "KG" }],
+    })).rejects.toMatchObject({ code: "QUALITY_MOVEMENT_UNIT_AMBIGUOUS" });
+    expect(qualityGate).not.toHaveBeenCalled();
+  });
+});

--- a/src/module/stock/repository/stock-reservation.repository.ts
+++ b/src/module/stock/repository/stock-reservation.repository.ts
@@ -1,5 +1,7 @@
 import db from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import { assertOperationalLotQualityEligibility } from "../../qualite/repository/quality-operational-gate.repository";
 import type {
   StockReservationDetail,
   StockReservationEvent,
@@ -263,6 +265,7 @@ export async function repoCreateStockReservation(
     }
 
     let stockBatchId: string | null = null;
+    let qualityDecision: Awaited<ReturnType<typeof assertOperationalLotQualityEligibility>> | null = null;
     if (body.lot_id) {
       const batch = await client.query<{ id: string }>(
         `
@@ -281,6 +284,12 @@ export async function repoCreateStockReservation(
       if (!stockBatchId) {
         throw new HttpError(409, "STOCK_BATCH_MISSING", "The lot has no stock batch at this emplacement");
       }
+      qualityDecision = await assertOperationalLotQualityEligibility({
+        client,
+        lotId: body.lot_id,
+        qty: body.qty,
+        purpose: "RESERVE",
+      });
     }
 
     const states = await lockStockStates(client, [
@@ -363,6 +372,28 @@ export async function repoCreateStockReservation(
     const reservationId = inserted.rows[0]?.id;
     if (!reservationId) throw new Error("Failed to create stock reservation");
 
+    if (qualityDecision) {
+      await repoInsertAuditLog({
+        user_id: audit.user_id,
+        body: {
+          event_type: "ACTION",
+          action: "stock.reservation.quality_gate_passed",
+          page_key: audit.page_key,
+          entity_type: "stock_reservation",
+          entity_id: reservationId,
+          path: audit.path,
+          client_session_id: audit.client_session_id,
+          details: qualityDecision,
+        },
+        ip: audit.ip,
+        user_agent: audit.user_agent,
+        device_type: audit.device_type,
+        os: audit.os,
+        browser: audit.browser,
+        tx: client,
+      });
+    }
+
     await completeStockCommand(client, {
       audit,
       command,
@@ -420,9 +451,37 @@ async function transitionReservation(
       return repoGetStockReservation(command.existing.resource_id);
     }
 
+    // Read the identity first without taking the reservation row lock.  The
+    // Quality gate locks lot/control then observes reservations; taking this
+    // row lock first would deadlock a concurrent writer that already holds the
+    // lot lock and is reading ACTIVE commitments.  We lock and re-validate the
+    // reservation immediately after the gate.
+    const reservationIdentity = await client.query<{
+      lot_id: string | null;
+    }>(
+      `SELECT lot_id::text AS lot_id FROM public.stock_reservations WHERE id = $1::uuid`,
+      [id]
+    );
+    const identity = reservationIdentity.rows[0] ?? null;
+    if (!identity) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    const qualityDecision = args.command_type === "RESERVATION_CONSUME" && identity.lot_id
+      ? await assertOperationalLotQualityEligibility({
+          client,
+          lotId: identity.lot_id,
+          // The ACTIVE reservation already spends this release entitlement.
+          // Consumption validates current state without charging it twice.
+          qty: 0,
+          purpose: "RESERVE",
+        })
+      : null;
+
     const reservation = await client.query<{
       article_id: string;
       location_id: string;
+      lot_id: string | null;
       stock_batch_id: string | null;
       qty_reserved: number;
       status: string;
@@ -432,6 +491,7 @@ async function transitionReservation(
         SELECT
           article_id::text AS article_id,
           location_id::text AS location_id,
+          lot_id::text AS lot_id,
           stock_batch_id::text AS stock_batch_id,
           qty_reserved::float8 AS qty_reserved,
           status,
@@ -572,6 +632,27 @@ async function transitionReservation(
         consumed_stock_movement_id: consumedMovementId,
       },
     });
+    if (qualityDecision) {
+      await repoInsertAuditLog({
+        user_id: audit.user_id,
+        body: {
+          event_type: "ACTION",
+          action: "stock.reservation.quality_gate_passed",
+          page_key: audit.page_key,
+          entity_type: "stock_reservation",
+          entity_id: id,
+          path: audit.path,
+          client_session_id: audit.client_session_id,
+          details: qualityDecision,
+        },
+        ip: audit.ip,
+        user_agent: audit.user_agent,
+        device_type: audit.device_type,
+        os: audit.os,
+        browser: audit.browser,
+        tx: client,
+      });
+    }
     await client.query("COMMIT");
     return repoGetStockReservation(id);
   } catch (error) {

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -29,6 +29,10 @@ import { classifyUploadReconciliation, withUploadTransaction } from "../../../sh
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import {
+  assertOperationalLotQualityEligibility,
+  recordDirectLotQualityConsumption,
+} from "../../qualite/repository/quality-operational-gate.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import { recordMaterialConsumptionOnPost } from "../../traceability/services/material-consumption.automation";
 import {
@@ -7237,6 +7241,41 @@ export async function repoCreateMovement(
   }
 }
 
+export async function assertDirectOutMovementQualityEligibility(params: {
+  client: Pick<PoolClient, "query">;
+  lines: Array<Pick<CreateMovementLineDTO, "lot_id" | "qty" | "unite">>;
+}): Promise<Array<Awaited<ReturnType<typeof assertOperationalLotQualityEligibility>>>> {
+  const quantitiesByLot = new Map<string, { qty: number; unit: string | null }>();
+  for (const line of params.lines) {
+    if (!line.lot_id) continue;
+    const qty = Math.abs(Number(line.qty));
+    if (!Number.isFinite(qty) || qty <= 0) {
+      throw new HttpError(422, "QUALITY_MOVEMENT_QTY_INVALID", "Quantité de sortie invalide pour le contrôle Qualité.");
+    }
+    const unit = line.unite?.trim().toUpperCase() || null;
+    const existing = quantitiesByLot.get(line.lot_id);
+    if (existing && (existing.unit ?? null) !== unit) {
+      throw new HttpError(
+        409,
+        "QUALITY_MOVEMENT_UNIT_AMBIGUOUS",
+        "Un même lot ne peut pas être sorti avec plusieurs unités dans un mouvement."
+      );
+    }
+    quantitiesByLot.set(line.lot_id, { qty: (existing?.qty ?? 0) + qty, unit });
+  }
+  const decisions: Array<Awaited<ReturnType<typeof assertOperationalLotQualityEligibility>>> = [];
+  for (const [lotId, input] of quantitiesByLot) {
+    decisions.push(await assertOperationalLotQualityEligibility({
+      client: params.client,
+      lotId,
+      qty: input.qty,
+      unit: input.unit,
+      purpose: "RESERVE",
+    }));
+  }
+  return decisions;
+}
+
 export async function repoPostMovement(
   id: string,
   body: PostMovementBodyDTO,
@@ -7324,6 +7363,16 @@ export async function repoPostMovement(
       [id]
     );
     await ensureLotTrackingRespected(client, m.article_id, draftLines.rows);
+
+    // A direct material issue does not have to be created through a stock
+    // reservation.  It is nevertheless an irreversible physical use of a
+    // released lot, so it must pass the same Quality 360 boundary inside the
+    // very transaction that posts the OUT movement.  Transfers merely change
+    // location and quality dispositions (SCRAP/ADJUSTMENT) remain dedicated
+    // workflows, so neither is treated as a released-material consumption.
+    const directOutQualityDecisions = m.movement_type === "OUT"
+      ? await assertDirectOutMovementQualityEligibility({ client, lines: draftLines.rows })
+      : [];
 
     if (m.movement_type === "TRANSFER") {
       const movementLines = draftLines.rows;
@@ -7656,6 +7705,17 @@ export async function repoPostMovement(
       correlationId: command.correlation_id,
     });
 
+    // Direct OUT has no stock-reservation row to remain as a future
+    // commitment. Persist its release-capacity consumption before commit,
+    // under the quality-control row lock acquired by the gate. Without this,
+    // sequential unreserved movements could each pass the same release.
+    if (m.movement_type === "OUT") {
+      for (const decision of directOutQualityDecisions) {
+        const qty = decision.target.qty_requested;
+        await recordDirectLotQualityConsumption({ client, decision, qty });
+      }
+    }
+
     await insertAuditLog(client, audit, {
       action: "stock.movements.post",
       entity_type: "stock_movements",
@@ -7664,6 +7724,7 @@ export async function repoPostMovement(
         movement_no: m.movement_no,
         movement_type: m.movement_type,
         negative_stock_override: body.negative_stock_override ?? null,
+        quality_gates: directOutQualityDecisions,
         traceability_consumptions_recorded: consumption.recorded,
         traceability_consumptions_compensated: consumption.compensated,
       },


### PR DESCRIPTION
Closes #616

## Outcome
- enforces one canonical Quality release-capacity gate for reservations, stock OUT, production receipts, deliveries, and invoice issuance
- serializes lot/control/reservation mutations with a single lock order and durable release consumption
- prevents quarantined/blocked/nonconforming stock from operational use
- adds direct-writer contract coverage plus real PostgreSQL concurrency proofs for over-release and deadlock prevention

## Validation
- 29 focused tests after rebase, including 3 real PostgreSQL races
- TypeScript typecheck
- production build, OpenAPI inventory (1129 operations), and production-data boundary checks

## Summary by Sourcery

Enforce transaction-safe Quality release gates and durable entitlement accounting across all operational stock, shipment, production, and invoice workflows.

New Features:
- Enforce a canonical Quality eligibility gate across stock reservations, direct OUT movements, production receipts, deliveries, and invoice issuance.
- Persist Quality release consumption and decision evidence for operational and financial actions.

Bug Fixes:
- Prevent quarantined, blocked, nonconforming, pending-control, unit-incompatible, or insufficient-release lots from operational use.
- Prevent partial reservation consumption, over-release, double-counting, and concurrent deadlocks across reservation and shipment workflows.
- Require new production lots to undergo Quality control before being treated as released.

Enhancements:
- Standardize transaction lock ordering across Quality, delivery, lot, reservation, and stock mutations.
- Re-evaluate delivery Quality eligibility during invoice issuance and retain the resulting release audit.

Tests:
- Add repository contract and focused unit coverage for Quality gates, reservation handling, direct OUT boundaries, and legacy shipment planning.
- Add opt-in real PostgreSQL concurrency tests covering over-release prevention and advisory-lock ordering.