### PR TITLE
feat(production): explicit OF readiness and release (#617)

### DIFF
--- a/db/patches/20260823_of_readiness_release_617.sql
+++ b/db/patches/20260823_of_readiness_release_617.sql
@@ -1,0 +1,119 @@
+-- #617 - Explicit, auditable OF release gate.
+--
+-- Migration policy: no historical OF is backfilled or inferred as ready. An
+-- OF already EN_COURS/EN_PAUSE continues its already-started execution, while
+-- every new entry into execution requires a RELEASED decision below.
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.of_release_decisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  of_id bigint NOT NULL REFERENCES public.ordres_fabrication(id) ON DELETE RESTRICT,
+  decision text NOT NULL DEFAULT 'RELEASED',
+  override boolean NOT NULL DEFAULT false,
+  blocker_codes text[] NOT NULL DEFAULT ARRAY[]::text[],
+  override_reason text NULL,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  decided_at timestamptz NOT NULL DEFAULT now(),
+  decided_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT of_release_decisions_decision_chk CHECK (decision = 'RELEASED'),
+  CONSTRAINT of_release_decisions_one_per_of_uk UNIQUE (of_id),
+  CONSTRAINT of_release_decisions_override_reason_chk CHECK (
+    (override = false AND override_reason IS NULL) OR (override = true AND length(trim(coalesce(override_reason, ''))) >= 10)
+  )
+);
+
+-- CREATE TABLE IF NOT EXISTS does not repair an early/partial installation.
+-- Add every safety constraint independently so rerunning this patch converges
+-- to the same protected ledger.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.of_release_decisions'::regclass
+      AND conname = 'of_release_decisions_one_per_of_uk'
+  ) THEN
+    ALTER TABLE public.of_release_decisions
+      ADD CONSTRAINT of_release_decisions_one_per_of_uk UNIQUE (of_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.of_release_decisions'::regclass
+      AND conname = 'of_release_decisions_decision_chk'
+  ) THEN
+    ALTER TABLE public.of_release_decisions
+      ADD CONSTRAINT of_release_decisions_decision_chk CHECK (decision = 'RELEASED');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.of_release_decisions'::regclass
+      AND conname = 'of_release_decisions_override_reason_chk'
+  ) THEN
+    ALTER TABLE public.of_release_decisions
+      ADD CONSTRAINT of_release_decisions_override_reason_chk CHECK (
+        (override = false AND override_reason IS NULL)
+        OR (override = true AND length(trim(coalesce(override_reason, ''))) >= 10)
+      );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS of_release_decisions_of_decided_idx
+  ON public.of_release_decisions (of_id, decided_at DESC);
+
+-- A release is a signed manufacturing decision, never mutable application
+-- state. Corrections are made through later audited business actions, not by
+-- rewriting or deleting the evidence that allowed work to start.
+CREATE OR REPLACE FUNCTION public.fn_of_release_decisions_append_only_617()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'OF release decisions are immutable audit evidence'
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_of_release_decisions_append_only_617
+  ON public.of_release_decisions;
+CREATE TRIGGER trg_of_release_decisions_append_only_617
+  BEFORE UPDATE OR DELETE ON public.of_release_decisions
+  FOR EACH ROW EXECUTE FUNCTION public.fn_of_release_decisions_append_only_617();
+
+-- Database-level backstop: application routes are not the only possible
+-- writer. Historical OFs are untouched; only a new pre-launch -> execution
+-- transition must be backed by the immutable release decision in this same
+-- transaction.
+CREATE OR REPLACE FUNCTION public.fn_guard_of_execution_release_617()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.statut IN ('BROUILLON', 'PLANIFIE')
+     AND NEW.statut = 'EN_COURS'
+     AND NOT EXISTS (
+       SELECT 1 FROM public.of_release_decisions decision
+       WHERE decision.of_id = NEW.id AND decision.decision = 'RELEASED'
+     ) THEN
+    RAISE EXCEPTION 'OF execution requires an immutable release decision'
+      USING ERRCODE = '55000', CONSTRAINT = 'of_execution_release_required_617';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_guard_of_execution_release_617 ON public.ordres_fabrication;
+CREATE TRIGGER trg_guard_of_execution_release_617
+BEFORE UPDATE OF statut ON public.ordres_fabrication
+FOR EACH ROW EXECUTE FUNCTION public.fn_guard_of_execution_release_617();
+
+REVOKE ALL ON TABLE public.of_release_decisions FROM PUBLIC;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT, INSERT ON TABLE public.of_release_decisions TO cerp_app;
+    REVOKE UPDATE, DELETE, TRUNCATE ON TABLE public.of_release_decisions FROM cerp_app;
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260823_of_readiness_release_617.preflight.sql
+++ b/db/patches/support/20260823_of_readiness_release_617.preflight.sql
@@ -1,0 +1,23 @@
+\set ON_ERROR_STOP on
+BEGIN TRANSACTION READ ONLY;
+DO $preflight$
+BEGIN
+  IF to_regclass('public.ordres_fabrication') IS NULL OR to_regclass('public.users') IS NULL THEN
+    RAISE EXCEPTION '#617 preflight: OF and users tables are required';
+  END IF;
+  IF to_regprocedure('gen_random_uuid()') IS NULL THEN
+    RAISE EXCEPTION '#617 preflight: gen_random_uuid() is required';
+  END IF;
+  IF to_regclass('public.of_release_decisions') IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM public.of_release_decisions
+      GROUP BY of_id HAVING count(*) > 1
+    ) THEN
+      RAISE EXCEPTION '#617 preflight: duplicate historical decisions must be reconciled before adding the one-release-per-OF constraint';
+    END IF;
+  END IF;
+END $preflight$;
+SELECT to_regclass('public.of_release_decisions') IS NOT NULL AS already_applied,
+       count(*) AS existing_ofs, count(*) FILTER (WHERE statut IN ('EN_COURS','EN_PAUSE')) AS already_executing_ofs
+FROM public.ordres_fabrication;
+COMMIT;

--- a/db/patches/support/20260823_of_readiness_release_617.rollback.sql
+++ b/db/patches/support/20260823_of_readiness_release_617.rollback.sql
@@ -1,0 +1,13 @@
+\set ON_ERROR_STOP on
+DO $guard$
+BEGIN
+  IF current_database() <> 'cerp_test' OR current_setting('cerp.migration_rehearsal', true) IS DISTINCT FROM 'on' THEN
+    RAISE EXCEPTION '#617 rollback is test-only: cerp_test and cerp.migration_rehearsal=on required';
+  END IF;
+END $guard$;
+BEGIN;
+DROP TRIGGER IF EXISTS trg_guard_of_execution_release_617 ON public.ordres_fabrication;
+DROP FUNCTION IF EXISTS public.fn_guard_of_execution_release_617();
+DROP TABLE IF EXISTS public.of_release_decisions;
+DROP FUNCTION IF EXISTS public.fn_of_release_decisions_append_only_617();
+COMMIT;

--- a/db/patches/support/20260823_of_readiness_release_617.verify.sql
+++ b/db/patches/support/20260823_of_readiness_release_617.verify.sql
@@ -1,0 +1,43 @@
+\set ON_ERROR_STOP on
+BEGIN TRANSACTION;
+DO $verify$
+BEGIN
+  IF to_regclass('public.of_release_decisions') IS NULL THEN RAISE EXCEPTION '#617 verify: release decision table missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'public.of_release_decisions'::regclass AND conname = 'of_release_decisions_override_reason_chk') THEN
+    RAISE EXCEPTION '#617 verify: override reason constraint missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'public.of_release_decisions'::regclass AND conname = 'of_release_decisions_one_per_of_uk' AND contype = 'u') THEN
+    RAISE EXCEPTION '#617 verify: one-release-per-OF constraint missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'of_release_decisions_of_decided_idx') THEN
+    RAISE EXCEPTION '#617 verify: decision lookup index missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_guard_of_execution_release_617' AND tgenabled <> 'D') THEN
+    RAISE EXCEPTION '#617 verify: OF execution release guard is missing or disabled';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'public.of_release_decisions'::regclass
+      AND tgname = 'trg_of_release_decisions_append_only_617'
+      AND tgenabled <> 'D'
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION '#617 verify: immutable ledger trigger missing or disabled';
+  END IF;
+END $verify$;
+SELECT count(*) AS historical_release_decisions FROM public.of_release_decisions;
+
+DO $immutability_probe$
+DECLARE
+  v_of_id bigint;
+BEGIN
+  SELECT of_id INTO v_of_id FROM public.of_release_decisions LIMIT 1;
+  IF v_of_id IS NULL THEN RETURN; END IF;
+  BEGIN
+    UPDATE public.of_release_decisions SET evidence = evidence WHERE of_id = v_of_id;
+    RAISE EXCEPTION '#617 verify: release evidence accepted UPDATE';
+  EXCEPTION WHEN SQLSTATE '55000' THEN
+    NULL;
+  END;
+END $immutability_probe$;
+COMMIT;

--- a/docs/http/openapi-route-coverage.json
+++ b/docs/http/openapi-route-coverage.json
@@ -1,9 +1,9 @@
 {
   "scope": "/api/v1",
-  "source_sha256": "c165392634f171493289ff7503d126fab4defc6dde10cff72c8130e0bd75fd52",
-  "discovered_operations": 1129,
-  "documented_operations": 1129,
+  "source_sha256": "f4cba735d762d8cc0024ce406234f23b168296739a5692389ac0ef2a2e106525",
+  "discovered_operations": 1131,
+  "documented_operations": 1131,
   "coverage_percent": 100,
-  "authenticated_operations": 1109,
+  "authenticated_operations": 1111,
   "public_operations": 20
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-23T13:58:32.612Z",
+  "started_at": "2026-08-23T15:05:30.619Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 19137,
-    "source_seed": 211,
-    "backup": 767,
-    "preflight": 161,
-    "integrity_before": 576,
-    "migration": 1001,
-    "verify": 337,
-    "replay": 126,
-    "integrity_after": 1551,
+    "source_migration": 17921,
+    "source_seed": 188,
+    "backup": 702,
+    "preflight": 172,
+    "integrity_before": 555,
+    "migration": 904,
+    "verify": 340,
+    "replay": 121,
+    "integrity_after": 1456,
     "negative_gate": 40,
-    "rollback": 470,
-    "restore": 4079
+    "rollback": 450,
+    "restore": 3847
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-23T13:58:55.488Z",
-    "duration_ms": 112,
+    "checked_at": "2026-08-23T15:05:52.071Z",
+    "duration_ms": 114,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36363287"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-oGODNy\\cerp-test-before-sol06.dump",
-      "bytes": 1968552,
-      "sha256": "91762b69aa2bde844338da441dab92b6ff8c3f18c77198f511d9c30fd5c5fc5d",
-      "free_bytes": 371293040640
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-JLVswE\\cerp-test-before-sol06.dump",
+      "bytes": 1968541,
+      "sha256": "a3669cc1ba2253b9a7ce2ed72e636203d7b77bf0d482e1faaf2ee6b5b9473fd7",
+      "free_bytes": 369955233792
     },
     "ledger": {
       "applied": 140,
@@ -71,6 +71,7 @@
         "20260819_devis_preparation_idempotency_grants_002_003.sql",
         "20260819_mfa_expired_artifact_cleanup_delete_grant.sql",
         "20260823_authoritative_pdf_archive_612.sql",
+        "20260823_of_readiness_release_617.sql",
         "20260823_operational_media_access_611.sql"
       ],
       "checksum_mismatches": [],
