### PR TITLE
fix(ged): permit authoritative PDF audit events

### DIFF
--- a/db/patches/20260823_ged_authoritative_pdf_access_events_634.sql
+++ b/db/patches/20260823_ged_authoritative_pdf_access_events_634.sql
@@ -1,0 +1,55 @@
+-- #634 — align GED's durable audit-event whitelist with authoritative PDF flows.
+-- This is deliberately additive: all SOL-11 antivirus and historical GED events
+-- remain valid, and no existing audit evidence is rewritten or removed.
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF to_regclass('public.ged_access_events') IS NULL THEN
+    RAISE EXCEPTION 'GED_AUTHORITATIVE_EVENTS_634_AUDIT_TABLE_MISSING';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.ged_access_events'::regclass
+       AND conname = 'ged_access_events_event_type_check'
+       AND contype = 'c'
+  ) THEN
+    RAISE EXCEPTION 'GED_AUTHORITATIVE_EVENTS_634_EVENT_TYPE_CONSTRAINT_MISSING';
+  END IF;
+  -- A non-validated/custom prior constraint could have admitted evidence which
+  -- the canonical contract does not understand. Refuse to make that evidence
+  -- unrepresentable rather than silently changing its meaning.
+  IF EXISTS (
+    SELECT 1 FROM public.ged_access_events
+     WHERE event_type NOT IN (
+       'UPLOAD', 'READ', 'DOWNLOAD', 'SUBMIT', 'APPROVE', 'REJECT',
+       'PUBLISH', 'OBSOLETE', 'ARCHIVE', 'CHECKOUT', 'CHECKIN',
+       'HOLD_PLACED', 'HOLD_RELEASED', 'INTEGRITY_FAILURE',
+       'SCAN_PENDING', 'SCAN_CLEAN', 'SCAN_INFECTED', 'SCAN_FAILED',
+       'QUARANTINED', 'QUARANTINE_RELEASED', 'QUARANTINE_DELETED',
+       'AUTHORITATIVE_PDF_ARCHIVED', 'AUTHORITATIVE_PDF_PREVIEWED',
+       'AUTHORITATIVE_PDF_DOWNLOADED', 'AUTHORITATIVE_PDF_PRINT_INTENT',
+       'AUTHORITATIVE_PDF_SENT', 'CREATION_SNAPSHOT_ARCHIVED'
+     )
+  ) THEN
+    RAISE EXCEPTION 'GED_AUTHORITATIVE_EVENTS_634_UNKNOWN_EXISTING_EVENT_TYPE';
+  END IF;
+END
+$guard$;
+
+ALTER TABLE public.ged_access_events
+  DROP CONSTRAINT IF EXISTS ged_access_events_event_type_check;
+ALTER TABLE public.ged_access_events
+  ADD CONSTRAINT ged_access_events_event_type_check CHECK (event_type IN (
+    'UPLOAD', 'READ', 'DOWNLOAD', 'SUBMIT', 'APPROVE', 'REJECT',
+    'PUBLISH', 'OBSOLETE', 'ARCHIVE', 'CHECKOUT', 'CHECKIN',
+    'HOLD_PLACED', 'HOLD_RELEASED', 'INTEGRITY_FAILURE',
+    'SCAN_PENDING', 'SCAN_CLEAN', 'SCAN_INFECTED', 'SCAN_FAILED',
+    'QUARANTINED', 'QUARANTINE_RELEASED', 'QUARANTINE_DELETED',
+    'AUTHORITATIVE_PDF_ARCHIVED', 'AUTHORITATIVE_PDF_PREVIEWED',
+    'AUTHORITATIVE_PDF_DOWNLOADED', 'AUTHORITATIVE_PDF_PRINT_INTENT',
+    'AUTHORITATIVE_PDF_SENT', 'CREATION_SNAPSHOT_ARCHIVED'
+  ));
+
+COMMIT;

