### PR TITLE
fix: repair creation PDF PostgreSQL queries

### DIFF
--- a/src/__tests__/automatic-creation-pdf-alternate-paths.contract.test.ts
+++ b/src/__tests__/automatic-creation-pdf-alternate-paths.contract.test.ts
@@ -30,6 +30,13 @@ describe("automatic creation PDFs: alternate transaction paths", () => {
     }
   });
 
+  it("derives the supplier line net amount from deployed columns", () => {
+    const snapshotStart = supplier.indexOf("async function buildSupplierPoCreationSnapshot");
+    const snapshot = supplier.slice(snapshotStart, supplier.indexOf("const issuer = await readIssuerParty", snapshotStart));
+    expect(snapshot).toContain("round(round(quantite * prix_unitaire_ht, 2) - round(quantite * prix_unitaire_ht * remise_pct / 100, 2) + frais_ht, 2)::text AS net_ht");
+    expect(snapshot).not.toContain("net_ht::text,");
+  });
+
   it("queues the replenishment conversion snapshot after its transition and before commit", () => {
     const slice = body(replenishment, "export async function repoValidateReplenishmentProposal");
     const queue = slice.indexOf("queueSupplierPurchaseOrderCreationPdfTx");

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -3455,7 +3455,7 @@ async function queueCommandeCreationPdf(
       LEFT JOIN public.clients c ON c.client_id = cc.client_id
       LEFT JOIN public.adresse_facturation af ON af.bill_address_id = cc.adresse_facturation_id
       WHERE cc.id = $1::bigint
-      FOR UPDATE
+      FOR UPDATE OF cc
     `,
     [params.commandeId]
   );

--- a/src/module/commande-client/repository/commande-creation-pdf.contract.test.ts
+++ b/src/module/commande-client/repository/commande-creation-pdf.contract.test.ts
@@ -18,6 +18,15 @@ describe("commande creation PDF transaction contract", () => {
     expect(source).not.toContain("dc.document_path");
   });
 
+  it("locks only the customer-order row when the snapshot header uses optional joins", () => {
+    const snapshotStart = source.indexOf("async function queueCommandeCreationPdf");
+    const snapshot = source.slice(snapshotStart, source.indexOf("const header = headerRes.rows[0]", snapshotStart));
+    expect(snapshot).toContain("LEFT JOIN public.clients c");
+    expect(snapshot).toContain("LEFT JOIN public.adresse_facturation af");
+    expect(snapshot).toContain("FOR UPDATE OF cc");
+    expect(snapshot.match(/FOR UPDATE/g)).toHaveLength(1);
+  });
+
   it("queues manual and generated OF roots inside their transactions, excluding children", () => {
     const manualQueue = productionSource.indexOf("await queueRootOfCreationPdf(client");
     const manualReturn = productionSource.indexOf("return ofId;", manualQueue);

--- a/src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts
+++ b/src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts
@@ -92,7 +92,8 @@ async function buildSupplierPoCreationSnapshot(tx: DbQueryer, commandeId: string
   const lines = await tx.query<Record<string, unknown>>(
     `SELECT position::int, reference_fournisseur AS reference, designation, unite AS unit,
             quantite::text AS quantity, prix_unitaire_ht::text AS unit_price_ht,
-            remise_pct::text AS discount_pct, tva_pct::text AS vat_pct, net_ht::text,
+            remise_pct::text AS discount_pct, tva_pct::text AS vat_pct,
+            round(round(quantite * prix_unitaire_ht, 2) - round(quantite * prix_unitaire_ht * remise_pct / 100, 2) + frais_ht, 2)::text AS net_ht,
             date_besoin::text AS need_date
        FROM public.commande_fournisseur_ligne
       WHERE commande_id = $1::uuid AND statut_ligne = 'ACTIVE'


### PR DESCRIPTION
## Summary\n\nFixes the two PostgreSQL 500s found by the isolated E2E release gate when automatic creation PDF snapshots are queued.\n\n- Locks only commande_client (FOR UPDATE OF cc) in the snapshot header query, preserving the row lock while allowing optional customer/address joins.\n- Calculates supplier-line net HT from actual persisted columns with the same cent rounding used by the supplier-order totals domain function.\n\nCloses #632.\n\n## Evidence\n\n- Focused Vitest: 2 files, 10 tests passed.\n- 
pm run build passed (route inventory, typecheck, OpenAPI contract, production-data boundary).\n- Real PostgreSQL 16 isolated schema probe passed both corrected queries; the temporary container was removed immediately after the probe.\n\n## Root cause\n\nThe release environment returned PostgreSQL

## Summary by Sourcery

Repair PostgreSQL creation PDF snapshot queries to prevent release-gate failures.

Bug Fixes:
- Fix PostgreSQL errors when queuing automatic creation PDF snapshots by restricting header-row locking to the customer order and calculating supplier-line net amounts from persisted pricing fields.

Tests:
- Add contract coverage for scoped row locking and supplier net-amount calculation in creation PDF snapshots.