@@ -484,13 +485,14 @@
         "20260819_devis_preparation_idempotency_grants_002_003.sql",
         "20260819_mfa_expired_artifact_cleanup_delete_grant.sql",
         "20260823_authoritative_pdf_archive_612.sql",
+        "20260823_of_readiness_release_617.sql",
         "20260823_operational_media_access_611.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "2ab61304f8c151509f23cf9a7a9f006178a71ac6759b8dd48082c1ce75dbf680"
+    "fingerprint": "e34dff916e151737929bb43238ab161a15aac4b83cde4777ae2ab727dd1a4cf0"
   },
   "replay": {
     "applied_zero": true,
@@ -498,8 +500,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-23T13:58:59.084Z",
-    "duration_ms": 1536,
+    "checked_at": "2026-08-23T15:05:55.452Z",
+    "duration_ms": 1443,
     "table_counts": {
       "accounting_export_batch_sources": "0",
       "accounting_export_batches": "0",
@@ -581,7 +583,7 @@
       "cerp_migration_supersessions": "5",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "171",
+      "cerp_schema_migrations": "172",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -760,6 +762,7 @@
       "of_planning_versions": "0",
       "of_quality_logs": "0",
       "of_receipts": "0",
+      "of_release_decisions": "0",
       "of_revisions": "0",
       "of_structure_snapshot": "0",
       "of_technical_snapshots": "0",
@@ -945,7 +948,7 @@
       "users": "8",
       "warehouses": "4"
     },
-    "table_count": 443,
+    "table_count": 444,
     "unvalidated_constraints": [
       {
         "table_name": "avoir",
@@ -1022,7 +1025,7 @@
         "groups": 0
       }
     ],
-    "foreign_key_count": 1230,
+    "foreign_key_count": 1232,
     "orphans": [],
     "readiness": [
       {
@@ -1034,7 +1037,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1051,7 +1054,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1069,7 +1072,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1095,7 +1098,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1112,7 +1115,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1130,7 +1133,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1150,7 +1153,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1168,7 +1171,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1194,7 +1197,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1212,7 +1215,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1231,7 +1234,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1269,7 +1272,7 @@
         "period_start": "2026-08-22T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-23T13:58:57.549Z",
+        "freshness_at": "2026-08-23T15:05:54.008Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1288,13 +1291,13 @@
       }
     ],
     "ledger": {
-      "applied": 171,
+      "applied": 172,
       "pending": [],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "f24ac611f0bb05457a546060715e1306acee24b6faa44000d17684291a63330e"
+    "fingerprint": "5be01aef72126314e94456da1bf659aa7f2e15aba3bbf793faa159d4d1ca0370"
   },
   "negative_gate": {
     "status": "passed",
@@ -1338,7 +1341,7 @@
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "2ab61304f8c151509f23cf9a7a9f006178a71ac6759b8dd48082c1ce75dbf680",
+    "fingerprint": "e34dff916e151737929bb43238ab161a15aac4b83cde4777ae2ab727dd1a4cf0",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1373,6 +1376,7 @@
         "20260819_devis_preparation_idempotency_grants_002_003.sql",
         "20260819_mfa_expired_artifact_cleanup_delete_grant.sql",
         "20260823_authoritative_pdf_archive_612.sql",
+        "20260823_of_readiness_release_617.sql",
         "20260823_operational_media_access_611.sql"
       ],
       "checksum_mismatches": [],
@@ -1380,5 +1384,5 @@
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-23T13:59:03.843Z"
+  "completed_at": "2026-08-23T15:05:59.944Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-23T13:59:03.843Z
+- Exécutée : 2026-08-23T15:05:59.944Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36363287 octets
-- Sauvegarde : 1968552 octets, SHA-256 `91762b69aa2bde844338da441dab92b6ff8c3f18c77198f511d9c30fd5c5fc5d`
-- Patches avant/après : 140 / 171
+- Sauvegarde : 1968541 octets, SHA-256 `a3669cc1ba2253b9a7ce2ed72e636203d7b77bf0d482e1faaf2ee6b5b9473fd7`
+- Patches avant/après : 140 / 172
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `2ab61304f8c151509f23cf9a7a9f006178a71ac6759b8dd48082c1ce75dbf680` / `2ab61304f8c151509f23cf9a7a9f006178a71ac6759b8dd48082c1ce75dbf680`
+- Empreinte source/restaurée : `e34dff916e151737929bb43238ab161a15aac4b83cde4777ae2ab727dd1a4cf0` / `e34dff916e151737929bb43238ab161a15aac4b83cde4777ae2ab727dd1a4cf0`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 19137 |
-| source_seed | 211 |
-| backup | 767 |
-| preflight | 161 |
-| integrity_before | 576 |
-| migration | 1001 |
-| verify | 337 |
-| replay | 126 |
-| integrity_after | 1551 |
+| source_migration | 17921 |
+| source_seed | 188 |
+| backup | 702 |
+| preflight | 172 |
+| integrity_before | 555 |
+| migration | 904 |
+| verify | 340 |
+| replay | 121 |
+| integrity_after | 1456 |
 | negative_gate | 40 |
-| rollback | 470 |
-| restore | 4079 |
+| rollback | 450 |
+| restore | 3847 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/src/__tests__/of-release-617.migration-guards.test.ts
+++ b/src/__tests__/of-release-617.migration-guards.test.ts
@@ -1,0 +1,28 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (file: string) => fs.readFileSync(path.resolve(process.cwd(), file), "utf8");
+
+describe("#617 OF release migration safety contract", () => {
+  const patch = read("db/patches/20260823_of_readiness_release_617.sql");
+  const preflight = read("db/patches/support/20260823_of_readiness_release_617.preflight.sql");
+  const verify = read("db/patches/support/20260823_of_readiness_release_617.verify.sql");
+  const rollback = read("db/patches/support/20260823_of_readiness_release_617.rollback.sql");
+
+  it("keeps one append-only release decision per OF", () => {
+    expect(patch).toContain("of_release_decisions_one_per_of_uk UNIQUE (of_id)");
+    expect(patch).toContain("BEFORE UPDATE OR DELETE ON public.of_release_decisions");
+    expect(patch).toContain("ERRCODE = '55000'");
+    expect(patch).toContain("GRANT SELECT, INSERT ON TABLE public.of_release_decisions TO cerp_app");
+    expect(patch).toContain("REVOKE UPDATE, DELETE, TRUNCATE ON TABLE public.of_release_decisions FROM cerp_app");
+  });
+
+  it("preflights duplicates, verifies the live trigger, and keeps rollback test-only", () => {
+    expect(preflight).toContain("GROUP BY of_id HAVING count(*) > 1");
+    expect(verify).toContain("trg_of_release_decisions_append_only_617");
+    expect(verify).toContain("UPDATE public.of_release_decisions SET evidence = evidence");
+    expect(rollback).toContain("current_database() <> 'cerp_test'");
+    expect(rollback).toContain("DROP FUNCTION IF EXISTS public.fn_of_release_decisions_append_only_617()");
+  });
+});

--- a/src/__tests__/of-release.concurrency.integration.test.ts
+++ b/src/__tests__/of-release.concurrency.integration.test.ts
@@ -1,0 +1,177 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const integrationUrl = process.env.OF_RELEASE_TEST_DATABASE_URL;
+
+const mocks = vi.hoisted(() => ({
+  audit: vi.fn(async () => ({ id: crypto.randomUUID(), created_at: new Date().toISOString() })),
+  enqueue: vi.fn(async () => undefined),
+}));
+
+vi.mock("../module/audit-logs/repository/audit-logs.repository", () => ({
+  repoInsertAuditLog: mocks.audit,
+}));
+vi.mock("../module/production/repository/production-realtime.repository", () => ({
+  enqueueProductionOfChanged: mocks.enqueue,
+  productionRealtimeActionFromAudit: vi.fn(() => "status_changed"),
+}));
+
+const suite = integrationUrl ? describe : describe.skip;
+
+suite("#617 PostgreSQL OF release serialization", () => {
+  let pool: import("pg").Pool;
+  let repository: typeof import("../module/production/repository/production.repository");
+  const audit = { user_id: 1, user_role: "Directeur", ip: null, user_agent: null, device_type: null, os: null, browser: null, path: "/api/v1/production/ofs/1/release", page_key: "production", client_session_id: null };
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = integrationUrl;
+    const pg = await import("pg");
+    const bootstrap = new pg.Client({ connectionString: integrationUrl });
+    await bootstrap.connect();
+    const database = await bootstrap.query<{ current_database: string }>("SELECT current_database()");
+    if (!/test|sandbox|local/i.test(database.rows[0]?.current_database ?? "")) throw new Error("OF_RELEASE_TEST_DATABASE_URL must target an explicitly named test/local/sandbox database");
+    await bootstrap.query(`DROP SCHEMA public CASCADE; CREATE SCHEMA public; CREATE EXTENSION IF NOT EXISTS pgcrypto;
+      CREATE TABLE public.users (id integer PRIMARY KEY);
+      CREATE TYPE public.of_status AS ENUM ('BROUILLON','PLANIFIE','EN_COURS','EN_PAUSE','TERMINE','CLOTURE','ANNULE');
+      CREATE TABLE public.ordres_fabrication (id bigint PRIMARY KEY, statut public.of_status NOT NULL, technical_snapshot jsonb, technical_snapshot_sha256 text, piece_technique_id uuid NOT NULL, quantite_lancee numeric NOT NULL DEFAULT 1, updated_at timestamptz NOT NULL DEFAULT now(), date_lancement_reelle date, updated_by integer);
+      CREATE TABLE public.of_operations (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), of_id bigint NOT NULL, status text, machine_id uuid);
+      CREATE TABLE public.planning_events (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), of_id bigint, start_ts timestamptz NOT NULL, end_ts timestamptz NOT NULL, status text NOT NULL DEFAULT 'PLANNED', archived_at timestamptz);
+      CREATE TABLE public.operation_dossiers (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), operation_type text, operation_id text, dossier_type text);
+      CREATE TABLE public.operation_dossier_versions (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), dossier_id uuid);
+      CREATE TABLE public.operation_dossier_version_documents (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), dossier_version_id uuid, document_id uuid);
+      CREATE TABLE public.quality_control (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), of_id bigint, plan_id uuid, plan_version integer, plan_snapshot jsonb, plan_snapshot_sha256 text);
+      CREATE TABLE public.non_conformity (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), of_id bigint, status text);
+      CREATE TABLE public.pieces_techniques_nomenclature (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), parent_piece_technique_id uuid);
+      CREATE TABLE public.stock_reservations (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), of_id bigint, article_id uuid, qty_reserved numeric, status text, expires_at timestamptz);
+    `);
+    const migration = await fs.readFile(path.resolve(process.cwd(), "db/patches/20260823_of_readiness_release_617.sql"), "utf8");
+    await bootstrap.query(migration);
+    await bootstrap.end();
+    pool = (await import("../config/database")).default;
+    repository = await import("../module/production/repository/production.repository");
+  }, 60_000);
+
+  beforeEach(async () => {
+    mocks.audit.mockClear();
+    mocks.enqueue.mockClear();
+    await pool.query("TRUNCATE public.of_release_decisions, public.of_operations, public.planning_events, public.operation_dossiers, public.operation_dossier_versions, public.operation_dossier_version_documents, public.quality_control, public.non_conformity, public.pieces_techniques_nomenclature, public.stock_reservations, public.ordres_fabrication, public.users");
+    await pool.query("INSERT INTO public.users (id) VALUES (1)");
+    await pool.query(`INSERT INTO public.ordres_fabrication
+      (id, statut, technical_snapshot, technical_snapshot_sha256, piece_technique_id, quantite_lancee)
+      VALUES (1,'PLANIFIE','{"nomenclature":[],"achats":[]}'::jsonb,$1,'11111111-1111-4111-8111-111111111111',2)`, ["a".repeat(64)]);
+    const operation = await pool.query<{ id: string }>("INSERT INTO public.of_operations (of_id,status) VALUES (1,'TODO') RETURNING id::text AS id");
+    const operationId = operation.rows[0]!.id;
+    await pool.query("INSERT INTO public.planning_events (of_id,start_ts,end_ts) VALUES (1,now(),now()+interval '1 hour')");
+    const dossier = await pool.query<{ id: string }>("INSERT INTO public.operation_dossiers (operation_type,operation_id,dossier_type) VALUES ('OF_OPERATION',$1,'INSTRUCTION') RETURNING id::text AS id", [operationId]);
+    const version = await pool.query<{ id: string }>("INSERT INTO public.operation_dossier_versions (dossier_id) VALUES ($1::uuid) RETURNING id::text AS id", [dossier.rows[0]!.id]);
+    await pool.query("INSERT INTO public.operation_dossier_version_documents (dossier_version_id,document_id) VALUES ($1::uuid,gen_random_uuid())", [version.rows[0]!.id]);
+    await pool.query(`INSERT INTO public.quality_control (of_id,plan_id,plan_version,plan_snapshot,plan_snapshot_sha256)
+      VALUES (1,gen_random_uuid(),3,'{"characteristics":[{"code":"DIM-A"}]}'::jsonb,$1)`, ["b".repeat(64)]);
+  });
+
+  afterAll(async () => { await pool?.end(); });
+
+  it("serializes two simultaneous releases: one decision, one status commitment and one audit", async () => {
+    const results = await Promise.allSettled([
+      repository.repoReleaseOrdreFabrication({ id: 1, body: { override: false }, audit }),
+      repository.repoReleaseOrdreFabrication({ id: 1, body: { override: false }, audit }),
+    ]);
+    const settledSummary = results.map((result) => result.status === "fulfilled"
+      ? { status: result.status }
+      : {
+          status: result.status,
+          name: result.reason instanceof Error ? result.reason.name : typeof result.reason,
+          message: result.reason instanceof Error ? result.reason.message : String(result.reason),
+          code: (result.reason as { code?: unknown } | null)?.code ?? null,
+        });
+    expect(
+      results.filter((result) => result.status === "fulfilled"),
+      JSON.stringify(settledSummary)
+    ).toHaveLength(1);
+    expect(results.find((result) => result.status === "rejected")).toMatchObject({ reason: { code: "OF_RELEASE_INVALID_STATE", status: 409 } });
+    expect((await pool.query("SELECT count(*)::int AS count FROM public.of_release_decisions WHERE of_id=1")).rows[0].count).toBe(1);
+    expect((await pool.query("SELECT statut::text AS statut FROM public.ordres_fabrication WHERE id=1")).rows[0].statut).toBe("EN_COURS");
+    const evidence = (await pool.query<{ evidence: Record<string, unknown> }>("SELECT evidence FROM public.of_release_decisions WHERE of_id=1")).rows[0].evidence;
+    expect(evidence).toMatchObject({ evidence_version: 2, technical_snapshot_sha256: "a".repeat(64), quality_plan_count: 1 });
+    expect(evidence.quality_plan_evidence).toEqual([expect.objectContaining({ snapshot_sha256: "b".repeat(64), plan_version: 3 })]);
+    expect(mocks.audit).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not accept a legacy Quality row without a frozen plan snapshot as release evidence", async () => {
+    await pool.query("UPDATE public.quality_control SET plan_snapshot=NULL, plan_snapshot_sha256=NULL WHERE of_id=1");
+    await expect(repository.repoReleaseOrdreFabrication({ id: 1, body: { override: false }, audit })).rejects.toMatchObject({
+      code: "OF_NOT_READY_FOR_RELEASE",
+      status: 409,
+      details: expect.objectContaining({ blockers: expect.arrayContaining(["QUALITY_PLAN_MISSING"]) }),
+    });
+    expect((await pool.query("SELECT count(*)::int AS count FROM public.of_release_decisions WHERE of_id=1")).rows[0].count).toBe(0);
+  });
+
+  it("does not treat cancelled or archived planning events as capacity evidence", async () => {
+    await pool.query("UPDATE public.planning_events SET status='CANCELLED' WHERE of_id=1");
+    await expect(repository.repoReleaseOrdreFabrication({ id: 1, body: { override: false }, audit })).rejects.toMatchObject({
+      code: "OF_NOT_READY_FOR_RELEASE",
+      status: 409,
+      details: expect.objectContaining({ blockers: expect.arrayContaining(["CAPACITY_OR_CALENDAR_MISSING"]) }),
+    });
+    await pool.query("UPDATE public.planning_events SET status='PLANNED', archived_at=now() WHERE of_id=1");
+    await expect(repository.repoReleaseOrdreFabrication({ id: 1, body: { override: false }, audit })).rejects.toMatchObject({
+      code: "OF_NOT_READY_FOR_RELEASE",
+      status: 409,
+      details: expect.objectContaining({ blockers: expect.arrayContaining(["CAPACITY_OR_CALENDAR_MISSING"]) }),
+    });
+  });
+
+  it("requires quantity coverage for every frozen material article and ignores unrelated reservations", async () => {
+    await pool.query(`UPDATE public.ordres_fabrication SET technical_snapshot = $1::jsonb WHERE id=1`, [JSON.stringify({
+      nomenclature: [
+        { child_article_id: "22222222-2222-4222-8222-222222222222", quantite: 2 },
+        { child_article_id: "33333333-3333-4333-8333-333333333333", quantite: 3 },
+      ],
+      achats: [],
+    })]);
+    await pool.query(`INSERT INTO public.stock_reservations (of_id,article_id,qty_reserved,status) VALUES
+      (1,'22222222-2222-4222-8222-222222222222',4,'ACTIVE'),
+      (1,'44444444-4444-4444-8444-444444444444',99,'ACTIVE')`);
+
+    const insufficient = await repository.repoGetOfReadiness({ id: 1 });
+    expect(insufficient).toMatchObject({ ready: false, blockers: expect.arrayContaining(["MATERIAL_RESERVATION_MISSING"]) });
+    expect(insufficient?.evidence).toMatchObject({ material_requirement_count: 2, material_requirement_covered_count: 1 });
+    expect(insufficient?.evidence.material_requirement_evidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({ article_id: "22222222-2222-4222-8222-222222222222", required_qty: 4, reserved_qty: 4, covered: true }),
+      expect.objectContaining({ article_id: "33333333-3333-4333-8333-333333333333", required_qty: 6, reserved_qty: 0, covered: false }),
+    ]));
+
+    await pool.query(`INSERT INTO public.stock_reservations (of_id,article_id,qty_reserved,status)
+      VALUES (1,'33333333-3333-4333-8333-333333333333',6,'ACTIVE')`);
+    await expect(repository.repoGetOfReadiness({ id: 1 })).resolves.toMatchObject({ ready: true, blockers: [] });
+
+    await pool.query(`UPDATE public.stock_reservations SET expires_at = now() - interval '1 second'
+      WHERE article_id='33333333-3333-4333-8333-333333333333'`);
+    await expect(repository.repoGetOfReadiness({ id: 1 })).resolves.toMatchObject({
+      ready: false,
+      blockers: expect.arrayContaining(["MATERIAL_RESERVATION_MISSING"]),
+    });
+  });
+
+  it("enforces one immutable decision per OF at the database boundary", async () => {
+    await repository.repoReleaseOrdreFabrication({ id: 1, body: { override: false }, audit });
+    await expect(pool.query("UPDATE public.of_release_decisions SET evidence='{}'::jsonb WHERE of_id=1")).rejects.toMatchObject({ code: "55000" });
+    await expect(pool.query("DELETE FROM public.of_release_decisions WHERE of_id=1")).rejects.toMatchObject({ code: "55000" });
+    await expect(pool.query(`INSERT INTO public.of_release_decisions
+      (of_id,decision,override,blocker_codes,override_reason,evidence,decided_by)
+      VALUES (1,'RELEASED',false,ARRAY[]::text[],NULL,'{}'::jsonb,1)`)).rejects.toMatchObject({
+        code: "23505",
+        constraint: "of_release_decisions_one_per_of_uk",
+      });
+  });
+
+  it("blocks a direct planned-to-execution write without an immutable decision", async () => {
+    await expect(pool.query("UPDATE public.ordres_fabrication SET statut='EN_COURS' WHERE id=1")).rejects.toMatchObject({
+      code: "55000", constraint: "of_execution_release_required_617",
+    });
+    expect((await pool.query("SELECT count(*)::int AS count FROM public.of_release_decisions WHERE of_id=1")).rows[0].count).toBe(0);
+  });
+});