--- a/db/patches/support/20260823_ged_authoritative_pdf_access_events_634.preflight.sql
+++ b/db/patches/support/20260823_ged_authoritative_pdf_access_events_634.preflight.sql
@@ -1,0 +1,55 @@
+-- #634 preflight — read-only and safe before the deployment window.
+BEGIN TRANSACTION READ ONLY;
+
+DO $guard$
+BEGIN
+  IF to_regclass('public.ged_access_events') IS NULL THEN
+    RAISE EXCEPTION 'GED_AUTHORITATIVE_EVENTS_634_PREFLIGHT_AUDIT_TABLE_MISSING';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.ged_access_events'::regclass
+       AND conname = 'ged_access_events_event_type_check' AND contype = 'c'
+  ) THEN
+    RAISE EXCEPTION 'GED_AUTHORITATIVE_EVENTS_634_PREFLIGHT_EVENT_TYPE_CONSTRAINT_MISSING';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.ged_access_events
+     WHERE event_type NOT IN (
+       'UPLOAD', 'READ', 'DOWNLOAD', 'SUBMIT', 'APPROVE', 'REJECT',
+       'PUBLISH', 'OBSOLETE', 'ARCHIVE', 'CHECKOUT', 'CHECKIN',
+       'HOLD_PLACED', 'HOLD_RELEASED', 'INTEGRITY_FAILURE',
+       'SCAN_PENDING', 'SCAN_CLEAN', 'SCAN_INFECTED', 'SCAN_FAILED',
+       'QUARANTINED', 'QUARANTINE_RELEASED', 'QUARANTINE_DELETED',
+       'AUTHORITATIVE_PDF_ARCHIVED', 'AUTHORITATIVE_PDF_PREVIEWED',
+       'AUTHORITATIVE_PDF_DOWNLOADED', 'AUTHORITATIVE_PDF_PRINT_INTENT',
+       'AUTHORITATIVE_PDF_SENT', 'CREATION_SNAPSHOT_ARCHIVED'
+     )
+  ) THEN
+    RAISE EXCEPTION 'GED_AUTHORITATIVE_EVENTS_634_PREFLIGHT_UNKNOWN_EXISTING_EVENT_TYPE';
+  END IF;
+END
+$guard$;
+
+SELECT
+  to_regclass('public.ged_access_events') IS NOT NULL AS audit_table_present,
+  EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.ged_access_events'::regclass
+       AND conname = 'ged_access_events_event_type_check' AND contype = 'c'
+  ) AS event_type_constraint_present,
+  NOT EXISTS (
+    SELECT 1 FROM public.ged_access_events
+     WHERE event_type NOT IN (
+       'UPLOAD', 'READ', 'DOWNLOAD', 'SUBMIT', 'APPROVE', 'REJECT',
+       'PUBLISH', 'OBSOLETE', 'ARCHIVE', 'CHECKOUT', 'CHECKIN',
+       'HOLD_PLACED', 'HOLD_RELEASED', 'INTEGRITY_FAILURE',
+       'SCAN_PENDING', 'SCAN_CLEAN', 'SCAN_INFECTED', 'SCAN_FAILED',
+       'QUARANTINED', 'QUARANTINE_RELEASED', 'QUARANTINE_DELETED',
+       'AUTHORITATIVE_PDF_ARCHIVED', 'AUTHORITATIVE_PDF_PREVIEWED',
+       'AUTHORITATIVE_PDF_DOWNLOADED', 'AUTHORITATIVE_PDF_PRINT_INTENT',
+       'AUTHORITATIVE_PDF_SENT', 'CREATION_SNAPSHOT_ARCHIVED'
+     )
+  ) AS existing_evidence_representable;
+
+COMMIT;

