### PR TITLE
feat: archive exact issued finance PDFs in GED

### DIFF
--- a/db/patches/20260823_finance_ged_archive_625.sql
+++ b/db/patches/20260823_finance_ged_archive_625.sql
@@ -1,0 +1,76 @@
+-- #625 — Byte-exact legal facture/avoir filing through the #612 archive outbox.
+-- The bytes are retained only until the GED archive worker has filed them; the
+-- immutable registry is the durable retry source when GED storage is degraded.
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.authoritative_pdf_archives') IS NULL
+     OR to_regclass('public.authoritative_pdf_archive_outbox') IS NULL
+     OR to_regprocedure('public.fn_authoritative_pdf_archive_immutable_612()') IS NULL THEN
+    RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_612_PREREQUISITE_MISSING';
+  END IF;
+  -- PostgreSQL's bytea digest is the database-side integrity backstop for the
+  -- exact legal source.  Do not rely only on a Node worker to notice tampering.
+  IF to_regprocedure('public.digest(bytea,text)') IS NULL THEN
+    RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_DIGEST_PREREQUISITE_MISSING';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='authoritative_pdf_archives'
+       AND column_name IN ('exact_pdf_bytes','exact_pdf_sha256','exact_pdf_size_bytes')
+  ) THEN
+    RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_TARGET_ALREADY_EXISTS';
+  END IF;
+END $$;
+
+ALTER TABLE public.authoritative_pdf_archives
+  ADD COLUMN exact_pdf_bytes bytea NULL,
+  ADD COLUMN exact_pdf_sha256 text NULL,
+  ADD COLUMN exact_pdf_size_bytes bigint NULL;
+
+ALTER TABLE public.authoritative_pdf_archives
+  ADD CONSTRAINT authoritative_pdf_archive_exact_pdf_sha_ck
+    CHECK (exact_pdf_sha256 IS NULL OR exact_pdf_sha256 ~ '^[a-f0-9]{64}$'),
+  ADD CONSTRAINT authoritative_pdf_archive_exact_pdf_size_ck
+    CHECK (exact_pdf_size_bytes IS NULL OR (exact_pdf_size_bytes > 0 AND exact_pdf_size_bytes <= 52428800)),
+  ADD CONSTRAINT authoritative_pdf_archive_exact_pdf_digest_ck
+    CHECK (exact_pdf_bytes IS NULL OR exact_pdf_sha256 = encode(digest(exact_pdf_bytes, 'sha256'), 'hex')),
+  ADD CONSTRAINT authoritative_pdf_archive_exact_pdf_pair_ck
+    CHECK (
+      (exact_pdf_bytes IS NULL AND exact_pdf_sha256 IS NULL AND exact_pdf_size_bytes IS NULL)
+      OR
+      (exact_pdf_bytes IS NOT NULL AND exact_pdf_sha256 IS NOT NULL AND exact_pdf_size_bytes = octet_length(exact_pdf_bytes))
+    );
+
+-- Extend #612's immutable-source contract. It is intentionally not a trigger
+-- replacement: existing archives retain the original guards, while legal bytes
+-- cannot be swapped before or after filing.
+CREATE OR REPLACE FUNCTION public.fn_authoritative_pdf_archive_immutable_612()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.entity_type IS DISTINCT FROM OLD.entity_type OR NEW.entity_id IS DISTINCT FROM OLD.entity_id
+     OR NEW.document_kind IS DISTINCT FROM OLD.document_kind OR NEW.document_version IS DISTINCT FROM OLD.document_version
+     OR NEW.render_version IS DISTINCT FROM OLD.render_version OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+     OR NEW.title IS DISTINCT FROM OLD.title OR NEW.original_name IS DISTINCT FROM OLD.original_name
+     OR NEW.source_snapshot IS DISTINCT FROM OLD.source_snapshot OR NEW.source_revision IS DISTINCT FROM OLD.source_revision
+     OR NEW.snapshot_sha256 IS DISTINCT FROM OLD.snapshot_sha256 OR NEW.exact_pdf_bytes IS DISTINCT FROM OLD.exact_pdf_bytes
+     OR NEW.exact_pdf_sha256 IS DISTINCT FROM OLD.exact_pdf_sha256 OR NEW.exact_pdf_size_bytes IS DISTINCT FROM OLD.exact_pdf_size_bytes
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at OR NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_ARCHIVE_IMMUTABLE: archive source identity cannot change (id=%)', OLD.id USING ERRCODE = 'check_violation';
+  END IF;
+  IF OLD.archived_at IS NOT NULL AND (
+       NEW.pdf_sha256 IS DISTINCT FROM OLD.pdf_sha256 OR NEW.pdf_size_bytes IS DISTINCT FROM OLD.pdf_size_bytes
+       OR NEW.ged_document_id IS DISTINCT FROM OLD.ged_document_id OR NEW.ged_version_id IS DISTINCT FROM OLD.ged_version_id
+       OR NEW.archived_at IS DISTINCT FROM OLD.archived_at) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_ARCHIVE_IMMUTABLE: archived bytes cannot change (id=%)', OLD.id USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END $$;
+
+COMMENT ON COLUMN public.authoritative_pdf_archives.exact_pdf_bytes IS
+  'Durable byte-exact source for legally issued finance PDFs; GED retry must never re-render it.';
+
+COMMIT;

--- a/db/patches/support/20260823_finance_ged_archive_625.preflight.sql
+++ b/db/patches/support/20260823_finance_ged_archive_625.preflight.sql
@@ -1,0 +1,27 @@
+-- #625 preflight — read-only, fail closed and safe to run before deployment.
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+BEGIN
+  IF to_regclass('public.authoritative_pdf_archives') IS NULL
+     OR to_regclass('public.authoritative_pdf_archive_outbox') IS NULL
+     OR to_regprocedure('public.fn_authoritative_pdf_archive_immutable_612()') IS NULL THEN
+    RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_PREFLIGHT_612_PREREQUISITE_MISSING';
+  END IF;
+  IF to_regprocedure('public.digest(bytea,text)') IS NULL THEN
+    RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_PREFLIGHT_DIGEST_PREREQUISITE_MISSING';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='authoritative_pdf_archives'
+       AND column_name IN ('exact_pdf_bytes','exact_pdf_sha256','exact_pdf_size_bytes')
+  ) THEN
+    RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_PREFLIGHT_TARGET_ALREADY_EXISTS';
+  END IF;
+END $$;
+
+SELECT
+  to_regclass('public.authoritative_pdf_archives') IS NOT NULL AS archive_registry_present,
+  to_regprocedure('public.digest(bytea,text)') IS NOT NULL AS bytea_digest_present;
+
+COMMIT;

--- a/db/patches/support/20260823_finance_ged_archive_625.rollback.sql
+++ b/db/patches/support/20260823_finance_ged_archive_625.rollback.sql
@@ -1,0 +1,66 @@
+-- #625 rollback — test-rehearsal only and refused once a legal source exists.
+\set ON_ERROR_STOP on
+DO $guard$
+BEGIN
+  IF current_database() <> 'cerp_test' OR current_setting('cerp.migration_rehearsal', true) IS DISTINCT FROM 'on' THEN
+    RAISE EXCEPTION '#625 rollback is test-only: cerp_test and cerp.migration_rehearsal=on required';
+  END IF;
+END $guard$;
+
+BEGIN;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.authoritative_pdf_archives
+     WHERE exact_pdf_bytes IS NOT NULL OR exact_pdf_sha256 IS NOT NULL OR exact_pdf_size_bytes IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION '#625 rollback refused: issued legal finance PDF source exists.';
+  END IF;
+END $$;
+
+ALTER TABLE public.authoritative_pdf_archives
+  DROP CONSTRAINT IF EXISTS authoritative_pdf_archive_exact_pdf_pair_ck,
+  DROP CONSTRAINT IF EXISTS authoritative_pdf_archive_exact_pdf_digest_ck,
+  DROP CONSTRAINT IF EXISTS authoritative_pdf_archive_exact_pdf_size_ck,
+  DROP CONSTRAINT IF EXISTS authoritative_pdf_archive_exact_pdf_sha_ck,
+  DROP COLUMN IF EXISTS exact_pdf_size_bytes,
+  DROP COLUMN IF EXISTS exact_pdf_sha256,
+  DROP COLUMN IF EXISTS exact_pdf_bytes;
+
+-- Restore #612's trigger body too.  The function body is PL/pgSQL (so its
+-- record-field references are not a catalog dependency) and would otherwise
+-- fail at the next archive UPDATE after the columns above disappear.
+CREATE OR REPLACE FUNCTION public.fn_authoritative_pdf_archive_immutable_612()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.entity_type IS DISTINCT FROM OLD.entity_type
+     OR NEW.entity_id IS DISTINCT FROM OLD.entity_id
+     OR NEW.document_kind IS DISTINCT FROM OLD.document_kind
+     OR NEW.document_version IS DISTINCT FROM OLD.document_version
+     OR NEW.render_version IS DISTINCT FROM OLD.render_version
+     OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+     OR NEW.title IS DISTINCT FROM OLD.title
+     OR NEW.original_name IS DISTINCT FROM OLD.original_name
+     OR NEW.source_snapshot IS DISTINCT FROM OLD.source_snapshot
+     OR NEW.source_revision IS DISTINCT FROM OLD.source_revision
+     OR NEW.snapshot_sha256 IS DISTINCT FROM OLD.snapshot_sha256
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at
+     OR NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_ARCHIVE_IMMUTABLE: archive source identity cannot change (id=%)', OLD.id
+      USING ERRCODE = 'check_violation';
+  END IF;
+  IF OLD.archived_at IS NOT NULL AND (
+       NEW.pdf_sha256 IS DISTINCT FROM OLD.pdf_sha256
+       OR NEW.pdf_size_bytes IS DISTINCT FROM OLD.pdf_size_bytes
+       OR NEW.ged_document_id IS DISTINCT FROM OLD.ged_document_id
+       OR NEW.ged_version_id IS DISTINCT FROM OLD.ged_version_id
+       OR NEW.archived_at IS DISTINCT FROM OLD.archived_at) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_ARCHIVE_IMMUTABLE: archived bytes cannot change (id=%)', OLD.id
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+COMMIT;