--- a/src/__tests__/of-work-orders-170.guards.test.ts
+++ b/src/__tests__/of-work-orders-170.guards.test.ts
@@ -72,9 +72,9 @@ describe("#170 OF status machine", () => {
     expect(Object.keys(OF_STATUT_TRANSITIONS).sort()).toEqual([...OF_STATUTS].sort());
   });
 
-  it("accepts the nominal life-cycle", () => {
+  it("accepts the nominal life-cycle while reserving PLANIFIE -> EN_COURS for explicit release", () => {
     expect(canTransitionOfStatut("BROUILLON", "PLANIFIE")).toBe(true);
-    expect(canTransitionOfStatut("PLANIFIE", "EN_COURS")).toBe(true);
+    expect(canTransitionOfStatut("PLANIFIE", "EN_COURS")).toBe(false);
     expect(canTransitionOfStatut("EN_COURS", "EN_PAUSE")).toBe(true);
     expect(canTransitionOfStatut("EN_PAUSE", "EN_COURS")).toBe(true);
     expect(canTransitionOfStatut("EN_COURS", "TERMINE")).toBe(true);

--- a/src/__tests__/production-execution-274.routes.test.ts
+++ b/src/__tests__/production-execution-274.routes.test.ts
@@ -664,6 +664,25 @@ describe("#274 anti-IDOR", () => {
       .set("x-test-user-id", "7");
     expect(res.status).toBe(403);
   });
+
+  it("ne propose au poste opérateur que des OF libérés ou en pause", async () => {
+    let candidateSql = "";
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.of_operations op") && sql.includes("JOIN public.ordres_fabrication")) {
+        candidateSql = sql;
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .get(`${BASE}/operator-board?operator_user_id=7`)
+      .set("x-test-role", OPERATOR)
+      .set("x-test-user-id", "7");
+
+    expect(res.status).toBe(200);
+    expect(candidateSql).toContain("o.statut IN ('EN_COURS', 'EN_PAUSE')");
+    expect(candidateSql).not.toContain("'PLANIFIE'");
+  });
 });
 
 /* -------------------------------------------------------------------------- */

--- a/src/__tests__/production-of-170.routes.test.ts
+++ b/src/__tests__/production-of-170.routes.test.ts
@@ -333,7 +333,7 @@ describe("#170 operation transitions + time logs", () => {
     expect(res.body).toMatchObject({ code: "OF_OPERATION_ALREADY_DONE" });
   });
 
-  it("auto-advances a BROUILLON OF to EN_COURS when a time log starts", async () => {
+  it("refuses a BROUILLON OF instead of implicitly entering execution", async () => {
     const updates: string[] = [];
     mocks.clientQuery.mockImplementation(async (sql: unknown) => {
       const q = String(sql);
@@ -401,8 +401,9 @@ describe("#170 operation transitions + time logs", () => {
       .post(`/api/v1/production/ofs/5/operations/${OP_1}/time-logs/start`)
       .set("x-test-role", "Responsable Production")
       .send({ type: "PRODUCTION" });
-    expect(res.status).toBe(201);
-    expect(updates.some((q) => q.includes("'EN_COURS'::of_status"))).toBe(true);
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ code: "OF_EXECUTION_NOT_ALLOWED" });
+    expect(updates.some((q) => q.includes("'EN_COURS'::of_status"))).toBe(false);
   });
 });
 
@@ -954,6 +955,70 @@ describe("#170 bounded production receipt", () => {
     const denied = await request(app).get("/api/v1/production/ofs/5/traceability").set("x-test-role", "Employe");
     expect(denied.status).toBe(403);
     const allowed = await request(app).get("/api/v1/production/ofs/5/traceability").set("x-test-role", "Qualite");
+    expect(allowed.status).toBe(200);
+  });
+});
+
+describe("#617 mounted explicit OF release route", () => {
+  function installReleaseMocks(params: { blockers?: string[]; statut?: string }) {
+    const blockers = params.blockers ?? [];
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (["BEGIN", "COMMIT", "ROLLBACK"].includes(q)) return { rows: [] };
+      if (q.includes("FROM public.ordres_fabrication WHERE") && q.includes("FOR UPDATE")) {
+        return { rows: [{ statut: params.statut ?? "PLANIFIE", updated_at: OF_UPDATED_AT }] };
+      }
+      if (q.includes("FROM public.ordres_fabrication o") && q.includes("WHERE o.id")) {
+        return { rows: [{ id: "5", technical_snapshot_sha256: "a".repeat(64), technical_snapshot_present: true, operation_count: 1, planned_event_count: 1, instruction_covered_count: 1, quality_plan_count: blockers.length ? 0 : 1, quality_plan_evidence: [], open_nc_count: 0, material_requirement_count: 0, material_requirement_covered_count: 0, material_requirement_evidence: [], reservation_count: 0, released_at: null, override: null }] };
+      }
+      if (q.includes("INSERT INTO public.of_release_decisions")) return { rows: [{ decided_at: "2026-08-23T00:00:00.000Z" }] };
+      if (q.includes("UPDATE public.ordres_fabrication")) return { rows: [] };
+      if (q.includes("INSERT INTO erp_audit_logs")) return { rows: [{ id: "audit-1", created_at: "2026-08-23T00:00:00.000Z" }] };
+      return { rows: [] };
+    });
+    // Readiness evaluation is kept source-backed in the repository. Override
+    // tests use its two schema-unavailable dimensions, never a fake green row.
+    if (blockers.length) {
+      mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+        const q = String(sql);
+        if (["BEGIN", "COMMIT", "ROLLBACK"].includes(q)) return { rows: [] };
+        if (q.includes("FROM public.ordres_fabrication WHERE") && q.includes("FOR UPDATE")) return { rows: [{ statut: "PLANIFIE", updated_at: OF_UPDATED_AT }] };
+        if (q.includes("FROM public.ordres_fabrication o") && q.includes("WHERE o.id")) return { rows: [{ id: "5", technical_snapshot_sha256: "a".repeat(64), technical_snapshot_present: true, operation_count: 1, planned_event_count: 1, instruction_covered_count: 1, quality_plan_count: 0, quality_plan_evidence: [], open_nc_count: 0, material_requirement_count: 0, material_requirement_covered_count: 0, material_requirement_evidence: [], reservation_count: 0, released_at: null, override: null }] };
+        if (q.includes("INSERT INTO public.of_release_decisions") || q.includes("UPDATE public.ordres_fabrication") || q.includes("INSERT INTO erp_audit_logs")) return { rows: [{ id: "audit-1", created_at: "2026-08-23T00:00:00.000Z" }] };
+        return { rows: [] };
+      });
+    }
+  }
+
+  it("denies the mounted release route to a role without release capability", async () => {
+    const response = await request(app).post("/api/v1/production/ofs/5/release").set("x-test-role", "Comptabilite").send({});
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({ code: "OF_FORBIDDEN" });
+  });
+
+  it("releases a ready planned OF once and writes an authoritative audit", async () => {
+    installReleaseMocks({});
+    const response = await request(app).post("/api/v1/production/ofs/5/release").set("x-test-role", "Responsable Production").send({ expected_updated_at: OF_UPDATED_AT });
+    expect(response.status).toBe(200);
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.of_release_decisions"))).toBe(true);
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO erp_audit_logs"))).toBe(true);
+  });
+
+  it("rejects a normal release when current readiness has blockers", async () => {
+    installReleaseMocks({ blockers: ["QUALITY_PLAN_MISSING"] });
+    const response = await request(app).post("/api/v1/production/ofs/5/release").set("x-test-role", "Responsable Production").send({});
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({ code: "OF_NOT_READY_FOR_RELEASE" });
+  });
+
+  it("denies override by a non-director and accepts an exact director override", async () => {
+    installReleaseMocks({ blockers: ["QUALITY_PLAN_MISSING"] });
+    const body = { override: true, override_reason: "Controlled customer-approved release", override_blocker_codes: ["QUALITY_PLAN_MISSING"] };
+    const denied = await request(app).post("/api/v1/production/ofs/5/release").set("x-test-role", "Responsable Production").send(body);
+    expect(denied.status).toBe(403);
+    expect(denied.body).toMatchObject({ code: "OF_RELEASE_OVERRIDE_FORBIDDEN" });
+    installReleaseMocks({ blockers: ["QUALITY_PLAN_MISSING"] });
+    const allowed = await request(app).post("/api/v1/production/ofs/5/release").set("x-test-role", "Directeur").send(body);
     expect(allowed.status).toBe(200);
   });
 });