--- a/db/patches/support/20260823_ged_authoritative_pdf_access_events_634.rollback.sql
+++ b/db/patches/support/20260823_ged_authoritative_pdf_access_events_634.rollback.sql
@@ -1,0 +1,36 @@
+-- #634 rollback is strictly for the isolated migration rehearsal. It refuses
+-- to discard any authoritative-PDF audit evidence; restore the coherent
+-- database/GED backup to roll back a database that contains such evidence.
+DO $guard$
+BEGIN
+  IF current_database() <> 'cerp_test'
+     OR current_setting('cerp.migration_rehearsal', true) IS DISTINCT FROM '1' THEN
+    RAISE EXCEPTION 'GED_AUTHORITATIVE_EVENTS_634_ROLLBACK_REFUSED_OUTSIDE_REHEARSAL';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.ged_access_events
+     WHERE event_type IN (
+       'AUTHORITATIVE_PDF_ARCHIVED', 'AUTHORITATIVE_PDF_PREVIEWED',
+       'AUTHORITATIVE_PDF_DOWNLOADED', 'AUTHORITATIVE_PDF_PRINT_INTENT',
+       'AUTHORITATIVE_PDF_SENT', 'CREATION_SNAPSHOT_ARCHIVED'
+     )
+  ) THEN
+    RAISE EXCEPTION 'GED_AUTHORITATIVE_EVENTS_634_ROLLBACK_REFUSED_AUTHORITATIVE_EVIDENCE_EXISTS';
+  END IF;
+END
+$guard$;
+
+BEGIN;
+
+ALTER TABLE public.ged_access_events
+  DROP CONSTRAINT IF EXISTS ged_access_events_event_type_check;
+ALTER TABLE public.ged_access_events
+  ADD CONSTRAINT ged_access_events_event_type_check CHECK (event_type IN (
+    'UPLOAD', 'READ', 'DOWNLOAD', 'SUBMIT', 'APPROVE', 'REJECT',
+    'PUBLISH', 'OBSOLETE', 'ARCHIVE', 'CHECKOUT', 'CHECKIN',
+    'HOLD_PLACED', 'HOLD_RELEASED', 'INTEGRITY_FAILURE',
+    'SCAN_PENDING', 'SCAN_CLEAN', 'SCAN_INFECTED', 'SCAN_FAILED',
+    'QUARANTINED', 'QUARANTINE_RELEASED', 'QUARANTINE_DELETED'
+  ));
+
+COMMIT;

--- a/db/patches/support/20260823_ged_authoritative_pdf_access_events_634.verify.sql
+++ b/db/patches/support/20260823_ged_authoritative_pdf_access_events_634.verify.sql
@@ -1,0 +1,53 @@
+-- #634 verification — read-only proof that all historical and new audit events are allowed.
+BEGIN TRANSACTION READ ONLY;
+
+DO $guard$
+DECLARE
+  definition text;
+  required_event text;
+BEGIN
+  SELECT pg_get_constraintdef(oid) INTO definition
+    FROM pg_constraint
+   WHERE conrelid = 'public.ged_access_events'::regclass
+     AND conname = 'ged_access_events_event_type_check' AND contype = 'c';
+  IF definition IS NULL THEN
+    RAISE EXCEPTION 'GED_AUTHORITATIVE_EVENTS_634_VERIFY_EVENT_TYPE_CONSTRAINT_MISSING';
+  END IF;
+  FOREACH required_event IN ARRAY ARRAY[
+    'UPLOAD', 'READ', 'DOWNLOAD', 'SUBMIT', 'APPROVE', 'REJECT',
+    'PUBLISH', 'OBSOLETE', 'ARCHIVE', 'CHECKOUT', 'CHECKIN',
+    'HOLD_PLACED', 'HOLD_RELEASED', 'INTEGRITY_FAILURE',
+    'SCAN_PENDING', 'SCAN_CLEAN', 'SCAN_INFECTED', 'SCAN_FAILED',
+    'QUARANTINED', 'QUARANTINE_RELEASED', 'QUARANTINE_DELETED',
+    'AUTHORITATIVE_PDF_ARCHIVED', 'AUTHORITATIVE_PDF_PREVIEWED',
+    'AUTHORITATIVE_PDF_DOWNLOADED', 'AUTHORITATIVE_PDF_PRINT_INTENT',
+    'AUTHORITATIVE_PDF_SENT', 'CREATION_SNAPSHOT_ARCHIVED'
+  ] LOOP
+    IF position(quote_literal(required_event) IN definition) = 0 THEN
+      RAISE EXCEPTION 'GED_AUTHORITATIVE_EVENTS_634_VERIFY_EVENT_TYPE_MISSING:%', required_event;
+    END IF;
+  END LOOP;
+END
+$guard$;
+
+SELECT
+  NOT EXISTS (
+    SELECT 1 FROM public.ged_access_events
+     WHERE event_type NOT IN (
+       'UPLOAD', 'READ', 'DOWNLOAD', 'SUBMIT', 'APPROVE', 'REJECT',
+       'PUBLISH', 'OBSOLETE', 'ARCHIVE', 'CHECKOUT', 'CHECKIN',
+       'HOLD_PLACED', 'HOLD_RELEASED', 'INTEGRITY_FAILURE',
+       'SCAN_PENDING', 'SCAN_CLEAN', 'SCAN_INFECTED', 'SCAN_FAILED',
+       'QUARANTINED', 'QUARANTINE_RELEASED', 'QUARANTINE_DELETED',
+       'AUTHORITATIVE_PDF_ARCHIVED', 'AUTHORITATIVE_PDF_PREVIEWED',
+       'AUTHORITATIVE_PDF_DOWNLOADED', 'AUTHORITATIVE_PDF_PRINT_INTENT',
+       'AUTHORITATIVE_PDF_SENT', 'CREATION_SNAPSHOT_ARCHIVED'
+     )
+  ) AS all_audit_evidence_representable,
+  EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'public.ged_access_events'::regclass
+       AND conname = 'ged_access_events_event_type_check' AND contype = 'c'
+  ) AS event_type_constraint_present;
+
+COMMIT;