--- a/db/patches/support/20260823_finance_ged_archive_625.verify.sql
+++ b/db/patches/support/20260823_finance_ged_archive_625.verify.sql
@@ -1,0 +1,17 @@
+-- #625 verification: exact legal bytes must be retained immutably for GED retry.
+DO $$
+DECLARE n integer;
+BEGIN
+  IF to_regclass('public.authoritative_pdf_archives') IS NULL THEN RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_VERIFY_ARCHIVE_MISSING'; END IF;
+  SELECT count(*) INTO n FROM information_schema.columns
+   WHERE table_schema='public' AND table_name='authoritative_pdf_archives'
+     AND column_name IN ('exact_pdf_bytes','exact_pdf_sha256','exact_pdf_size_bytes');
+  IF n <> 3 THEN RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_VERIFY_EXACT_COLUMNS_MISSING'; END IF;
+  IF to_regprocedure('public.fn_authoritative_pdf_archive_immutable_612()') IS NULL THEN RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_VERIFY_IMMUTABILITY_MISSING'; END IF;
+  IF to_regprocedure('public.digest(bytea,text)') IS NULL THEN RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_VERIFY_DIGEST_MISSING'; END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.authoritative_pdf_archives'::regclass
+       AND conname = 'authoritative_pdf_archive_exact_pdf_digest_ck'
+  ) THEN RAISE EXCEPTION 'FINANCE_GED_ARCHIVE_VERIFY_DIGEST_CONSTRAINT_MISSING'; END IF;
+END $$;

--- a/docs/http/openapi-route-coverage.json
+++ b/docs/http/openapi-route-coverage.json
@@ -1,9 +1,9 @@
 {
   "scope": "/api/v1",
-  "source_sha256": "5c072234e4bb5227345223ffdbea9dfa4121f2b87792d4c8e0805175563a46a3",
-  "discovered_operations": 1139,
-  "documented_operations": 1139,
+  "source_sha256": "899f968a2950bc15d761f78477b9d1ebf48f060e54c138270434827ca6295ebe",
+  "discovered_operations": 1149,
+  "documented_operations": 1149,
   "coverage_percent": 100,
-  "authenticated_operations": 1119,
+  "authenticated_operations": 1129,
   "public_operations": 20
 }

--- a/docs/release/MIGRATION_INVENTORY_SOL_06.json
+++ b/docs/release/MIGRATION_INVENTORY_SOL_06.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-08-23T12:35:34.241Z",
+  "generated_at": "2026-08-23T15:16:56.629Z",
   "source": "filesystem scan of db/patches and db/patches/support",
