### PR TITLE
test: repair merged delivery snapshot regressions

### DIFF
--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -1561,6 +1561,37 @@ describe("/api/v1/commandes", () => {
         return { rows: [{ id: "1", designation: "Line", code_piece: "P1", quantite: 1, unite: "u", delai_client: null }] };
       }
       if (q.includes("INSERT INTO bon_livraison_ligne (")) return { rows: [] };
+      if (q.includes("FROM public.bon_livraison bl") && q.includes("JOIN public.clients c")) {
+        return { rows: [{
+          numero: "BL-00000001",
+          statut: "DRAFT",
+          client_name: "Client test",
+          commande_numero: "CC-123",
+          affaire_reference: "AFF-7",
+          address_label: null,
+          date_creation: "2026-08-23",
+          date_expedition: null,
+          transporteur: null,
+          tracking_number: null,
+          commentaire_client: null,
+          updated_at: "2026-08-23T00:00:00.000Z",
+        }] };
+      }
+      if (q.includes("FROM public.bon_livraison_ligne line") && q.includes("array_agg")) {
+        return { rows: [{
+          ordre: 1,
+          designation: "Line",
+          code_piece: "P1",
+          quantite: 1,
+          unite: "u",
+          delai_client: null,
+          lot_codes: [],
+        }] };
+      }
+      if (q.includes("to_regprocedure('public.fn_finance_issuer_snapshot")) {
+        return { rows: [{ function_name: null }] };
+      }
+      if (q.includes("FROM public.factureur f")) return { rows: [{ party: {} }] };
       if (q.includes("SELECT id::text AS id, commande_ligne_id::bigint::int AS commande_ligne_id")) {
         return { rows: [{ id: "55555555-5555-4555-8555-555555555555", commande_ligne_id: 1 }] };
       }

--- a/src/__tests__/creation-snapshot.routes.test.ts
+++ b/src/__tests__/creation-snapshot.routes.test.ts
@@ -15,6 +15,7 @@ const aggregates: readonly RouteExpectation[] = [
   { root: "/pieces-techniques/{id}/creation-snapshot" },
   { root: "/affaires/{id}/creation-snapshot", rbac: "requireAffaireCapability(read)" },
   { root: "/stock/articles/{id}/creation-snapshot", rbac: "requireStockCapability(read)" },
+  { root: "/livraisons/{id}/creation-snapshot", rbac: "requireLivraisonCapability(read)" },
 ];
 
 describe("Wave 2 creation-snapshot route contract", () => {


### PR DESCRIPTION
Post-merge full-suite repair: registers the new delivery creation-snapshot surface in the route contract and updates the legacy command-to-delivery repository fixture to model the authoritative snapshot queries. The underlying transaction path is unchanged. Evidence: both complete affected files pass (35/35), typecheck and production build/OpenAPI/security gates pass.

## Summary by Sourcery

Restore merged delivery snapshot test coverage and route-contract validation without changing the underlying transaction flow.

Bug Fixes:
- Repair command route test fixtures to support delivery creation-snapshot queries and prevent merged-suite regressions.

Enhancements:
- Register the delivery creation-snapshot endpoint in the route contract with its required read capability.

Tests:
- Update route and repository test coverage for delivery creation snapshots and authoritative snapshot data.