--- a/src/__tests__/ged-authoritative-pdf-access-events-634.migration.test.ts
+++ b/src/__tests__/ged-authoritative-pdf-access-events-634.migration.test.ts
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const base = "20260823_ged_authoritative_pdf_access_events_634";
+const patch = fs.readFileSync(path.join(root, "db", "patches", `${base}.sql`), "utf8");
+const support = (kind: "preflight" | "verify" | "rollback") =>
+  fs.readFileSync(path.join(root, "db", "patches", "support", `${base}.${kind}.sql`), "utf8");
+
+const legacyEvents = [
+  "UPLOAD", "READ", "DOWNLOAD", "SUBMIT", "APPROVE", "REJECT", "PUBLISH", "OBSOLETE", "ARCHIVE", "CHECKOUT", "CHECKIN",
+  "HOLD_PLACED", "HOLD_RELEASED", "INTEGRITY_FAILURE", "SCAN_PENDING", "SCAN_CLEAN", "SCAN_INFECTED", "SCAN_FAILED",
+  "QUARANTINED", "QUARANTINE_RELEASED", "QUARANTINE_DELETED",
+];
+const authoritativeEvents = [
+  "AUTHORITATIVE_PDF_ARCHIVED", "AUTHORITATIVE_PDF_PREVIEWED", "AUTHORITATIVE_PDF_DOWNLOADED",
+  "AUTHORITATIVE_PDF_PRINT_INTENT", "AUTHORITATIVE_PDF_SENT", "CREATION_SNAPSHOT_ARCHIVED",
+];
+
+describe("#634 GED authoritative-PDF audit-event migration contract", () => {
+  it("is additive over every historical GED/antivirus event and includes every source audit event", () => {
+    for (const event of [...legacyEvents, ...authoritativeEvents]) expect(patch).toContain(`'${event}'`);
+    expect(authoritativeEvents).toHaveLength(6);
+    expect(patch).toContain("GED_AUTHORITATIVE_EVENTS_634_UNKNOWN_EXISTING_EVENT_TYPE");
+    expect(patch).toContain("DROP CONSTRAINT IF EXISTS ged_access_events_event_type_check");
+  });
+
+  it("ships read-only preflight/verification plus a non-lossy rehearsal-only rollback", () => {
+    for (const sql of [support("preflight"), support("verify")]) {
+      expect(sql).toContain("BEGIN TRANSACTION READ ONLY");
+      for (const event of [...legacyEvents, ...authoritativeEvents]) expect(sql).toContain(`'${event}'`);
+    }
+    const rollback = support("rollback");
+    expect(rollback).toContain("current_database() <> 'cerp_test'");
+    expect(rollback).toContain("cerp.migration_rehearsal");
+    expect(rollback).toContain("GED_AUTHORITATIVE_EVENTS_634_ROLLBACK_REFUSED_AUTHORITATIVE_EVIDENCE_EXISTS");
+    for (const event of legacyEvents) expect(rollback).toContain(`'${event}'`);
+    for (const event of authoritativeEvents) expect(rollback).toContain(`'${event}'`);
+  });
+});