--- a/src/module/production/controllers/production.controller.ts
+++ b/src/module/production/controllers/production.controller.ts
@@ -20,6 +20,7 @@ import {
   posteIdParamSchema,
   previewOfGenerationSchema,
   reorderOfOperationsSchema,
+  releaseOfSchema,
   startOfTimeLogSchema,
   stopOfTimeLogSchema,
   updateMachineSchema,
@@ -49,6 +50,8 @@ import {
   svcCreateOfReceipt,
   svcPreviewOfGeneration,
   svcReorderOfOperations,
+  svcGetOfReadiness,
+  svcReleaseOrdreFabrication,
   svcStartOfOperationTimeLog,
   svcStopOfOperationTimeLog,
   svcUpdateOrdreFabrication,
@@ -375,6 +378,21 @@ export const updateOrdreFabrication = asyncHandler(async (req, res) => {
     res.status(404).json({ error: "Not found" });
     return;
   }
+  res.status(200).json(out);
+});
+
+export const getOfReadiness = asyncHandler(async (req, res) => {
+  const { id } = ofIdParamSchema.parse({ params: req.params }).params;
+  const out = await svcGetOfReadiness({ id });
+  if (!out) { res.status(404).json({ error: "Not found" }); return; }
+  res.status(200).json(out);
+});
+
+export const releaseOrdreFabrication = asyncHandler(async (req, res) => {
+  const audit = buildAuditContext(req);
+  const { id } = ofIdParamSchema.parse({ params: req.params }).params;
+  const body = releaseOfSchema.parse({ body: parseBody(req) }).body;
+  const out = await svcReleaseOrdreFabrication({ id, body, audit });
   res.status(200).json(out);
 });
 

--- a/src/module/production/domain/of-rbac.ts
+++ b/src/module/production/domain/of-rbac.ts
@@ -10,6 +10,7 @@ export type OfCapability =
   | "generate"
   | "edit_prelaunch"
   | "launch"
+  | "release"
   | "operate"
   | "receipt"
   | "quality_decision"
@@ -30,6 +31,9 @@ const NEEDLES: Record<OfCapability, readonly string[]> = {
   generate: ["admin", "administrateur", "directeur", "production", "method"],
   edit_prelaunch: ["admin", "administrateur", "directeur", "production", "method"],
   launch: ["admin", "administrateur", "directeur", "production"],
+  // Release is a manufacturing commitment, deliberately narrower than normal
+  // workshop execution. Overrides remain director/admin only in the service.
+  release: ["admin", "administrateur", "directeur", "production", "method", "planif"],
   operate: ["admin", "administrateur", "directeur", "production", "atelier"],
   receipt: ["admin", "administrateur", "directeur", "production", "atelier", "logisti", "qualit"],
   quality_decision: ["admin", "administrateur", "directeur", "production", "qualit"],

--- a/src/module/production/domain/of-release.test.ts
+++ b/src/module/production/domain/of-release.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { canTransitionOfStatut, ofStatutAllowsExecution } from "./of-status";
+import { releaseOfSchema } from "../validators/production.validators";
+
+describe("OF explicit release boundary (#617)", () => {
+  it("does not expose an implicit draft/planned to execution transition", () => {
+    expect(canTransitionOfStatut("BROUILLON", "EN_COURS")).toBe(false);
+    expect(canTransitionOfStatut("PLANIFIE", "EN_COURS")).toBe(false);
+    expect(ofStatutAllowsExecution("BROUILLON")).toBe(false);
+    expect(ofStatutAllowsExecution("PLANIFIE")).toBe(false);
+    expect(ofStatutAllowsExecution("EN_COURS")).toBe(true);
+    expect(ofStatutAllowsExecution("EN_PAUSE")).toBe(true);
+  });
+
+  it("requires a reason and an explicit blocker selection for an override", () => {
+    expect(() => releaseOfSchema.parse({ body: { override: true } })).toThrow();
+    expect(() => releaseOfSchema.parse({ body: { override: true, override_reason: "Reason with enough detail", override_blocker_codes: [] } })).toThrow();
+    expect(() => releaseOfSchema.parse({ body: { override: false, override_reason: "This must not be accepted" } })).toThrow();
+    expect(releaseOfSchema.parse({ body: { override: true, override_reason: "Customer-approved controlled deviation", override_blocker_codes: ["QUALITY_PLAN_MISSING"] } }).body.override).toBe(true);
+  });
+});

--- a/src/module/production/domain/of-status.ts
+++ b/src/module/production/domain/of-status.ts
@@ -28,8 +28,10 @@ export const OF_STATUT_LABELS: Record<OfStatut, string> = {
 // prématurée est une réalité (correction contrôlée, auditée), pas une
 // réécriture d'historique. CLOTURE et ANNULE sont terminaux.
 export const OF_STATUT_TRANSITIONS: Record<OfStatut, readonly OfStatut[]> = {
-  BROUILLON: ["PLANIFIE", "EN_COURS", "ANNULE"],
-  PLANIFIE: ["BROUILLON", "EN_COURS", "ANNULE"],
+  // Entering execution is a separate, lock-held release command. A generic
+  // PATCH must never bypass the readiness decision.
+  BROUILLON: ["PLANIFIE", "ANNULE"],
+  PLANIFIE: ["BROUILLON", "ANNULE"],
   EN_COURS: ["EN_PAUSE", "TERMINE", "ANNULE"],
   EN_PAUSE: ["EN_COURS", "ANNULE"],
   TERMINE: ["EN_COURS", "CLOTURE"],
@@ -51,14 +53,9 @@ export function isOfPrelaunch(statut: OfStatut): boolean {
 }
 
 // Statuts d'OF sur lesquels un pointage/une exécution d'opération est admissible.
-// Démarrer une opération sur un OF BROUILLON/PLANIFIE le fait basculer EN_COURS
-// (transition automatique serveur, auditée).
-export const OF_STATUTS_ALLOWING_EXECUTION: readonly OfStatut[] = [
-  "BROUILLON",
-  "PLANIFIE",
-  "EN_COURS",
-  "EN_PAUSE",
-];
+// BROUILLON/PLANIFIE require the separate lock-held release decision and may
+// never be promoted by an execution action.
+export const OF_STATUTS_ALLOWING_EXECUTION: readonly OfStatut[] = ["EN_COURS", "EN_PAUSE"];
 
 export function ofStatutAllowsExecution(statut: OfStatut): boolean {
   return OF_STATUTS_ALLOWING_EXECUTION.includes(statut);

--- a/src/module/production/repository/production-execution.repository.ts
+++ b/src/module/production/repository/production-execution.repository.ts
@@ -837,7 +837,7 @@ export async function repoOperatorBoard(params: {
       FROM public.of_operations op
       JOIN public.ordres_fabrication o ON o.id = op.of_id
       LEFT JOIN public.machines m ON m.id = op.machine_id
-      WHERE o.statut IN ('PLANIFIE', 'EN_COURS', 'EN_PAUSE')
+      WHERE o.statut IN ('EN_COURS', 'EN_PAUSE')
         AND op.status <> 'DONE'
         AND $1::int IS NOT NULL
         ${filter}
@@ -943,7 +943,7 @@ async function lockExecutionContext(
 
 /** L'OF doit être dans un état exécutable — on ne pointe pas sur un OF clos. */
 function assertOfExecutable(statut: string) {
-  const executable = ["BROUILLON", "PLANIFIE", "EN_COURS", "EN_PAUSE"];
+  const executable = ["EN_COURS", "EN_PAUSE"];
   if (!executable.includes(statut)) {
     throw new HttpError(
       422,
@@ -1149,20 +1149,8 @@ export async function repoStartExecution(params: {
       note: params.body.retroactive_reason ?? params.body.for_other_reason ?? null,
     });
 
-    // L'OF passe EN_COURS au premier pointage : c'est le seul effet de bord
-    // toléré, il est explicite et audité.
-    if (["BROUILLON", "PLANIFIE", "EN_PAUSE"].includes(of.statut)) {
-      await client.query(
-        `
-          UPDATE public.ordres_fabrication
-          SET statut = 'EN_COURS'::of_status,
-              date_lancement_reelle = COALESCE(date_lancement_reelle, CURRENT_DATE),
-              updated_at = now(), updated_by = $2
-          WHERE id = $1::bigint
-        `,
-        [params.body.of_id, params.audit.user_id]
-      );
-    }
+    // The only transition into execution is POST /ofs/:id/release. Pointage
+    // never promotes a draft/planned OF implicitly.
 
     if (operation && operation.status !== "RUNNING") {
       await client.query(

--- a/src/module/production/repository/production.repository.ts
+++ b/src/module/production/repository/production.repository.ts
@@ -41,6 +41,7 @@ import type {
   UpdateOfOperationBodyDTO,
   UpdatePosteBodyDTO,
   ReorderOfOperationsBodyDTO,
+  ReleaseOfBodyDTO,
 } from "../validators/production.validators";
 import {
   OF_STATUT_TRANSITIONS,
@@ -73,6 +74,217 @@ export type AuditContext = {
   page_key: string | null;
   client_session_id: string | null;
 };
+
+export type OfReadinessBlockerCode =
+  | "MATERIAL_RESERVATION_MISSING"
+  | "CAPACITY_OR_CALENDAR_MISSING"
+  | "PROGRAM_OR_INSTRUCTION_MISSING"
+  | "QUALITY_PLAN_MISSING"
+  | "INSTRUMENT_READINESS_MISSING"
+  | "SUBCONTRACT_READINESS_MISSING"
+  | "TECHNICAL_REFERENCE_MISSING";
+
+const OF_RELEASE_BLOCKERS: readonly OfReadinessBlockerCode[] = [
+  "MATERIAL_RESERVATION_MISSING", "CAPACITY_OR_CALENDAR_MISSING", "PROGRAM_OR_INSTRUCTION_MISSING",
+  "QUALITY_PLAN_MISSING", "INSTRUMENT_READINESS_MISSING", "SUBCONTRACT_READINESS_MISSING", "TECHNICAL_REFERENCE_MISSING",
+];
+
+type OfReadiness = { of_id: number; ready: boolean; blockers: OfReadinessBlockerCode[]; evidence: Record<string, unknown>; released_at: string | null; override: boolean | null };
+
+/**
+ * Builds only evidence the current schema can prove. Missing source models are
+ * blockers, not green defaults: an override records that conscious exception.
+ * Called after the OF row has been locked by the release transaction.
+ */
+async function evaluateOfReadiness(tx: DbQueryer, ofId: number): Promise<OfReadiness | null> {
+  const result = await tx.query<{
+    id: string; technical_snapshot_sha256: string | null; evaluated_at: string; operation_count: number; planned_event_count: number; reservation_count: number;
+    technical_snapshot_present: boolean; instruction_covered_count: number; quality_plan_count: number; open_nc_count: number;
+    material_requirement_count: number; material_requirement_covered_count: number;
+    material_requirement_evidence: Array<{ article_id: string; required_qty: number; reserved_qty: number; covered: boolean }>;
+    quality_plan_evidence: Array<{ control_id: string; plan_id: string | null; plan_version: number | null; snapshot_sha256: string }>;
+    released_at: string | null; override: boolean | null;
+  }>(`
+    SELECT o.id::text AS id, o.technical_snapshot_sha256,
+      jsonb_typeof(o.technical_snapshot) = 'object' AS technical_snapshot_present,
+      statement_timestamp()::text AS evaluated_at,
+      (SELECT count(*)::int FROM public.of_operations op WHERE op.of_id = o.id) AS operation_count,
+      -- A cancelled or archived planning event is historical noise, not
+      -- reservable execution capacity. Keep this aligned with the planning
+      -- module's active-event predicates.
+      (SELECT count(*)::int FROM public.planning_events pe
+        WHERE pe.of_id = o.id
+          AND pe.end_ts > pe.start_ts
+          AND pe.archived_at IS NULL
+          AND pe.status <> 'CANCELLED') AS planned_event_count,
+      (SELECT count(DISTINCT op.id)::int FROM public.of_operations op
+        WHERE op.of_id = o.id AND EXISTS (
+          SELECT 1 FROM public.operation_dossiers d
+          JOIN public.operation_dossier_versions dv ON dv.dossier_id = d.id
+          JOIN public.operation_dossier_version_documents dd ON dd.dossier_version_id = dv.id
+          WHERE d.operation_type = 'OF_OPERATION' AND d.operation_id = op.id::text AND dd.document_id IS NOT NULL)) AS instruction_covered_count,
+      (SELECT count(*)::int FROM public.quality_control qc
+        WHERE qc.of_id = o.id
+          AND qc.plan_snapshot IS NOT NULL
+          AND qc.plan_snapshot_sha256 ~ '^[a-f0-9]{64}$') AS quality_plan_count,
+      COALESCE((SELECT jsonb_agg(jsonb_build_object(
+          'control_id', qc.id::text,
+          'plan_id', qc.plan_id::text,
+          'plan_version', qc.plan_version,
+          'snapshot_sha256', qc.plan_snapshot_sha256
+        ) ORDER BY qc.id)
+        FROM public.quality_control qc
+        WHERE qc.of_id = o.id
+          AND qc.plan_snapshot IS NOT NULL
+          AND qc.plan_snapshot_sha256 ~ '^[a-f0-9]{64}$'), '[]'::jsonb) AS quality_plan_evidence,
+      (SELECT count(*)::int FROM public.non_conformity nc WHERE nc.of_id = o.id AND nc.status::text NOT IN ('CLOSED','CANCELLED')) AS open_nc_count,
+      material.material_requirement_count,
+      material.material_requirement_covered_count,
+      material.material_requirement_evidence,
+      (SELECT count(*)::int FROM public.stock_reservations sr
+        WHERE sr.of_id = o.id AND sr.status = 'ACTIVE'
+          AND (sr.expires_at IS NULL OR sr.expires_at > statement_timestamp())) AS reservation_count,
+      (SELECT r.decided_at::text FROM public.of_release_decisions r WHERE r.of_id = o.id AND r.decision = 'RELEASED') AS released_at,
+      (SELECT r.override FROM public.of_release_decisions r WHERE r.of_id = o.id AND r.decision = 'RELEASED') AS override
+    FROM public.ordres_fabrication o
+    CROSS JOIN LATERAL (
+      SELECT
+        count(*)::int AS material_requirement_count,
+        count(*) FILTER (WHERE requirement.reserved_qty + 0.000000001 >= requirement.required_qty)::int AS material_requirement_covered_count,
+        COALESCE(jsonb_agg(jsonb_build_object(
+          'article_id', requirement.article_id::text,
+          'required_qty', requirement.required_qty,
+          'reserved_qty', requirement.reserved_qty,
+          'covered', requirement.reserved_qty + 0.000000001 >= requirement.required_qty
+        ) ORDER BY requirement.article_id), '[]'::jsonb) AS material_requirement_evidence
+      FROM (
+        SELECT source.article_id,
+          sum(source.qty_per_piece * o.quantite_lancee)::numeric AS required_qty,
+          COALESCE((
+            SELECT sum(sr.qty_reserved)
+            FROM public.stock_reservations sr
+            WHERE sr.of_id = o.id
+              AND sr.article_id = source.article_id
+              AND sr.status = 'ACTIVE'
+              AND (sr.expires_at IS NULL OR sr.expires_at > statement_timestamp())
+          ), 0)::numeric AS reserved_qty
+        FROM (
+          SELECT nomenclature.child_article_id::uuid AS article_id, nomenclature.quantite AS qty_per_piece
+          FROM jsonb_to_recordset(
+            CASE WHEN jsonb_typeof(o.technical_snapshot->'nomenclature') = 'array'
+              THEN o.technical_snapshot->'nomenclature' ELSE '[]'::jsonb END
+          ) AS nomenclature(child_article_id text, quantite numeric)
+          WHERE nomenclature.child_article_id ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+            AND nomenclature.quantite > 0
+          UNION ALL
+          SELECT achat.article_id::uuid AS article_id, achat.quantite AS qty_per_piece
+          FROM jsonb_to_recordset(
+            CASE WHEN jsonb_typeof(o.technical_snapshot->'achats') = 'array'
+              THEN o.technical_snapshot->'achats' ELSE '[]'::jsonb END
+          ) AS achat(article_id text, quantite numeric)
+          WHERE achat.article_id ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+            AND achat.quantite > 0
+        ) source
+        GROUP BY source.article_id
+      ) requirement
+    ) material
+    WHERE o.id = $1::bigint`, [ofId]);
+  const row = result.rows[0];
+  if (!row) return null;
+  const blockers: OfReadinessBlockerCode[] = [];
+  if (!row.technical_snapshot_sha256 || !row.technical_snapshot_present || row.operation_count < 1) blockers.push("TECHNICAL_REFERENCE_MISSING");
+  // Requirements come from the OF's immutable technical snapshot. Coverage is
+  // proven per article and quantity; an unrelated or undersized reservation can
+  // never release the material gate.
+  if (row.material_requirement_covered_count < row.material_requirement_count) blockers.push("MATERIAL_RESERVATION_MISSING");
+  if (row.planned_event_count < 1) blockers.push("CAPACITY_OR_CALENDAR_MISSING");
+  if (row.instruction_covered_count < row.operation_count) blockers.push("PROGRAM_OR_INSTRUCTION_MISSING");
+  if (row.quality_plan_count < 1 || row.open_nc_count > 0) blockers.push("QUALITY_PLAN_MISSING");
+  return { of_id: Number(row.id), ready: blockers.length === 0, blockers, evidence: {
+    evidence_version: 2,
+    evaluated_at: row.evaluated_at,
+    technical_snapshot_sha256: row.technical_snapshot_sha256,
+    technical_snapshot_present: row.technical_snapshot_present,
+    operation_count: row.operation_count,
+    planned_event_count: row.planned_event_count, instruction_covered_count: row.instruction_covered_count,
+    quality_plan_count: row.quality_plan_count,
+    quality_plan_evidence: Array.isArray(row.quality_plan_evidence) ? row.quality_plan_evidence : [],
+    open_nc_count: row.open_nc_count,
+    material_requirement_count: row.material_requirement_count,
+    material_requirement_covered_count: row.material_requirement_covered_count,
+    material_requirement_evidence: Array.isArray(row.material_requirement_evidence) ? row.material_requirement_evidence : [],
+    reservation_count: row.reservation_count,
+    // These dimensions are evaluated only when the OF's quality/procurement
+    // sources declare them applicable; this schema does not infer an obligation
+    // merely from their absence.
+    instrument_readiness: "NOT_APPLICABLE_OR_NOT_DECLARED",
+    subcontract_readiness: "NOT_APPLICABLE_OR_NOT_DECLARED",
+  }, released_at: row.released_at, override: row.override };
+}
+
+export async function repoGetOfReadiness(params: { id: number }): Promise<OfReadiness | null> {
+  return evaluateOfReadiness(pool, params.id);
+}
+
+export async function repoReleaseOrdreFabrication(params: { id: number; body: ReleaseOfBodyDTO; audit: AuditContext }): Promise<OfReadiness> {
+  const client = await pool.connect();
+  let committedDecisionAt: string | null = null;
+  try {
+    await client.query("BEGIN");
+    const locked = await client.query<{ statut: string; updated_at: string | null }>(
+      `SELECT statut::text AS statut, to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"') AS updated_at FROM public.ordres_fabrication WHERE id = $1::bigint FOR UPDATE`, [params.id]);
+    const of = locked.rows[0];
+    if (!of) throw new HttpError(404, "OF_NOT_FOUND", "Ordre de fabrication introuvable.");
+    if (!["BROUILLON", "PLANIFIE"].includes(of.statut)) throw new HttpError(409, "OF_RELEASE_INVALID_STATE", "Seul un OF non démarré peut être libéré.", { statut: of.statut });
+    if (params.body.expected_updated_at && of.updated_at !== params.body.expected_updated_at) throw new HttpError(409, "CONCURRENT_MODIFICATION", "L'OF a été modifié par une autre session. Rechargez la fiche avant de libérer.");
+    // Freeze every reservation row used as release evidence until the decision
+    // and OF transition commit. Concurrent release/consumption must wait.
+    await client.query(
+      `SELECT id FROM public.stock_reservations
+       WHERE of_id = $1::bigint AND status = 'ACTIVE'
+         AND (expires_at IS NULL OR expires_at > statement_timestamp())
+       ORDER BY id
+       FOR SHARE`,
+      [params.id]
+    );
+    const readiness = await evaluateOfReadiness(client, params.id);
+    if (!readiness) throw new HttpError(404, "OF_NOT_FOUND", "Ordre de fabrication introuvable.");
+    const requested = new Set(params.body.override_blocker_codes ?? []);
+    const actual = new Set(readiness.blockers);
+    if (!params.body.override && !readiness.ready) throw new HttpError(409, "OF_NOT_READY_FOR_RELEASE", "L'OF ne peut pas être libéré : des prérequis vérifiables manquent.", { blockers: readiness.blockers, evidence: readiness.evidence });
+    if (params.body.override) {
+      if (!roleHasOfCapability(params.audit.user_role, "archive")) throw new HttpError(403, "OF_RELEASE_OVERRIDE_FORBIDDEN", "Une dérogation de libération exige Direction ou Administration.");
+      if (requested.size !== actual.size || [...requested].some((code) => !actual.has(code as OfReadinessBlockerCode))) throw new HttpError(422, "OF_RELEASE_OVERRIDE_BLOCKERS_MISMATCH", "La dérogation doit sélectionner exactement les bloqueurs actuellement constatés.", { blockers: readiness.blockers });
+    }
+    const decision = await client.query<{ decided_at: string }>(`INSERT INTO public.of_release_decisions (of_id, decision, override, blocker_codes, override_reason, evidence, decided_by)
+      VALUES ($1::bigint, 'RELEASED', $2::boolean, $3::text[], $4::text, $5::jsonb, $6::int)
+      RETURNING decided_at::text AS decided_at`,
+      [params.id, params.body.override, readiness.blockers, params.body.override_reason ?? null, JSON.stringify(readiness.evidence), params.audit.user_id]);
+    committedDecisionAt = decision.rows[0]?.decided_at ?? null;
+    await client.query(
+      `UPDATE public.ordres_fabrication
+         SET statut = 'EN_COURS'::public.of_status,
+             date_lancement_reelle = COALESCE(date_lancement_reelle, CURRENT_DATE),
+             updated_at = now(), updated_by = $2::int
+       WHERE id = $1::bigint`,
+      [params.id, params.audit.user_id]
+    );
+    // Freeze source references as a recorded evidence snapshot. The OF's own
+    // technical hash is already immutable after launch; this captures the exact
+    // release decision without mutating the original technical entities.
+    await insertAuditLog(client, params.audit, { action: "production.of.release", entity_type: "ordres_fabrication", entity_id: String(params.id), details: { override: params.body.override, blockers: readiness.blockers, evidence: readiness.evidence } });
+    await client.query("COMMIT");
+    // `ready` remains the objective evidence verdict. A controlled override is
+    // released, but must never masquerade as a technically ready OF.
+    return { ...readiness, released_at: committedDecisionAt, override: params.body.override };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    if (isPgUniqueViolation(error) && pgConstraint(error) === "of_release_decisions_one_per_of_uk") {
+      throw new HttpError(409, "OF_RELEASE_ALREADY_RECORDED", "Une décision de libération existe déjà pour cet OF. Rechargez la fiche.");
+    }
+    throw error;
+  } finally { client.release(); }
+}
 
 type DbQueryer = Pick<PoolClient, "query">;
 
@@ -3788,9 +4000,9 @@ export async function repoStartOfOperationTimeLog(params: {
   const client = await pool.connect();
   try {
     const updated = await withRealtimeOutboxTransaction(client, async (client) => {
-    // #170 : le pointage verrouille aussi l'OF — la règle d'admissibilité se
-    // joue sur son statut, et le démarrage fait basculer un OF encore
-    // BROUILLON/PLANIFIE en EN_COURS (transition serveur auditée).
+    // The OF is locked before a time log is opened. Since #617 only the
+    // explicit release command may enter execution; this path never promotes
+    // BROUILLON/PLANIFIE.
     const ofRes = await client.query<{ id: string; statut: string }>(
       `
         SELECT id::text AS id, statut::text AS statut
@@ -3877,13 +4089,14 @@ export async function repoStartOfOperationTimeLog(params: {
       [params.of_id, params.op_id]
     );
 
-    const autoStarted = ofStatut === "BROUILLON" || ofStatut === "PLANIFIE" || ofStatut === "EN_PAUSE";
+    // Re-opening a paused OF is an allowed execution transition. A draft or
+    // planned OF was rejected above and is never silently launched here.
+    const autoResumed = ofStatut === "EN_PAUSE";
     await client.query(
       `
         UPDATE ordres_fabrication
         SET
-          statut = CASE WHEN statut IN ('BROUILLON','PLANIFIE','EN_PAUSE') THEN 'EN_COURS'::of_status ELSE statut END,
-          date_lancement_reelle = CASE WHEN statut IN ('BROUILLON','PLANIFIE') THEN COALESCE(date_lancement_reelle, CURRENT_DATE) ELSE date_lancement_reelle END,
+          statut = CASE WHEN statut = 'EN_PAUSE' THEN 'EN_COURS'::of_status ELSE statut END,
           updated_at = now(),
           updated_by = $2
         WHERE id = $1::bigint
@@ -3901,7 +4114,7 @@ export async function repoStartOfOperationTimeLog(params: {
         machine_id: machineId,
         type: params.body.type,
         of_statut_before: ofStatut,
-        of_auto_started: autoStarted,
+        of_auto_resumed: autoResumed,
       },
     });
 

--- a/src/module/production/routes/production.routes.ts
+++ b/src/module/production/routes/production.routes.ts
@@ -37,6 +37,8 @@ import {
   startOfOperationTimeLog,
   stopOfOperationTimeLog,
   updateOrdreFabrication,
+  getOfReadiness,
+  releaseOrdreFabrication,
   updateOrdreFabricationOperation,
   updateMachine,
   updateMachineOnboarding,
@@ -223,6 +225,8 @@ router.get("/ofs/:id/creation-snapshot/:documentId/preview", previewOfCreationSn
 router.get("/ofs/:id/creation-snapshot/:documentId/download", downloadOfCreationSnapshot);
 router.post("/ofs/:id/creation-snapshot/:documentId/print-intents", printOfCreationSnapshot);
 router.get("/ofs/:id", getOrdreFabrication);
+router.get("/ofs/:id/readiness", requireOfCapability("read"), getOfReadiness);
+router.post("/ofs/:id/release", requireOfCapability("release"), releaseOrdreFabrication);
 router.post("/ofs", requireOfCapability("create"), createOrdreFabrication);
 router.patch("/ofs/:id", requireAnyOfCapability(["edit_prelaunch", "launch", "operate", "cancel", "archive"]), updateOrdreFabrication);
 router.patch("/ofs/:id/operations/reorder", requireOfCapability("edit_prelaunch"), reorderOfOperations);

--- a/src/module/production/services/production.service.ts
+++ b/src/module/production/services/production.service.ts
@@ -10,6 +10,7 @@ import type {
   OfReceiptBodyDTO,
   PreviewOfGenerationBodyDTO,
   ReorderOfOperationsBodyDTO,
+  ReleaseOfBodyDTO,
   StartOfTimeLogBodyDTO,
   UpdateMachineBodyDTO,
   UpdateMachineOnboardingBodyDTO,
@@ -81,6 +82,10 @@ export const svcCreateOrdreFabrication = (params: { body: CreateOfBodyDTO; audit
 
 export const svcUpdateOrdreFabrication = (params: { id: number; patch: UpdateOfBodyDTO; audit: repo.AuditContext }) =>
   repo.repoUpdateOrdreFabrication(params);
+
+export const svcGetOfReadiness = (params: { id: number }) => repo.repoGetOfReadiness(params);
+export const svcReleaseOrdreFabrication = (params: { id: number; body: ReleaseOfBodyDTO; audit: repo.AuditContext }) =>
+  repo.repoReleaseOrdreFabrication(params);
 
 export const svcUpdateOrdreFabricationOperation = (params: {
   of_id: number;

--- a/src/module/production/validators/production.validators.ts
+++ b/src/module/production/validators/production.validators.ts
@@ -384,6 +384,30 @@ export const updateOfSchema = z.object({
 
 export type UpdateOfBodyDTO = z.infer<typeof updateOfSchema>["body"];
 
+export const ofReleaseOverrideBlockerSchema = z.enum([
+  "MATERIAL_RESERVATION_MISSING",
+  "CAPACITY_OR_CALENDAR_MISSING",
+  "PROGRAM_OR_INSTRUCTION_MISSING",
+  "QUALITY_PLAN_MISSING",
+  "INSTRUMENT_READINESS_MISSING",
+  "SUBCONTRACT_READINESS_MISSING",
+  "TECHNICAL_REFERENCE_MISSING",
+]);
+
+export const releaseOfSchema = z.object({
+  body: z.object({
+    expected_updated_at: z.string().datetime({ offset: true }).optional(),
+    override: z.boolean().optional().default(false),
+    override_reason: z.string().trim().min(10).max(2000).optional(),
+    override_blocker_codes: z.array(ofReleaseOverrideBlockerSchema).min(1).max(7).optional(),
+  }).strict().superRefine((body, ctx) => {
+    if (body.override && !body.override_reason) ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["override_reason"], message: "An override requires a documented reason." });
+    if (body.override && !body.override_blocker_codes?.length) ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["override_blocker_codes"], message: "An override must name each accepted blocker." });
+    if (!body.override && (body.override_reason || body.override_blocker_codes?.length)) ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["override"], message: "Override details are forbidden unless override is true." });
+  }),
+});
+export type ReleaseOfBodyDTO = z.infer<typeof releaseOfSchema>["body"];
+
 // #170 — réordonnancement des opérations avant lancement (DnD ou clavier).
 export const reorderOfOperationsSchema = z.object({
   body: z

--- a/src/swagger/generated-route-inventory.ts
+++ b/src/swagger/generated-route-inventory.ts
@@ -8,7 +8,7 @@ export type GeneratedRouteContract = {
   rbac: readonly string[];
 };
 
-export const GENERATED_ROUTE_SOURCE_SHA256 = "c165392634f171493289ff7503d126fab4defc6dde10cff72c8130e0bd75fd52";
+export const GENERATED_ROUTE_SOURCE_SHA256 = "f4cba735d762d8cc0024ce406234f23b168296739a5692389ac0ef2a2e106525";
 export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
@@ -11331,7 +11331,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/groups",
-    "source": "src/module/production/routes/production.routes.ts:239",
+    "source": "src/module/production/routes/production.routes.ts:243",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11349,7 +11349,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/groups",
-    "source": "src/module/production/routes/production.routes.ts:240",
+    "source": "src/module/production/routes/production.routes.ts:244",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11367,7 +11367,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/groups/{id}",
-    "source": "src/module/production/routes/production.routes.ts:241",
+    "source": "src/module/production/routes/production.routes.ts:245",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11385,7 +11385,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/groups/{id}",
-    "source": "src/module/production/routes/production.routes.ts:242",
+    "source": "src/module/production/routes/production.routes.ts:246",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11403,7 +11403,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/groups/{id}/link",
-    "source": "src/module/production/routes/production.routes.ts:243",
+    "source": "src/module/production/routes/production.routes.ts:247",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11421,7 +11421,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/groups/{id}/unlink",
-    "source": "src/module/production/routes/production.routes.ts:244",
+    "source": "src/module/production/routes/production.routes.ts:248",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11439,7 +11439,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machine-models",
-    "source": "src/module/production/routes/production.routes.ts:176",
+    "source": "src/module/production/routes/production.routes.ts:178",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11457,7 +11457,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machine-models/{id}",
-    "source": "src/module/production/routes/production.routes.ts:177",
+    "source": "src/module/production/routes/production.routes.ts:179",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11475,7 +11475,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machine-models/{id}/capabilities",
-    "source": "src/module/production/routes/production.routes.ts:178",
+    "source": "src/module/production/routes/production.routes.ts:180",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11493,7 +11493,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machine-models/{id}/documents",
-    "source": "src/module/production/routes/production.routes.ts:179",
+    "source": "src/module/production/routes/production.routes.ts:181",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11511,7 +11511,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines",
-    "source": "src/module/production/routes/production.routes.ts:181",
+    "source": "src/module/production/routes/production.routes.ts:183",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11529,7 +11529,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines",
-    "source": "src/module/production/routes/production.routes.ts:200",
+    "source": "src/module/production/routes/production.routes.ts:202",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11548,7 +11548,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/production/machines/{id}",
-    "source": "src/module/production/routes/production.routes.ts:203",
+    "source": "src/module/production/routes/production.routes.ts:205",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11566,7 +11566,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}",
-    "source": "src/module/production/routes/production.routes.ts:198",
+    "source": "src/module/production/routes/production.routes.ts:200",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11584,7 +11584,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/machines/{id}",
-    "source": "src/module/production/routes/production.routes.ts:202",
+    "source": "src/module/production/routes/production.routes.ts:204",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11603,7 +11603,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/capabilities",
-    "source": "src/module/production/routes/production.routes.ts:192",
+    "source": "src/module/production/routes/production.routes.ts:194",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11621,7 +11621,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/context",
-    "source": "src/module/production/routes/production.routes.ts:182",
+    "source": "src/module/production/routes/production.routes.ts:184",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11639,7 +11639,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/documents",
-    "source": "src/module/production/routes/production.routes.ts:193",
+    "source": "src/module/production/routes/production.routes.ts:195",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11657,7 +11657,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/documents",
-    "source": "src/module/production/routes/production.routes.ts:195",
+    "source": "src/module/production/routes/production.routes.ts:197",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11675,7 +11675,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/production/machines/{id}/documents/{documentId}",
-    "source": "src/module/production/routes/production.routes.ts:197",
+    "source": "src/module/production/routes/production.routes.ts:199",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11693,7 +11693,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/documents/{documentId}/download",
-    "source": "src/module/production/routes/production.routes.ts:196",
+    "source": "src/module/production/routes/production.routes.ts:198",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11711,7 +11711,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/documents/upload",
-    "source": "src/module/production/routes/production.routes.ts:194",
+    "source": "src/module/production/routes/production.routes.ts:196",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11730,7 +11730,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/maintenance/events",
-    "source": "src/module/production/routes/production.routes.ts:189",
+    "source": "src/module/production/routes/production.routes.ts:191",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11748,7 +11748,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/maintenance/events",
-    "source": "src/module/production/routes/production.routes.ts:190",
+    "source": "src/module/production/routes/production.routes.ts:192",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11766,7 +11766,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/maintenance/plans",
-    "source": "src/module/production/routes/production.routes.ts:186",
+    "source": "src/module/production/routes/production.routes.ts:188",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11784,7 +11784,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/maintenance/plans",
-    "source": "src/module/production/routes/production.routes.ts:187",
+    "source": "src/module/production/routes/production.routes.ts:189",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11802,7 +11802,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/machines/{id}/maintenance/plans/{planId}",
-    "source": "src/module/production/routes/production.routes.ts:188",
+    "source": "src/module/production/routes/production.routes.ts:190",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11820,7 +11820,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/machines/{id}/onboarding",
-    "source": "src/module/production/routes/production.routes.ts:201",
+    "source": "src/module/production/routes/production.routes.ts:203",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11839,7 +11839,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/reactivate",
-    "source": "src/module/production/routes/production.routes.ts:191",
+    "source": "src/module/production/routes/production.routes.ts:193",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11857,7 +11857,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/machines/{id}/unavailability",
-    "source": "src/module/production/routes/production.routes.ts:183",
+    "source": "src/module/production/routes/production.routes.ts:185",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11875,7 +11875,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/{id}/unavailability",
-    "source": "src/module/production/routes/production.routes.ts:184",
+    "source": "src/module/production/routes/production.routes.ts:186",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11893,7 +11893,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/production/machines/{id}/unavailability/{unavailabilityId}",
-    "source": "src/module/production/routes/production.routes.ts:185",
+    "source": "src/module/production/routes/production.routes.ts:187",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -11911,7 +11911,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/machines/onboarding",
-    "source": "src/module/production/routes/production.routes.ts:199",
+    "source": "src/module/production/routes/production.routes.ts:201",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12372,7 +12372,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs",
-    "source": "src/module/production/routes/production.routes.ts:214",
+    "source": "src/module/production/routes/production.routes.ts:216",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12388,7 +12388,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs",
-    "source": "src/module/production/routes/production.routes.ts:226",
+    "source": "src/module/production/routes/production.routes.ts:230",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12406,7 +12406,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}",
-    "source": "src/module/production/routes/production.routes.ts:225",
+    "source": "src/module/production/routes/production.routes.ts:227",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12422,7 +12422,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/ofs/{id}",
-    "source": "src/module/production/routes/production.routes.ts:227",
+    "source": "src/module/production/routes/production.routes.ts:231",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12440,7 +12440,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}/creation-snapshot",
-    "source": "src/module/production/routes/production.routes.ts:221",
+    "source": "src/module/production/routes/production.routes.ts:223",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12456,7 +12456,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}/creation-snapshot/{documentId}/download",
-    "source": "src/module/production/routes/production.routes.ts:223",
+    "source": "src/module/production/routes/production.routes.ts:225",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12472,7 +12472,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}/creation-snapshot/{documentId}/preview",
-    "source": "src/module/production/routes/production.routes.ts:222",
+    "source": "src/module/production/routes/production.routes.ts:224",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12488,7 +12488,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs/{id}/creation-snapshot/{documentId}/print-intents",
-    "source": "src/module/production/routes/production.routes.ts:224",
+    "source": "src/module/production/routes/production.routes.ts:226",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12504,7 +12504,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/ofs/{id}/operations/{opId}",
-    "source": "src/module/production/routes/production.routes.ts:229",
+    "source": "src/module/production/routes/production.routes.ts:233",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12522,7 +12522,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs/{id}/operations/{opId}/time-logs/start",
-    "source": "src/module/production/routes/production.routes.ts:230",
+    "source": "src/module/production/routes/production.routes.ts:234",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12540,7 +12540,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs/{id}/operations/{opId}/time-logs/stop",
-    "source": "src/module/production/routes/production.routes.ts:231",
+    "source": "src/module/production/routes/production.routes.ts:235",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12558,7 +12558,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/ofs/{id}/operations/reorder",
-    "source": "src/module/production/routes/production.routes.ts:228",
+    "source": "src/module/production/routes/production.routes.ts:232",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12574,9 +12574,27 @@ export const GENERATED_ROUTE_INVENTORY = [
     ]
   },
   {
+    "method": "get",
+    "path": "/production/ofs/{id}/readiness",
+    "source": "src/module/production/routes/production.routes.ts:228",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireOfCapability(read)",
+      "getOfReadiness"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireOfCapability(read)"
+    ]
+  },
+  {
     "method": "post",
     "path": "/production/ofs/{id}/receipt",
-    "source": "src/module/production/routes/production.routes.ts:235",
+    "source": "src/module/production/routes/production.routes.ts:239",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12594,7 +12612,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}/receipt-context",
-    "source": "src/module/production/routes/production.routes.ts:234",
+    "source": "src/module/production/routes/production.routes.ts:238",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12610,9 +12628,27 @@ export const GENERATED_ROUTE_INVENTORY = [
     ]
   },
   {
+    "method": "post",
+    "path": "/production/ofs/{id}/release",
+    "source": "src/module/production/routes/production.routes.ts:229",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "authenticateToken",
+      "requireOfCapability(release)",
+      "releaseOrdreFabrication"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireOfCapability(release)"
+    ]
+  },
+  {
     "method": "get",
     "path": "/production/ofs/{id}/technical-snapshot",
-    "source": "src/module/production/routes/production.routes.ts:218",
+    "source": "src/module/production/routes/production.routes.ts:220",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12628,7 +12664,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}/traceability",
-    "source": "src/module/production/routes/production.routes.ts:236",
+    "source": "src/module/production/routes/production.routes.ts:240",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12646,7 +12682,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/ofs/{id}/tree",
-    "source": "src/module/production/routes/production.routes.ts:217",
+    "source": "src/module/production/routes/production.routes.ts:219",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12662,7 +12698,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs/generate",
-    "source": "src/module/production/routes/production.routes.ts:216",
+    "source": "src/module/production/routes/production.routes.ts:218",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12680,7 +12716,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/ofs/generate/preview",
-    "source": "src/module/production/routes/production.routes.ts:215",
+    "source": "src/module/production/routes/production.routes.ts:217",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12698,7 +12734,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/operators",
-    "source": "src/module/production/routes/production.routes.ts:247",
+    "source": "src/module/production/routes/production.routes.ts:251",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12716,7 +12752,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/pointages",
-    "source": "src/module/production/routes/production.routes.ts:248",
+    "source": "src/module/production/routes/production.routes.ts:252",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12734,7 +12770,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/pointages",
-    "source": "src/module/production/routes/production.routes.ts:251",
+    "source": "src/module/production/routes/production.routes.ts:255",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12752,7 +12788,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/pointages/{id}",
-    "source": "src/module/production/routes/production.routes.ts:250",
+    "source": "src/module/production/routes/production.routes.ts:254",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12770,7 +12806,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/pointages/{id}",
-    "source": "src/module/production/routes/production.routes.ts:254",
+    "source": "src/module/production/routes/production.routes.ts:258",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12788,7 +12824,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/pointages/{id}/start",
-    "source": "src/module/production/routes/production.routes.ts:252",
+    "source": "src/module/production/routes/production.routes.ts:256",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12806,7 +12842,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/pointages/{id}/stop",
-    "source": "src/module/production/routes/production.routes.ts:253",
+    "source": "src/module/production/routes/production.routes.ts:257",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12824,7 +12860,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/pointages/{id}/validate",
-    "source": "src/module/production/routes/production.routes.ts:255",
+    "source": "src/module/production/routes/production.routes.ts:259",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12842,7 +12878,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/pointages/kpis",
-    "source": "src/module/production/routes/production.routes.ts:249",
+    "source": "src/module/production/routes/production.routes.ts:253",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12860,7 +12896,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/postes",
-    "source": "src/module/production/routes/production.routes.ts:206",
+    "source": "src/module/production/routes/production.routes.ts:208",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12876,7 +12912,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/production/postes",
-    "source": "src/module/production/routes/production.routes.ts:208",
+    "source": "src/module/production/routes/production.routes.ts:210",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12892,7 +12928,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/production/postes/{id}",
-    "source": "src/module/production/routes/production.routes.ts:210",
+    "source": "src/module/production/routes/production.routes.ts:212",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12910,7 +12946,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/production/postes/{id}",
-    "source": "src/module/production/routes/production.routes.ts:207",
+    "source": "src/module/production/routes/production.routes.ts:209",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -12926,7 +12962,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/production/postes/{id}",
-    "source": "src/module/production/routes/production.routes.ts:209",
+    "source": "src/module/production/routes/production.routes.ts:211",
     "middleware": [
       "anonymous",
       "authenticateToken",


### PR DESCRIPTION
Closes #617

## Outcome
- replaces generic planned-to-running edits with an explicit server-owned release command
- evaluates technical snapshot, operations, active capacity events, instructions, frozen Quality-plan snapshots, NCs, BOM/reservation evidence
- requires exact, reasoned Director/Admin override of live blockers
- records one immutable release decision per OF and database-blocks direct prelaunch-to-execution SQL without it
- restricts execution/time logging to released/running states

## Proof
- 50 focused tests, including 5 real PostgreSQL migration/race/immutability cases
- typecheck and production build (1131 OpenAPI operations)
- isolated migration apply, verify, replay, rollback and restore rehearsal passed

## Summary by Sourcery

Introduce an explicit, auditable OF release gate that validates readiness before allowing manufacturing execution to begin.

New Features:
- Add explicit OF readiness evaluation and a role-protected release workflow with readiness and release endpoints.
- Capture technical, scheduling, instruction, quality, non-conformity, and material-reservation evidence for each release decision.

Bug Fixes:
- Prevent draft or planned OFs from entering execution implicitly through generic status updates or time logging.
- Restrict operator execution views and activity to released or running OFs.

Enhancements:
- Require exact, reasoned Director/Admin overrides for active readiness blockers and serialize concurrent release attempts.
- Enforce one immutable release decision per OF at the database boundary and block direct prelaunch-to-execution transitions without one.

Deployment:
- Add an idempotent PostgreSQL migration with preflight, verification, protected test-only rollback, append-only audit enforcement, and execution safeguards.

Documentation:
- Update the OpenAPI route inventory and migration rehearsal records for the new release workflow.

Tests:
- Add focused unit, route, migration-safety, and PostgreSQL concurrency tests covering readiness evidence, overrides, immutability, and execution gating.