-  "patch_count": 171,
-  "support_file_count": 305,
-  "recent_patch_count": 113,
+  "patch_count": 172,
+  "support_file_count": 308,
+  "recent_patch_count": 114,
   "recent_support_gaps": [
     {
       "filename": "20260706_affaire_allow_projet.sql",
@@ -210,7 +210,7 @@
     "destructive_ddl": 2,
     "destructive_dml": 9,
     "data_rewrite": 104,
-    "table_lock": 130,
+    "table_lock": 131,
     "blocking_index": 127,
     "enum_change": 1
   },
@@ -3114,8 +3114,8 @@
     {
       "order": 170,
       "filename": "20260823_authoritative_pdf_archive_612.sql",
-      "sha256": "776abd77520868b535de280d14ff61c71177b8cf131192f8b76ff836fec254d1",
-      "bytes": 10756,
+      "sha256": "3517bc1fefee179c00209237018446964153b4314233cdebbaa57bb5cdf7c70b",
+      "bytes": 10942,
       "transaction_wrapped": true,
       "replay_markers": true,
       "support": {
@@ -3130,6 +3130,22 @@
     },
     {
       "order": 171,
+      "filename": "20260823_finance_ged_archive_625.sql",
+      "sha256": "486ded479fa78d3020f53f3cb9920abc492e1ccd13f9f0e60ebdef0ee0fa9d39",
+      "bytes": 4318,
+      "transaction_wrapped": true,
+      "replay_markers": true,
+      "support": {
+        "preflight": true,
+        "verify": true,
+        "rollback": true
+      },
+      "risks": [
+        "table-lock"
+      ]
+    },
+    {
+      "order": 172,
       "filename": "20260823_operational_media_access_611.sql",
       "sha256": "cad0368b00c3bff67a9390a0e1e9669bca37d0fa8bd4f89b4854aef5a1505415",
       "bytes": 11961,

--- a/docs/release/MIGRATION_INVENTORY_SOL_06.md
+++ b/docs/release/MIGRATION_INVENTORY_SOL_06.md
@@ -1,10 +1,10 @@
 # Inventaire des migrations — SOL-06
 
-- Généré : 2026-08-23T12:35:34.241Z
+- Généré : 2026-08-23T15:16:56.629Z
 - Source : filesystem scan of db/patches and db/patches/support
-- Patches exécutables : 171
-- Scripts auxiliaires : 305
-- Patches depuis 2026-07-01 : 113
+- Patches exécutables : 172
+- Scripts auxiliaires : 308
+- Patches depuis 2026-07-01 : 114
 
 ## Risques statiques à examiner
 
@@ -13,7 +13,7 @@
 | DDL destructif | 2 |
 | DML destructif | 9 |
 | Réécriture de données | 104 |
-| Verrou de table possible | 130 |
+| Verrou de table possible | 131 |
 | Index non concurrent | 127 |
 | Évolution d'enum | 1 |
 

--- a/src/__tests__/finance-ged-archive-625.contract.test.ts
+++ b/src/__tests__/finance-ged-archive-625.contract.test.ts
@@ -1,0 +1,72 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import { queueCreationPdfArchive } from "../shared/authoritative-documents/authoritative-document.service";
+
+const root = process.cwd();
+const factureWriter = fs.readFileSync(path.join(root, "src/module/facturation/services/finance-document.service.ts"), "utf8");
+const avoirWriter = fs.readFileSync(path.join(root, "src/module/facturation/services/avoir-document.service.ts"), "utf8");
+const factureIssue = fs.readFileSync(path.join(root, "src/module/facturation/repository/facture-workflow.repository.ts"), "utf8");
+const avoirIssue = fs.readFileSync(path.join(root, "src/module/facturation/repository/avoir-workflow.repository.ts"), "utf8");
+const factureController = fs.readFileSync(path.join(root, "src/module/facturation/controllers/factures.controller.ts"), "utf8");
+const avoirController = fs.readFileSync(path.join(root, "src/module/facturation/controllers/avoirs.controller.ts"), "utf8");
+const legalArchiveService = fs.readFileSync(path.join(root, "src/module/facturation/services/finance-legal-archive.service.ts"), "utf8");
+const patch = fs.readFileSync(path.join(root, "db/patches/20260823_finance_ged_archive_625.sql"), "utf8");
+
+describe("#625 finance legal GED bridge", () => {
+  it("makes both legal writers hand the exact rendered Buffer to the transactional archive intent", () => {
+    for (const source of [factureWriter, avoirWriter]) {
+      expect(source).toContain("pdfBytes: Buffer.from(pdf)");
+      expect(source).toContain('createHash("sha256").update(pdf).digest("hex")');
+    }
+    for (const source of [factureIssue, avoirIssue]) {
+      expect(source).toContain("queueCreationPdfArchive(client");
+      expect(source).toContain("exactPdfBytes: artifact.pdfBytes");
+      expect(source).toContain("authoritative_archive_id: legalArchive.id");
+    }
+  });
+
+  it("persists the byte payload and immutable checksum as one idempotent request under a concurrency replay", async () => {
+    const pdf = Buffer.from("%PDF-1.7\nexact-issued-finance-bytes\n%%EOF");
+    const sha = crypto.createHash("sha256").update(pdf).digest("hex");
+    const snapshotSha = crypto.createHash("sha256").update('{"legal_number":"F-1"}').digest("hex");
+    const stored = {
+      id: "11111111-1111-4111-8111-111111111111", entity_type: "facture", entity_id: "f-1", document_kind: "FINANCE_INVOICE_LEGAL_PDF",
+      document_version: 1, render_version: "finance-legal-issued-v1", idempotency_key: "finance:facture:f-1:legal:F-1:v1", title: "Facture légale F-1", original_name: "Facture_F-1_v1.pdf",
+      source_snapshot: { legal_number: "F-1" }, source_revision: `F-1:${sha}`, snapshot_sha256: snapshotSha,
+      exact_pdf_bytes: pdf, exact_pdf_sha256: sha, exact_pdf_size_bytes: String(pdf.byteLength), pdf_sha256: null, pdf_size_bytes: null,
+      ged_document_id: null, ged_version_id: null, archived_at: null, created_at: "2026-08-23T00:00:00.000Z", created_by: 7,
+    };
+    let inserted = false;
+    const tx = { query: vi.fn(async (sql: string) => {
+      if (sql.includes("INSERT INTO public.authoritative_pdf_archives")) { if (!inserted) { inserted = true; return { rows: [stored] }; } return { rows: [] }; }
+      if (sql.includes("SELECT") && sql.includes("idempotency_key")) return { rows: [stored] };
+      return { rows: [] };
+    }) };
+    const request = { entityType: "facture", entityId: "f-1", documentKind: "FINANCE_INVOICE_LEGAL_PDF", documentVersion: 1, renderVersion: "finance-legal-issued-v1", idempotencyKey: "finance:facture:f-1:legal:F-1:v1", title: "Facture légale F-1", originalName: "Facture_F-1_v1.pdf", sourceRevision: `F-1:${sha}`, sourceSnapshot: { legal_number: "F-1" }, exactPdfBytes: pdf, actorUserId: 7 } as const;
+    const [first, replay] = await Promise.all([queueCreationPdfArchive(tx, request), queueCreationPdfArchive(tx, request)]);
+    expect(first.id).toBe(replay.id);
+    expect(first.exactPdfSha256).toBe(sha);
+    expect(Buffer.from(first.exactPdfBytes ?? []).equals(pdf)).toBe(true);
+    expect(tx.query.mock.calls.filter(([sql]) => String(sql).includes("authoritative_pdf_archive_outbox"))).toHaveLength(2);
+  });
+
+  it("makes the migration retain the bytes, size/checksum pair and immutable source identity", () => {
+    expect(patch).toContain("exact_pdf_bytes bytea");
+    expect(patch).toContain("exact_pdf_sha256");
+    expect(patch).toContain("exact_pdf_size_bytes");
+    expect(patch).toContain("exact_pdf_size_bytes = octet_length(exact_pdf_bytes)");
+    expect(patch).toContain("NEW.exact_pdf_bytes IS DISTINCT FROM OLD.exact_pdf_bytes");
+    expect(patch).toContain("FINANCE_GED_ARCHIVE_612_PREREQUISITE_MISSING");
+  });
+
+  it("prevents the legacy legal PDF readers from regenerating an issued document", () => {
+    for (const source of [factureController, avoirController]) {
+      expect(source).toContain('readLatestFinanceLegalArchive');
+      expect(source).toContain('statut === "ISSUED"');
+    }
+    expect(legalArchiveService).toContain('OFFICIAL_DOCUMENT_NOT_READY');
+  });
+});

--- a/src/__tests__/finance-ged-archive-625.postgres.integration.test.ts
+++ b/src/__tests__/finance-ged-archive-625.postgres.integration.test.ts
@@ -1,0 +1,82 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+const integrationUrl = process.env.FINANCE_GED_ARCHIVE_TEST_DATABASE_URL;
+const suite = integrationUrl ? describe : describe.skip;
+const root = process.cwd();
+const pdf = Buffer.from("%PDF-1.7\\nfinance-issued-exact-bytes\\n%%EOF");
+const pdfSha = crypto.createHash("sha256").update(pdf).digest("hex");
+
+suite("#625 finance GED archive PostgreSQL integrity", () => {
+  let pg: typeof import("pg");
+  let pool: import("pg").Pool;
+
+  const archiveInsert = (key: string, source = pdf, sha = pdfSha) => `
+    INSERT INTO public.authoritative_pdf_archives
+      (entity_type, entity_id, document_kind, document_version, render_version, idempotency_key,
+       title, original_name, source_snapshot, source_revision, snapshot_sha256,
+       exact_pdf_bytes, exact_pdf_sha256, exact_pdf_size_bytes, created_by)
+    VALUES ('facture','11111111-1111-4111-8111-111111111111','FINANCE_INVOICE_LEGAL_PDF',1,
+            'finance-legal-issued-v1',$1,'Facture légale F-1','Facture_F-1_v1.pdf',
+            '{"legal_number":"F-1"}'::jsonb,'F-1:${pdfSha}',repeat('a',64),$2,$3,$4,1)
+    ON CONFLICT (idempotency_key) DO NOTHING
+    RETURNING id::text`;
+
+  beforeAll(async () => {
+    const pgModule = await import("pg"); pg = pgModule;
+    const bootstrap = new pg.Client({ connectionString: integrationUrl });
+    await bootstrap.connect();
+    const target = await bootstrap.query<{ current_database: string }>("SELECT current_database()");
+    if (!/test|sandbox|local/i.test(target.rows[0]?.current_database ?? "")) {
+      throw new Error("FINANCE_GED_ARCHIVE_TEST_DATABASE_URL must target an explicitly named test/local/sandbox database");
+    }
+    await bootstrap.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public; CREATE EXTENSION IF NOT EXISTS pgcrypto;");
+    await bootstrap.query(`
+      DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN CREATE ROLE cerp_app; END IF; END $$;
+      CREATE TABLE public.users (id integer PRIMARY KEY);
+      INSERT INTO public.users (id) VALUES (1);
+      CREATE TABLE public.ged_document_classes (class_key text PRIMARY KEY, domain text, label text, nature text, allowed_mime_types text[], allowed_extensions text[], max_size_bytes bigint, approvals_required smallint, retention_months integer, hold_on_publish boolean, is_active boolean);
+      CREATE TABLE public.ged_documents (id uuid PRIMARY KEY DEFAULT gen_random_uuid());
+      CREATE TABLE public.ged_document_versions (id uuid PRIMARY KEY DEFAULT gen_random_uuid());
+      CREATE TABLE public.ged_document_links (id uuid PRIMARY KEY DEFAULT gen_random_uuid());
+    `);
+    for (const file of ["20260823_authoritative_pdf_archive_612.sql", "20260823_finance_ged_archive_625.sql"]) {
+      await bootstrap.query(await fs.readFile(path.join(root, "db/patches", file), "utf8"));
+    }
+    await bootstrap.end();
+    pool = new pg.Pool({ connectionString: integrationUrl });
+  }, 60_000);
+
+  beforeEach(async () => {
+    await pool.query("TRUNCATE public.authoritative_pdf_archive_outbox, public.authoritative_pdf_archives CASCADE");
+  });
+
+  afterAll(async () => { await pool?.end(); });
+
+  it("rejects a byte/checksum mismatch in PostgreSQL, before any worker can consume it", async () => {
+    await expect(pool.query(archiveInsert("finance:bad", pdf, "b".repeat(64)), ["finance:bad", pdf, "b".repeat(64), pdf.byteLength]))
+      .rejects.toMatchObject({ code: "23514" });
+  });
+
+  it("keeps the exact legal bytes immutable after insertion", async () => {
+    const inserted = await pool.query(archiveInsert("finance:immutable"), ["finance:immutable", pdf, pdfSha, pdf.byteLength]);
+    await expect(pool.query("UPDATE public.authoritative_pdf_archives SET exact_pdf_bytes = $2 WHERE id = $1::uuid", [inserted.rows[0].id, Buffer.from("%PDF-1.7\\nchanged\\n%%EOF")]))
+      .rejects.toMatchObject({ code: "23514" });
+  });
+
+  it("is idempotent under concurrent legal archive enqueue attempts", async () => {
+    const first = pool.connect(); const second = pool.connect();
+    const [one, two] = await Promise.all([first, second]);
+    try {
+      const [a, b] = await Promise.all([
+        one.query(archiveInsert("finance:concurrent"), ["finance:concurrent", pdf, pdfSha, pdf.byteLength]),
+        two.query(archiveInsert("finance:concurrent"), ["finance:concurrent", pdf, pdfSha, pdf.byteLength]),
+      ]);
+      expect(a.rowCount! + b.rowCount!).toBe(1);
+      const row = await pool.query("SELECT encode(exact_pdf_bytes, 'hex') AS bytes, exact_pdf_sha256, exact_pdf_size_bytes::int AS size FROM public.authoritative_pdf_archives WHERE idempotency_key = $1", ["finance:concurrent"]);
+      expect(row.rows[0]).toMatchObject({ bytes: pdf.toString("hex"), exact_pdf_sha256: pdfSha, size: pdf.byteLength });
+    } finally { one.release(); two.release(); }
+  });
+});

--- a/src/__tests__/finance-ged-archive-625.routes.test.ts
+++ b/src/__tests__/finance-ged-archive-625.routes.test.ts
@@ -1,0 +1,50 @@
+import express, { type RequestHandler } from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const legal = vi.hoisted(() => ({
+  list: vi.fn(), get: vi.fn(), read: vi.fn(), print: vi.fn(),
+}));
+
+vi.mock("../module/facturation/services/finance-legal-archive.service", () => ({
+  listFinanceLegalArchive: (...args: unknown[]) => legal.list(...args),
+  getFinanceLegalArchive: (...args: unknown[]) => legal.get(...args),
+  readFinanceLegalArchive: (...args: unknown[]) => legal.read(...args),
+  printFinanceLegalArchive: (...args: unknown[]) => legal.print(...args),
+  readLatestFinanceLegalArchive: (...args: unknown[]) => legal.read(...args),
+}));
+
+import { validationErrorMiddleware } from "../module/auth/middlewares/validationError.middleware";
+import factureRoutes from "../module/facturation/routes/factures.routes";
+import { errorHandler } from "../middlewares/errorHandler";
+
+function app(role: string | null) {
+  const server = express();
+  server.use(express.json());
+  server.use(((req, _res, next) => {
+    if (role) req.user = { id: 7, username: "finance-test", role };
+    next();
+  }) as RequestHandler);
+  server.use("/factures", factureRoutes);
+  server.use(validationErrorMiddleware);
+  server.use(errorHandler);
+  return server;
+}
+
+describe("#625 mounted legal PDF archive routes", () => {
+  beforeEach(() => { for (const mock of Object.values(legal)) mock.mockReset(); vi.spyOn(console, "error").mockImplementation(() => undefined); });
+
+  it("fails closed before an invoice archive handler runs", async () => {
+    expect((await request(app(null)).get("/factures/1/official-documents")).status).toBe(401);
+    const denied = await request(app("Employee")).get("/factures/1/official-documents");
+    expect(denied.status).toBe(403);
+    expect(legal.list).not.toHaveBeenCalled();
+  });
+
+  it("admits a Finance documents_read role and keeps the route mounted before /:id", async () => {
+    legal.list.mockResolvedValue({ state: "READY", latest_document: null, retryable: false, failure_code: null });
+    const response = await request(app("Comptable")).get("/factures/1/official-documents");
+    expect(response.status).toBe(200);
+    expect(legal.list).toHaveBeenCalledWith("FACTURE", 1);
+  });
+});

--- a/src/module/facturation/controllers/avoirs.controller.ts
+++ b/src/module/facturation/controllers/avoirs.controller.ts
@@ -2,6 +2,9 @@ import type { RequestHandler } from "express";
 import fs from "node:fs/promises";
 import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { readLatestFinanceLegalArchive } from "../services/finance-legal-archive.service";
 import {
   avoirIdParamsSchema,
   createAvoirBodySchema,
@@ -109,6 +112,16 @@ export const getAvoirPdf: RequestHandler = async (req, res, next) => {
   try {
     const { id } = avoirIdParamsSchema.parse(req.params);
     const download = coerceBool((req.query as { download?: unknown } | undefined)?.download);
+
+    const issued = await pool.query<{ statut: string }>(`SELECT statut FROM public.avoir WHERE id = $1`, [id]);
+    if (issued.rows[0]?.statut === "ISSUED") {
+      const actorId = req.user?.id;
+      if (typeof actorId !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+      const official = await readLatestFinanceLegalArchive("AVOIR", id, actorId, download ? "AUTHORITATIVE_PDF_DOWNLOADED" : "AUTHORITATIVE_PDF_PREVIEWED");
+      res.setHeader("Content-Type", "application/pdf"); res.setHeader("Content-Length", String(official.bytes.byteLength));
+      res.setHeader("Content-Disposition", `${download ? "attachment" : "inline"}; filename=\"${official.filename.replace(/[\\\"\r\n]/g, "_")}\"`);
+      res.send(official.bytes); return;
+    }
 
     let documentId = await svcGetLatestAvoirPdfDocumentId(id);
     if (!documentId) {

--- a/src/module/facturation/controllers/factures.controller.ts
+++ b/src/module/facturation/controllers/factures.controller.ts
@@ -1,7 +1,10 @@
 import type { RequestHandler } from "express";
 import fs from "node:fs/promises";
+import db from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
 import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
+import { readLatestFinanceLegalArchive } from "../services/finance-legal-archive.service";
 import {
   createFactureBodySchema,
   factureIdParamsSchema,
@@ -115,6 +118,18 @@ export const getFacturePdf: RequestHandler = async (req, res, next) => {
   try {
     const { id } = factureIdParamsSchema.parse(req.params);
     const download = coerceBool((req.query as { download?: unknown } | undefined)?.download);
+
+    // Legal issuance is archive-backed. A missing/degraded GED archive is a
+    // visible retryable condition, never permission to regenerate changed data.
+    const issued = await db.query<{ statut: string }>(`SELECT statut FROM public.facture WHERE id = $1`, [id]);
+    if (issued.rows[0]?.statut === "ISSUED") {
+      const actorId = req.user?.id;
+      if (typeof actorId !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+      const official = await readLatestFinanceLegalArchive("FACTURE", id, actorId, download ? "AUTHORITATIVE_PDF_DOWNLOADED" : "AUTHORITATIVE_PDF_PREVIEWED");
+      res.setHeader("Content-Type", "application/pdf"); res.setHeader("Content-Length", String(official.bytes.byteLength));
+      res.setHeader("Content-Disposition", `${download ? "attachment" : "inline"}; filename=\"${official.filename.replace(/[\\\"\r\n]/g, "_")}\"`);
+      res.send(official.bytes); return;
+    }
 
     let documentId = await svcGetLatestFacturePdfDocumentId(id);
     if (!documentId) {

--- a/src/module/facturation/controllers/finance-legal-archive.controller.ts
+++ b/src/module/facturation/controllers/finance-legal-archive.controller.ts
@@ -1,0 +1,23 @@
+import type { RequestHandler } from "express";
+import { HttpError } from "../../../utils/httpError";
+import { financeLegacyIdParamsSchema } from "../validators/workflow.validators";
+import { getFinanceLegalArchive, listFinanceLegalArchive, printFinanceLegalArchive, readFinanceLegalArchive } from "../services/finance-legal-archive.service";
+
+type Kind = "FACTURE" | "AVOIR";
+const actor = (req: { user?: { id?: unknown } }) => {
+  if (typeof req.user?.id !== "number" || !Number.isInteger(req.user.id) || req.user.id <= 0) throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  return req.user.id;
+};
+const send = (res: Parameters<RequestHandler>[1], bytes: Buffer, filename: string, disposition: "inline" | "attachment") => {
+  res.setHeader("Content-Type", "application/pdf"); res.setHeader("Content-Length", String(bytes.byteLength));
+  res.setHeader("Content-Disposition", `${disposition}; filename=\"${filename.replace(/[\\\"\r\n]/g, "_")}\"`); res.send(bytes);
+};
+const handlers = (kind: Kind) => ({
+  list: (async (req, res, next) => { try { const { id } = financeLegacyIdParamsSchema.parse(req.params); actor(req); res.json(await listFinanceLegalArchive(kind, id)); } catch (e) { next(e); } }) as RequestHandler,
+  get: (async (req, res, next) => { try { const { id } = financeLegacyIdParamsSchema.parse(req.params); const archiveId = String(req.params.documentId ?? ""); actor(req); const out = await getFinanceLegalArchive(kind, id, archiveId); if (!out) throw new HttpError(404, "OFFICIAL_DOCUMENT_NOT_FOUND", "Document officiel introuvable."); res.json(out); } catch (e) { next(e); } }) as RequestHandler,
+  preview: (async (req, res, next) => { try { const { id } = financeLegacyIdParamsSchema.parse(req.params); const out = await readFinanceLegalArchive(kind, id, String(req.params.documentId ?? ""), actor(req), "AUTHORITATIVE_PDF_PREVIEWED"); send(res, out.bytes, out.filename, "inline"); } catch (e) { next(e); } }) as RequestHandler,
+  download: (async (req, res, next) => { try { const { id } = financeLegacyIdParamsSchema.parse(req.params); const out = await readFinanceLegalArchive(kind, id, String(req.params.documentId ?? ""), actor(req), "AUTHORITATIVE_PDF_DOWNLOADED"); send(res, out.bytes, out.filename, "attachment"); } catch (e) { next(e); } }) as RequestHandler,
+  print: (async (req, res, next) => { try { const { id } = financeLegacyIdParamsSchema.parse(req.params); await printFinanceLegalArchive(kind, id, String(req.params.documentId ?? ""), actor(req)); res.status(204).send(); } catch (e) { next(e); } }) as RequestHandler,
+});
+export const factureLegalArchive = handlers("FACTURE");
+export const avoirLegalArchive = handlers("AVOIR");

--- a/src/module/facturation/repository/avoir-workflow.repository.ts
+++ b/src/module/facturation/repository/avoir-workflow.repository.ts
@@ -3,6 +3,7 @@ import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
 import {
   assertAvoirTransition,
   assertSeparationOfDuties,
@@ -89,6 +90,8 @@ export type AvoirDocumentArtifact = {
   fileName: string;
   checksumSha256: string;
   fileSizeBytes: number;
+  /** Exact issued bytes, retained until the #625 durable GED intent is committed. */
+  pdfBytes: Buffer;
   cleanup: () => Promise<void>;
 };
 
@@ -828,6 +831,21 @@ export async function repoIssueAvoir(params: {
       totals: preview.totals,
     };
     artifact = await params.writeDocument(snapshot);
+    // #625: preserve the byte-exact issued credit note for GED retry/reconcile.
+    const legalArchive = await queueCreationPdfArchive(client, {
+      entityType: "avoir",
+      entityId: avoir.uuid,
+      documentKind: "FINANCE_CREDIT_NOTE_LEGAL_PDF",
+      documentVersion: 1,
+      renderVersion: "finance-legal-issued-v1",
+      idempotencyKey: `finance:avoir:${avoir.uuid}:legal:${legal.legalNumber}:v1`,
+      title: `Avoir légal ${legal.legalNumber}`,
+      originalName: artifact.fileName,
+      sourceRevision: `${legal.legalNumber}:${artifact.checksumSha256}`,
+      sourceSnapshot: snapshot,
+      exactPdfBytes: artifact.pdfBytes,
+      actorUserId: params.actor.userId,
+    });
     const correlationId = newCorrelationId();
     await client.query(
       `
@@ -922,7 +940,7 @@ export async function repoIssueAvoir(params: {
       aggregateId: avoir.uuid,
       eventType: "AVOIR_ISSUED",
       oldValues: { status: avoir.statut },
-      newValues: { status: "ISSUED", legal_number: legal.legalNumber },
+      newValues: { status: "ISSUED", legal_number: legal.legalNumber, document_checksum_sha256: artifact.checksumSha256, authoritative_archive_id: legalArchive.id },
       actor: params.actor,
       correlationId,
       idempotencyKey: receipt.idempotencyKey,
@@ -951,7 +969,7 @@ export async function repoIssueAvoir(params: {
       action: "facturation.avoir_issued",
       entityType: "avoir",
       entityId: avoir.uuid,
-      details: { facture_id: preview.facture_id, legal_number: legal.legalNumber, correlation_id: correlationId },
+      details: { facture_id: preview.facture_id, legal_number: legal.legalNumber, document_checksum_sha256: artifact.checksumSha256, authoritative_archive_id: legalArchive.id, correlation_id: correlationId },
     });
     await saveFinanceReceipt({
       client,

--- a/src/module/facturation/repository/facture-workflow.repository.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.ts
@@ -1,6 +1,7 @@
 import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
+import { queueCreationPdfArchive } from "../../../shared/authoritative-documents/authoritative-document.service";
 import { HttpError } from "../../../utils/httpError";
 import { lockDeliveryQualityReleaseScope, repoGetDeliveryQualityRelease } from "../../livraisons/repository/quality-release.repository";
 import {
@@ -158,6 +159,8 @@ export type FinanceDocumentArtifact = {
   fileName: string;
   checksumSha256: string;
   fileSizeBytes: number;
+  /** Exact issued bytes, retained until the #625 durable GED intent is committed. */
+  pdfBytes: Buffer;
   cleanup: () => Promise<void>;
 };
 
@@ -1267,6 +1270,24 @@ export async function repoIssueFacture(params: {
       customer_text: facture.customer_text,
     };
     artifact = await params.writeDocument(snapshot);
+    // #625: the legal issuer has just produced the only authoritative bytes.
+    // Queue them in the same transaction as legal numbering and the issuance
+    // state; the GED worker subsequently files these bytes, never re-renders
+    // a snapshot against later data/template state.
+    const legalArchive = await queueCreationPdfArchive(client, {
+      entityType: "facture",
+      entityId: facture.uuid,
+      documentKind: "FINANCE_INVOICE_LEGAL_PDF",
+      documentVersion: 1,
+      renderVersion: "finance-legal-issued-v1",
+      idempotencyKey: `finance:facture:${facture.uuid}:legal:${legal.legalNumber}:v1`,
+      title: `Facture légale ${legal.legalNumber}`,
+      originalName: artifact.fileName,
+      sourceRevision: `${legal.legalNumber}:${artifact.checksumSha256}`,
+      sourceSnapshot: snapshot,
+      exactPdfBytes: artifact.pdfBytes,
+      actorUserId: params.actor.userId,
+    });
     const correlationId = newCorrelationId();
     await client.query(
       `
@@ -1366,6 +1387,7 @@ export async function repoIssueFacture(params: {
         status: "ISSUED",
         legal_number: legal.legalNumber,
         document_checksum_sha256: artifact.checksumSha256,
+        authoritative_archive_id: legalArchive.id,
       },
       actor: params.actor,
       correlationId,
@@ -1396,6 +1418,7 @@ export async function repoIssueFacture(params: {
       details: {
         legal_number: legal.legalNumber,
         document_checksum_sha256: artifact.checksumSha256,
+        authoritative_archive_id: legalArchive.id,
         correlation_id: correlationId,
         quality_releases: qualityReleases,
       },

--- a/src/module/facturation/routes/avoirs.routes.ts
+++ b/src/module/facturation/routes/avoirs.routes.ts
@@ -8,6 +8,7 @@ import {
   listAvoirs,
   updateAvoir,
 } from "../controllers/avoirs.controller";
+import { avoirLegalArchive } from "../controllers/finance-legal-archive.controller";
 import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
 import {
   createAvoirDraftWorkflow,
@@ -38,6 +39,11 @@ router.post(
   validateAvoirWorkflow
 );
 router.post("/workflow/:id/issue", requireFinanceCapability("credit_issue"), issueAvoirWorkflow);
+router.get("/:id/official-documents", requireFinanceCapability("documents_read"), avoirLegalArchive.list);
+router.get("/:id/official-documents/:documentId", requireFinanceCapability("documents_read"), avoirLegalArchive.get);
+router.get("/:id/official-documents/:documentId/preview", requireFinanceCapability("documents_read"), avoirLegalArchive.preview);
+router.get("/:id/official-documents/:documentId/download", requireFinanceCapability("documents_read"), avoirLegalArchive.download);
+router.post("/:id/official-documents/:documentId/print-intents", requireFinanceCapability("documents_read"), avoirLegalArchive.print);
 
 router.get("/", requireFinanceCapability("read"), listAvoirs);
 router.get("/:id", requireFinanceCapability("read"), getAvoir);

--- a/src/module/facturation/routes/factures.routes.ts
+++ b/src/module/facturation/routes/factures.routes.ts
@@ -16,6 +16,7 @@ import {
   requestFactureValidation,
   validateFactureWorkflow,
 } from "../controllers/facture-workflow.controller";
+import { factureLegalArchive } from "../controllers/finance-legal-archive.controller";
 import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
 import {
   activateFinanceConfiguration,
@@ -89,6 +90,12 @@ router.post(
   validateFactureWorkflow
 );
 router.post("/workflow/:id/issue", requireFinanceCapability("issue"), issueFactureWorkflow);
+// Issued legal bytes are served only from #625's authoritative GED archive.
+router.get("/:id/official-documents", requireFinanceCapability("documents_read"), factureLegalArchive.list);
+router.get("/:id/official-documents/:documentId", requireFinanceCapability("documents_read"), factureLegalArchive.get);
+router.get("/:id/official-documents/:documentId/preview", requireFinanceCapability("documents_read"), factureLegalArchive.preview);
+router.get("/:id/official-documents/:documentId/download", requireFinanceCapability("documents_read"), factureLegalArchive.download);
+router.post("/:id/official-documents/:documentId/print-intents", requireFinanceCapability("documents_read"), factureLegalArchive.print);
 
 // Must precede `/:id`: configuration is a Finance settings resource, not a legacy invoice id.
 router.get(

--- a/src/module/facturation/services/avoir-document.service.ts
+++ b/src/module/facturation/services/avoir-document.service.ts
@@ -69,6 +69,7 @@ export async function writeImmutableAvoirDocument(
     fileName,
     checksumSha256: crypto.createHash("sha256").update(pdf).digest("hex"),
     fileSizeBytes: pdf.byteLength,
+    pdfBytes: Buffer.from(pdf),
     cleanup: async () => {
       await fs.unlink(filePath).catch((error: NodeJS.ErrnoException) => {
         if (error.code !== "ENOENT") throw error;

--- a/src/module/facturation/services/finance-document.service.ts
+++ b/src/module/facturation/services/finance-document.service.ts
@@ -74,6 +74,7 @@ export async function writeImmutableFactureDocument(
     fileName,
     checksumSha256: crypto.createHash("sha256").update(pdf).digest("hex"),
     fileSizeBytes: pdf.byteLength,
+    pdfBytes: Buffer.from(pdf),
     cleanup: async () => {
       await fs.unlink(filePath).catch((error: NodeJS.ErrnoException) => {
         if (error.code !== "ENOENT") throw error;

--- a/src/module/facturation/services/finance-legal-archive.service.ts
+++ b/src/module/facturation/services/finance-legal-archive.service.ts
@@ -1,0 +1,43 @@
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { getOfficialDocumentGenerationEnvelope, getOfficialPdfDto, readOfficialPdfBytes, recordOfficialPdfPrintIntent } from "../../../shared/authoritative-documents/authoritative-document.service";
+
+type FinanceLegalKind = "FACTURE" | "AVOIR";
+
+const config = (kind: FinanceLegalKind) => kind === "FACTURE"
+  ? { table: "facture", entityType: "facture", documentKind: "FINANCE_INVOICE_LEGAL_PDF", base: "/factures" }
+  : { table: "avoir", entityType: "avoir", documentKind: "FINANCE_CREDIT_NOTE_LEGAL_PDF", base: "/avoirs" };
+
+async function entityUuid(kind: FinanceLegalKind, id: number): Promise<string> {
+  const c = config(kind);
+  const row = await pool.query<{ uuid: string; statut: string }>(`SELECT uuid::text, statut FROM public.${c.table} WHERE id = $1`, [id]);
+  if (!row.rows[0]) throw new HttpError(404, "FINANCE_DOCUMENT_NOT_FOUND", "Document Finance introuvable.");
+  if (row.rows[0].statut !== "ISSUED") throw new HttpError(409, "OFFICIAL_DOCUMENT_NOT_ISSUED", "Le document légal n'est pas encore émis.");
+  return row.rows[0].uuid;
+}
+
+const baseUrl = (kind: FinanceLegalKind, id: number) => `${config(kind).base}/${id}/official-documents`;
+
+export async function listFinanceLegalArchive(kind: FinanceLegalKind, id: number) {
+  const entityId = await entityUuid(kind, id); const c = config(kind);
+  return getOfficialDocumentGenerationEnvelope({ tx: pool, entityType: c.entityType, entityId, documentKind: c.documentKind, baseUrl: baseUrl(kind, id) });
+}
+export async function getFinanceLegalArchive(kind: FinanceLegalKind, id: number, archiveId: string) {
+  const entityId = await entityUuid(kind, id); const c = config(kind);
+  return getOfficialPdfDto({ tx: pool, entityType: c.entityType, entityId, documentKind: c.documentKind, archiveId, baseUrl: baseUrl(kind, id) });
+}
+export async function readFinanceLegalArchive(kind: FinanceLegalKind, id: number, archiveId: string, actorUserId: number, eventType: "AUTHORITATIVE_PDF_PREVIEWED" | "AUTHORITATIVE_PDF_DOWNLOADED") {
+  const entityId = await entityUuid(kind, id); const c = config(kind);
+  return readOfficialPdfBytes({ entityType: c.entityType, entityId, documentKind: c.documentKind, archiveId, actorUserId, eventType });
+}
+/** Legacy `/pdf` adapters use this only for an issued document: never regenerate legal bytes. */
+export async function readLatestFinanceLegalArchive(kind: FinanceLegalKind, id: number, actorUserId: number, eventType: "AUTHORITATIVE_PDF_PREVIEWED" | "AUTHORITATIVE_PDF_DOWNLOADED") {
+  const envelope = await listFinanceLegalArchive(kind, id);
+  const archiveId = envelope.latest_document?.id;
+  if (!archiveId) throw new HttpError(409, "OFFICIAL_DOCUMENT_NOT_READY", "Le document légal officiel est en cours d'archivage.");
+  return readFinanceLegalArchive(kind, id, archiveId, actorUserId, eventType);
+}
+export async function printFinanceLegalArchive(kind: FinanceLegalKind, id: number, archiveId: string, actorUserId: number) {
+  const entityId = await entityUuid(kind, id); const c = config(kind);
+  return recordOfficialPdfPrintIntent({ entityType: c.entityType, entityId, documentKind: c.documentKind, archiveId, actorUserId });
+}

--- a/src/module/livraisons/services/delivery-authoritative-document.test.ts
+++ b/src/module/livraisons/services/delivery-authoritative-document.test.ts
@@ -9,7 +9,7 @@ describe("#624 shipped delivery authoritative renderer", () => {
       id: "11111111-1111-4111-8111-111111111111", entityType: "bon-livraison", entityId: "22222222-2222-4222-8222-222222222222",
       documentKind: "DELIVERY_NOTE_SHIPPED", documentVersion: 1, renderVersion: "delivery-note-shipped-v1", idempotencyKey: "delivery:test:shipped:v1",
       title: "BL expédié", originalName: "bon-livraison-BL-0001-expedie.pdf", sourceRevision: "1:test", snapshotSha256: "a".repeat(64),
-      pdfSha256: null, pdfSizeBytes: null, gedDocumentId: null, gedVersionId: null, archivedAt: null, createdAt: "2026-08-23T00:00:00.000Z", actorUserId: 1,
+      exactPdfSha256: null, exactPdfSizeBytes: null, pdfSha256: null, pdfSizeBytes: null, gedDocumentId: null, gedVersionId: null, archivedAt: null, createdAt: "2026-08-23T00:00:00.000Z", actorUserId: 1,
       sourceSnapshot: { type: "DELIVERY_NOTE_SHIPPED_SNAPSHOT", numero: "BL-0001", statut: "SHIPPED", client_name: "Client Démo", commande_numero: "CMD-1", affaire_reference: null, address_label: "12 rue Exemple\n75000 Paris", date_creation: "2026-08-23", date_expedition: "2026-08-23", transporteur: "CERP", tracking_number: "TRK-1", commentaire_client: "Livraison contrôlée", updated_at: "2026-08-23T00:00:00.000Z", issuer: { company_name: "CERP Historique", siret: "12345678900012" }, lines: [{ ordre: 1, designation: "Pièce A", code_piece: "A-01", quantite: 2, unite: "u", delai_client: null, lot_codes: ["LOT-01"] }] },
     } });
     expect(bytes.subarray(0, 5).toString("ascii")).toBe("%PDF-");

--- a/src/shared/authoritative-documents/authoritative-document.repository.ts
+++ b/src/shared/authoritative-documents/authoritative-document.repository.ts
@@ -1,4 +1,5 @@
 import type { PoolClient } from "pg";
+import crypto from "node:crypto";
 
 import { HttpError } from "../../utils/httpError";
 import type { ArchiveQueueItem, AuthoritativePdfArchiveRecord, AuthoritativePdfCreationInput } from "./authoritative-document.types";
@@ -7,6 +8,7 @@ type ArchiveRow = {
   id: string; entity_type: string; entity_id: string; document_kind: string; document_version: number | string; render_version: string;
   idempotency_key: string; title: string; original_name: string; source_snapshot: Record<string, unknown>;
   source_revision: string; snapshot_sha256: string; pdf_sha256: string | null; pdf_size_bytes: string | null;
+  exact_pdf_bytes: Buffer | null; exact_pdf_sha256: string | null; exact_pdf_size_bytes: string | null;
   ged_document_id: string | null; ged_version_id: string | null; archived_at: string | null; created_at: string; created_by: number | null;
 };
 
@@ -16,6 +18,9 @@ function mapArchive(row: ArchiveRow): AuthoritativePdfArchiveRecord {
     documentKind: row.document_kind, documentVersion: Number(row.document_version), renderVersion: row.render_version,
     idempotencyKey: row.idempotency_key, title: row.title, originalName: row.original_name,
     sourceRevision: row.source_revision, sourceSnapshot: row.source_snapshot, snapshotSha256: row.snapshot_sha256,
+    exactPdfBytes: row.exact_pdf_bytes ?? undefined,
+    exactPdfSha256: row.exact_pdf_sha256,
+    exactPdfSizeBytes: row.exact_pdf_size_bytes == null ? null : Number(row.exact_pdf_size_bytes),
     pdfSha256: row.pdf_sha256, pdfSizeBytes: row.pdf_size_bytes == null ? null : Number(row.pdf_size_bytes),
     gedDocumentId: row.ged_document_id, gedVersionId: row.ged_version_id,
     archivedAt: row.archived_at, createdAt: row.created_at, actorUserId: row.created_by,
@@ -24,7 +29,8 @@ function mapArchive(row: ArchiveRow): AuthoritativePdfArchiveRecord {
 
 const ARCHIVE_COLUMNS = `id::text, entity_type, entity_id, document_kind, document_version, render_version,
   idempotency_key, title, original_name, source_snapshot, source_revision, snapshot_sha256, pdf_sha256,
-  pdf_size_bytes::text, ged_document_id::text, ged_version_id::text, archived_at::text, created_at::text, created_by`;
+  pdf_size_bytes::text, exact_pdf_bytes, exact_pdf_sha256, exact_pdf_size_bytes::text,
+  ged_document_id::text, ged_version_id::text, archived_at::text, created_at::text, created_by`;
 
 /** Insert is intentionally idempotent; a repeated create transaction returns the same job. */
 export async function repoQueueAuthoritativePdf(
@@ -36,12 +42,16 @@ export async function repoQueueAuthoritativePdf(
   try {
     inserted = await tx.query<ArchiveRow>(
       `INSERT INTO public.authoritative_pdf_archives
-         (entity_type, entity_id, document_kind, document_version, render_version, idempotency_key, title, original_name, source_snapshot, source_revision, snapshot_sha256, created_by)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11,$12)
+         (entity_type, entity_id, document_kind, document_version, render_version, idempotency_key, title, original_name, source_snapshot, source_revision, snapshot_sha256, exact_pdf_bytes, exact_pdf_sha256, exact_pdf_size_bytes, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11,$12,$13,$14,$15)
        ON CONFLICT (idempotency_key) DO NOTHING
        RETURNING ${ARCHIVE_COLUMNS}`,
       [input.entityType, input.entityId, input.documentKind, input.documentVersion, input.renderVersion, input.idempotencyKey,
-        input.title, input.originalName, JSON.stringify(input.sourceSnapshot), input.sourceRevision, snapshotSha256, input.actorUserId]
+        input.title, input.originalName, JSON.stringify(input.sourceSnapshot), input.sourceRevision, snapshotSha256,
+        input.exactPdfBytes ?? null,
+        input.exactPdfBytes ? crypto.createHash("sha256").update(input.exactPdfBytes).digest("hex") : null,
+        input.exactPdfBytes?.byteLength ?? null,
+        input.actorUserId]
     );
   } catch (error) {
     // Aggregate adapters serialise normal issuance, but a residual database
@@ -61,7 +71,8 @@ export async function repoQueueAuthoritativePdf(
     mapped.snapshotSha256 !== snapshotSha256 || mapped.entityType !== input.entityType ||
     mapped.entityId !== input.entityId || mapped.documentKind !== input.documentKind ||
     mapped.documentVersion !== input.documentVersion || mapped.renderVersion !== input.renderVersion ||
-    mapped.title !== input.title || mapped.originalName !== input.originalName || mapped.sourceRevision !== input.sourceRevision
+    mapped.title !== input.title || mapped.originalName !== input.originalName || mapped.sourceRevision !== input.sourceRevision ||
+    (input.exactPdfBytes != null && (mapped.exactPdfSha256 !== crypto.createHash("sha256").update(input.exactPdfBytes).digest("hex") || mapped.exactPdfSizeBytes !== input.exactPdfBytes.byteLength))
   ) {
     throw new HttpError(409, "OFFICIAL_DOCUMENT_IDEMPOTENCY_CONFLICT", "Cette clé d'idempotence est déjà utilisée avec une autre demande de document.");
   }

--- a/src/shared/authoritative-documents/authoritative-document.service.ts
+++ b/src/shared/authoritative-documents/authoritative-document.service.ts
@@ -56,6 +56,11 @@ function assertCreationInput(input: AuthoritativePdfCreationInput): void {
     !input.sourceRevision.trim() || input.sourceRevision.length > 160
   ) throw new Error("AUTHORITATIVE_PDF_INPUT_INVALID");
   assertAuthoritativePdfFilename(input.originalName);
+  if (input.exactPdfBytes) {
+    if (!Buffer.isBuffer(input.exactPdfBytes) || input.exactPdfBytes.length === 0 || input.exactPdfBytes.length > MAX_AUTHORITATIVE_PDF_BYTES || input.exactPdfBytes.subarray(0, 5).toString("ascii") !== "%PDF-") {
+      throw new Error("AUTHORITATIVE_PDF_EXACT_BYTES_INVALID");
+    }
+  }
 }
 
 /**
@@ -267,6 +272,14 @@ export async function processAuthoritativePdfItem(
   registry: AuthoritativePdfProducerRegistry,
   observeOwnership?: (ownership: { sha256: string; ownership: VaultBlobOwnership }) => void
 ): Promise<void> {
+  if (item.archive.exactPdfBytes) {
+    const exact = Buffer.from(item.archive.exactPdfBytes);
+    if (!item.archive.exactPdfSha256 || computeSha256(exact) !== item.archive.exactPdfSha256 || exact.byteLength !== item.archive.exactPdfSizeBytes) {
+      throw new Error("AUTHORITATIVE_PDF_EXACT_BYTES_INTEGRITY");
+    }
+    await archiveClaimedAuthoritativePdf(tx, item, exact, observeOwnership);
+    return;
+  }
   const producer = registry.get(item.archive.entityType, item.archive.documentKind);
   // No dynamic entity/document value is retained in a failure record or log.
   if (!producer) throw new Error("AUTHORITATIVE_PDF_PRODUCER_NOT_REGISTERED");

--- a/src/shared/authoritative-documents/authoritative-document.types.ts
+++ b/src/shared/authoritative-documents/authoritative-document.types.ts
@@ -13,6 +13,14 @@ export type AuthoritativePdfCreationInput = Readonly<{
   /** Server-derived aggregate revision that a browser can round-trip on reissue. */
   sourceRevision: string;
   sourceSnapshot: Record<string, unknown>;
+  /**
+   * Some legal issuers render their final document while holding the legal
+   * numbering transaction.  Persist those exact bytes in the durable intent:
+   * the archive worker must file them, never render a later view of the data.
+   * This is deliberately optional so the existing snapshot-rendered producers
+   * keep their current contract.
+   */
+  exactPdfBytes?: Buffer;
   actorUserId: number | null;
 }>;
 
@@ -21,6 +29,8 @@ export type AuthoritativePdfArchiveRecord = AuthoritativePdfCreationInput & {
   /** Durable queue chronology; never inferred from PDF issuance time. */
   createdAt: string;
   snapshotSha256: string;
+  exactPdfSha256: string | null;
+  exactPdfSizeBytes: number | null;
   pdfSha256: string | null;
   pdfSizeBytes: number | null;
   gedDocumentId: string | null;

--- a/src/swagger/generated-route-inventory.ts
+++ b/src/swagger/generated-route-inventory.ts
@@ -8,7 +8,7 @@ export type GeneratedRouteContract = {
   rbac: readonly string[];
 };
 
-export const GENERATED_ROUTE_SOURCE_SHA256 = "5c072234e4bb5227345223ffdbea9dfa4121f2b87792d4c8e0805175563a46a3";
+export const GENERATED_ROUTE_SOURCE_SHA256 = "899f968a2950bc15d761f78477b9d1ebf48f060e54c138270434827ca6295ebe";
 export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
@@ -1978,7 +1978,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/avoirs",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:42",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:48",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -1995,7 +1995,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/avoirs",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:45",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:51",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2012,7 +2012,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/avoirs/{id}",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:48",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:54",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2029,7 +2029,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/avoirs/{id}",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:43",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:49",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2046,7 +2046,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/avoirs/{id}",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:47",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:53",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2062,8 +2062,93 @@ export const GENERATED_ROUTE_INVENTORY = [
   },
   {
     "method": "get",
-    "path": "/avoirs/{id}/pdf",
+    "path": "/avoirs/{id}/official-documents",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:42",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)",
+      "avoirLegalArchive.list"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/avoirs/{id}/official-documents/{documentId}",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:43",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)",
+      "avoirLegalArchive.get"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/avoirs/{id}/official-documents/{documentId}/download",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:45",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)",
+      "avoirLegalArchive.download"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/avoirs/{id}/official-documents/{documentId}/preview",
     "source": "src/module/facturation/routes/avoirs.routes.ts:44",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)",
+      "avoirLegalArchive.preview"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/avoirs/{id}/official-documents/{documentId}/print-intents",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:46",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)",
+      "avoirLegalArchive.print"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/avoirs/{id}/pdf",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:50",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2080,7 +2165,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/avoirs/{id}/pdf",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:46",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:52",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2097,7 +2182,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/avoirs/workflow/{id}/issue",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:40",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:41",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2114,7 +2199,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/avoirs/workflow/{id}/request-validation",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:30",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:31",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2131,7 +2216,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/avoirs/workflow/{id}/validate",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:35",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:36",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2148,7 +2233,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/avoirs/workflow/drafts",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:29",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:30",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2165,7 +2250,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/avoirs/workflow/invoices/{id}/eligible-lines",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:23",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:24",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -2182,7 +2267,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/avoirs/workflow/preview",
-    "source": "src/module/facturation/routes/avoirs.routes.ts:28",
+    "source": "src/module/facturation/routes/avoirs.routes.ts:29",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4411,7 +4496,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/factures",
-    "source": "src/module/facturation/routes/factures.routes.ts:110",
+    "source": "src/module/facturation/routes/factures.routes.ts:117",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4428,7 +4513,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures",
-    "source": "src/module/facturation/routes/factures.routes.ts:113",
+    "source": "src/module/facturation/routes/factures.routes.ts:120",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4445,7 +4530,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "delete",
     "path": "/factures/{id}",
-    "source": "src/module/facturation/routes/factures.routes.ts:116",
+    "source": "src/module/facturation/routes/factures.routes.ts:123",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4462,7 +4547,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/factures/{id}",
-    "source": "src/module/facturation/routes/factures.routes.ts:111",
+    "source": "src/module/facturation/routes/factures.routes.ts:118",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4479,7 +4564,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "patch",
     "path": "/factures/{id}",
-    "source": "src/module/facturation/routes/factures.routes.ts:115",
+    "source": "src/module/facturation/routes/factures.routes.ts:122",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4496,7 +4581,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/factures/{id}/electronic-invoicing",
-    "source": "src/module/facturation/routes/factures.routes.ts:58",
+    "source": "src/module/facturation/routes/factures.routes.ts:59",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4513,7 +4598,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/{id}/electronic-invoicing/reconcile",
-    "source": "src/module/facturation/routes/factures.routes.ts:68",
+    "source": "src/module/facturation/routes/factures.routes.ts:69",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4530,7 +4615,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/{id}/electronic-invoicing/submissions",
-    "source": "src/module/facturation/routes/factures.routes.ts:63",
+    "source": "src/module/facturation/routes/factures.routes.ts:64",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4546,8 +4631,93 @@ export const GENERATED_ROUTE_INVENTORY = [
   },
   {
     "method": "get",
+    "path": "/factures/{id}/official-documents",
+    "source": "src/module/facturation/routes/factures.routes.ts:94",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)",
+      "factureLegalArchive.list"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/factures/{id}/official-documents/{documentId}",
+    "source": "src/module/facturation/routes/factures.routes.ts:95",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)",
+      "factureLegalArchive.get"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/factures/{id}/official-documents/{documentId}/download",
+    "source": "src/module/facturation/routes/factures.routes.ts:97",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)",
+      "factureLegalArchive.download"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/factures/{id}/official-documents/{documentId}/preview",
+    "source": "src/module/facturation/routes/factures.routes.ts:96",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)",
+      "factureLegalArchive.preview"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/factures/{id}/official-documents/{documentId}/print-intents",
+    "source": "src/module/facturation/routes/factures.routes.ts:98",
+    "middleware": [
+      "anonymous",
+      "authenticateToken",
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)",
+      "factureLegalArchive.print"
+    ],
+    "authenticated": true,
+    "rbac": [
+      "moduleAccessGate",
+      "requireFinanceCapability(documents_read)"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/factures/{id}/pdf",
-    "source": "src/module/facturation/routes/factures.routes.ts:112",
+    "source": "src/module/facturation/routes/factures.routes.ts:119",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4564,7 +4734,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/{id}/pdf",
-    "source": "src/module/facturation/routes/factures.routes.ts:114",
+    "source": "src/module/facturation/routes/factures.routes.ts:121",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4581,7 +4751,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/factures/configuration",
-    "source": "src/module/facturation/routes/factures.routes.ts:94",
+    "source": "src/module/facturation/routes/factures.routes.ts:101",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4598,7 +4768,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/configuration/activate",
-    "source": "src/module/facturation/routes/factures.routes.ts:99",
+    "source": "src/module/facturation/routes/factures.routes.ts:106",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4615,7 +4785,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/configuration/sequences",
-    "source": "src/module/facturation/routes/factures.routes.ts:104",
+    "source": "src/module/facturation/routes/factures.routes.ts:111",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4632,7 +4802,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/factures/electronic-invoicing/provider-configuration",
-    "source": "src/module/facturation/routes/factures.routes.ts:37",
+    "source": "src/module/facturation/routes/factures.routes.ts:38",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4649,7 +4819,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/electronic-invoicing/provider-configuration/activate",
-    "source": "src/module/facturation/routes/factures.routes.ts:42",
+    "source": "src/module/facturation/routes/factures.routes.ts:43",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4666,7 +4836,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/electronic-invoicing/provider-configuration/deactivate",
-    "source": "src/module/facturation/routes/factures.routes.ts:47",
+    "source": "src/module/facturation/routes/factures.routes.ts:48",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4683,7 +4853,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/factures/electronic-invoicing/readiness",
-    "source": "src/module/facturation/routes/factures.routes.ts:53",
+    "source": "src/module/facturation/routes/factures.routes.ts:54",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4700,7 +4870,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/workflow/{id}/issue",
-    "source": "src/module/facturation/routes/factures.routes.ts:91",
+    "source": "src/module/facturation/routes/factures.routes.ts:92",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4717,7 +4887,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/workflow/{id}/request-validation",
-    "source": "src/module/facturation/routes/factures.routes.ts:81",
+    "source": "src/module/facturation/routes/factures.routes.ts:82",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4734,7 +4904,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/workflow/{id}/validate",
-    "source": "src/module/facturation/routes/factures.routes.ts:86",
+    "source": "src/module/facturation/routes/factures.routes.ts:87",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4751,7 +4921,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/workflow/drafts",
-    "source": "src/module/facturation/routes/factures.routes.ts:80",
+    "source": "src/module/facturation/routes/factures.routes.ts:81",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4768,7 +4938,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "get",
     "path": "/factures/workflow/eligible-sources",
-    "source": "src/module/facturation/routes/factures.routes.ts:74",
+    "source": "src/module/facturation/routes/factures.routes.ts:75",
     "middleware": [
       "anonymous",
       "authenticateToken",
@@ -4785,7 +4955,7 @@ export const GENERATED_ROUTE_INVENTORY = [
   {
     "method": "post",
     "path": "/factures/workflow/preview",
-    "source": "src/module/facturation/routes/factures.routes.ts:79",
+    "source": "src/module/facturation/routes/factures.routes.ts:80",
     "middleware": [
       "anonymous",
       "authenticateToken",


### PR DESCRIPTION
Closes #625. Invoice and credit-note issuance now captures the exact legal PDF bytes inside the issuing transaction, verifies SHA-256 in PostgreSQL, queues idempotent GED filing, and serves only immutable archived bytes. Includes capability-gated official routes, guarded migration rollback, checksum/immutability/concurrency PostgreSQL proof, mounted route authorization tests, typecheck and production build/OpenAPI/security checks.

## Summary by Sourcery

Preserve and serve immutable, byte-exact invoice and credit-note PDFs through an authorized, idempotent GED archive workflow.

New Features:
- Archive the exact invoice and credit-note PDF bytes produced during legal issuance and file them through the durable GED workflow.
- Expose capability-protected official-document listing, metadata, preview, download, and print-intent routes for invoices and credit notes.

Bug Fixes:
- Prevent issued finance PDFs from being regenerated from potentially changed data or templates, serving only the archived legal bytes instead.

Enhancements:
- Add PostgreSQL-enforced SHA-256, size, byte-pair, immutability, and idempotency guarantees for archived finance PDFs.
- Add guarded migration preflight, verification, and test-only rollback support for the finance archive schema.

Documentation:
- Update route coverage and migration inventory documentation for the new official finance-document endpoints and migration.

Tests:
- Add contract, PostgreSQL integrity, concurrency, and mounted-route authorization tests for finance PDF archiving.