--- a/src/__tests__/ged-authoritative-pdf-access-events-634.postgres.integration.test.ts
+++ b/src/__tests__/ged-authoritative-pdf-access-events-634.postgres.integration.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const integrationUrl = process.env.GED_AUTHORITATIVE_EVENTS_634_TEST_DATABASE_URL;
+const suite = integrationUrl ? describe : describe.skip;
+const root = process.cwd();
+const base = "20260823_ged_authoritative_pdf_access_events_634";
+const oldEvents = [
+  "UPLOAD", "READ", "DOWNLOAD", "SUBMIT", "APPROVE", "REJECT", "PUBLISH", "OBSOLETE", "ARCHIVE", "CHECKOUT", "CHECKIN",
+  "HOLD_PLACED", "HOLD_RELEASED", "INTEGRITY_FAILURE", "SCAN_PENDING", "SCAN_CLEAN", "SCAN_INFECTED", "SCAN_FAILED",
+  "QUARANTINED", "QUARANTINE_RELEASED", "QUARANTINE_DELETED",
+];
+const newEvents = [
+  "AUTHORITATIVE_PDF_ARCHIVED", "AUTHORITATIVE_PDF_PREVIEWED", "AUTHORITATIVE_PDF_DOWNLOADED",
+  "AUTHORITATIVE_PDF_PRINT_INTENT", "AUTHORITATIVE_PDF_SENT", "CREATION_SNAPSHOT_ARCHIVED",
+];
+
+suite("#634 GED authoritative-PDF audit events: PostgreSQL migration", () => {
+  let client: import("pg").Client;
+  let patch: string;
+  let preflight: string;
+  let verify: string;
+  let rollback: string;
+
+  beforeAll(async () => {
+    const pg = await import("pg");
+    client = new pg.Client({ connectionString: integrationUrl });
+    await client.connect();
+    const database = await client.query<{ current_database: string }>("SELECT current_database()");
+    if (!/test|sandbox|local/i.test(database.rows[0]?.current_database ?? "")) {
+      throw new Error("GED_AUTHORITATIVE_EVENTS_634_TEST_DATABASE_URL must target a test/local/sandbox database");
+    }
+    [patch, preflight, verify, rollback] = await Promise.all([
+      fs.readFile(path.join(root, "db", "patches", `${base}.sql`), "utf8"),
+      fs.readFile(path.join(root, "db", "patches", "support", `${base}.preflight.sql`), "utf8"),
+      fs.readFile(path.join(root, "db", "patches", "support", `${base}.verify.sql`), "utf8"),
+      fs.readFile(path.join(root, "db", "patches", "support", `${base}.rollback.sql`), "utf8"),
+    ]);
+  });
+
+  afterAll(async () => { await client?.end(); });
+
+  it("applies and replays without losing legacy evidence, accepts all six source events, rejects unknown values, and restores the SOL-11 constraint on safe rollback", async () => {
+    await client.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+    await client.query(`
+      CREATE TABLE public.ged_access_events (id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY, event_type text NOT NULL);
+      ALTER TABLE public.ged_access_events ADD CONSTRAINT ged_access_events_event_type_check CHECK (event_type IN (${oldEvents.map((event) => `'${event}'`).join(", ")}));
+      INSERT INTO public.ged_access_events(event_type) VALUES ('SCAN_CLEAN'), ('QUARANTINED');
+    `);
+
+    await expect(client.query(preflight)).resolves.toBeDefined();
+    await client.query(patch);
+    await client.query(patch); // SQL itself is safe if a rehearsal invokes it again.
+    await expect(client.query(verify)).resolves.toBeDefined();
+    expect((await client.query("SELECT event_type FROM public.ged_access_events ORDER BY id")).rows.map((row) => row.event_type)).toEqual(["SCAN_CLEAN", "QUARANTINED"]);
+
+    for (const event of newEvents) await expect(client.query("INSERT INTO public.ged_access_events(event_type) VALUES ($1)", [event])).resolves.toBeDefined();
+    await expect(client.query("INSERT INTO public.ged_access_events(event_type) VALUES ('UNRECOGNIZED_AUDIT_EVENT')")).rejects.toMatchObject({ code: "23514" });
+
+    await client.query("SET cerp.migration_rehearsal = '1'");
+    await expect(client.query(rollback)).rejects.toMatchObject({ message: expect.stringContaining("GED_AUTHORITATIVE_EVENTS_634_ROLLBACK_REFUSED_AUTHORITATIVE_EVIDENCE_EXISTS") });
+    await client.query("DELETE FROM public.ged_access_events WHERE event_type = ANY($1::text[])", [newEvents]);
+    await client.query(rollback);
+    for (const event of oldEvents) await expect(client.query("INSERT INTO public.ged_access_events(event_type) VALUES ($1)", [event])).resolves.toBeDefined();
+    await expect(client.query("INSERT INTO public.ged_access_events(event_type) VALUES ('AUTHORITATIVE_PDF_ARCHIVED')")).rejects.toMatchObject({ code: "23514" });
+  });
+});


### PR DESCRIPTION
Closes #634

## Release fix

Adds ordered patch `20260823_ged_authoritative_pdf_access_events_634.sql`, extending `ged_access_events_event_type_check` without removing any of the 21 existing GED/SOL-11 antivirus event types.

New accepted runtime values are:

- `AUTHORITATIVE_PDF_ARCHIVED`
- `AUTHORITATIVE_PDF_PREVIEWED`
- `AUTHORITATIVE_PDF_DOWNLOADED`
- `AUTHORITATIVE_PDF_PRINT_INTENT`
- `AUTHORITATIVE_PDF_SENT`
- `CREATION_SNAPSHOT_ARCHIVED`

The patch fail-closes if legacy evidence contains an unrepresentable event. It includes read-only preflight/verification support and a rehearsal-only rollback that refuses if new audit evidence exists.

## Validation

- `corepack pnpm vitest run src/__tests__/ged-authoritative-pdf-access-events-634.migration.test.ts`
- Real PostgreSQL 17 integration: patch apply + direct replay, legacy evidence preservation, all six accepts, unknown value rejects with `23514`, rollback refusal with new evidence, safe rollback restores legacy constraint
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `node scripts/db-patches.js status` and `node scripts/db-patches.js up --dry-run` against disposable PostgreSQL
- `node scripts/migrations/release-gate.js inventory`

## Summary by Sourcery

Extend GED audit-event validation to support authoritative-PDF workflows without compromising historical evidence.

New Features:
- Permit six authoritative-PDF and creation-snapshot audit event types in GED access-event validation.

Bug Fixes:
- Prevent authoritative-PDF audit flows from being rejected by the GED event-type constraint while preserving all existing audit evidence and event types.

Enhancements:
- Add read-only migration preflight and verification checks, plus a non-lossy rollback limited to migration rehearsals.

Tests:
- Add migration contract and PostgreSQL integration coverage for legacy-event preservation, new-event acceptance, unknown-event rejection, and safe rollback behavior.