### PR TITLE
fix(pdf): qualify archive read projections

### DIFF
--- a/src/__tests__/authoritative-document.domain.test.ts
+++ b/src/__tests__/authoritative-document.domain.test.ts
@@ -140,6 +140,7 @@ describe("authoritative PDF archive foundation (#612)", () => {
     await repoListAuthoritativePdfs(spyTx, "commande-client", "123", "CUSTOMER_ORDER_ACKNOWLEDGEMENT");
     await repoGetAuthoritativePdf(spyTx, "commande-client", "123", "11111111-1111-4111-8111-111111111111", "CUSTOMER_ORDER_ACKNOWLEDGEMENT");
     await repoFindLatestAuthoritativePdfForEntity(spyTx, "commande-client", "123", "CUSTOMER_ORDER_ACKNOWLEDGEMENT");
+    await repoClaimAuthoritativePdfWork(spyTx, "worker-1", 8);
     expect(calls[0]?.[0]).toContain("a.document_kind = $3");
     expect(calls[0]?.[1]).toEqual(["commande-client", "123", "CUSTOMER_ORDER_ACKNOWLEDGEMENT"]);
     expect(calls[1]?.[0]).toContain("a.document_kind = $4");
@@ -147,6 +148,13 @@ describe("authoritative PDF archive foundation (#612)", () => {
     expect(calls[2]?.[0]).toContain("a.document_kind = $3");
     expect(calls[2]?.[0]).not.toContain("$3::text IS NULL");
     expect(calls[2]?.[1]).toEqual(["commande-client", "123", "CUSTOMER_ORDER_ACKNOWLEDGEMENT"]);
+    for (const [sql] of calls) {
+      if (sql.includes("JOIN public.authoritative_pdf_archive_outbox")) {
+        expect(sql).toContain("a.id::text");
+        expect(sql).toContain("a.created_by");
+        expect(sql).not.toContain("SELECT id::text");
+      }
+    }
   });
 
   it("carries the exact fresh claim token from the outbox claim into the worker item", async () => {

--- a/src/__tests__/finance-ged-archive-625.postgres.integration.test.ts
+++ b/src/__tests__/finance-ged-archive-625.postgres.integration.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import { repoFindLatestAuthoritativePdfForEntity, repoGetAuthoritativePdf, repoListAuthoritativePdfs } from "../shared/authoritative-documents/authoritative-document.repository";
+
 const integrationUrl = process.env.FINANCE_GED_ARCHIVE_TEST_DATABASE_URL;
 const suite = integrationUrl ? describe : describe.skip;
 const root = process.cwd();
@@ -41,8 +43,18 @@ suite("#625 finance GED archive PostgreSQL integrity", () => {
       CREATE TABLE public.ged_documents (id uuid PRIMARY KEY DEFAULT gen_random_uuid());
       CREATE TABLE public.ged_document_versions (id uuid PRIMARY KEY DEFAULT gen_random_uuid());
       CREATE TABLE public.ged_document_links (id uuid PRIMARY KEY DEFAULT gen_random_uuid());
+      CREATE TABLE public.ged_access_events (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(), document_id uuid NOT NULL,
+        version_id uuid NULL, event_type text NOT NULL,
+        actor_user_id integer NULL, created_at timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT ged_access_events_event_type_check CHECK (event_type IN ('READ'))
+      );
     `);
-    for (const file of ["20260823_authoritative_pdf_archive_612.sql", "20260823_finance_ged_archive_625.sql"]) {
+    for (const file of [
+      "20260823_authoritative_pdf_archive_612.sql",
+      "20260823_finance_ged_archive_625.sql",
+      "20260823_ged_authoritative_pdf_access_events_634.sql",
+    ]) {
       await bootstrap.query(await fs.readFile(path.join(root, "db/patches", file), "utf8"));
     }
     await bootstrap.end();
@@ -51,6 +63,7 @@ suite("#625 finance GED archive PostgreSQL integrity", () => {
 
   beforeEach(async () => {
     await pool.query("TRUNCATE public.authoritative_pdf_archive_outbox, public.authoritative_pdf_archives CASCADE");
+    await pool.query("TRUNCATE public.ged_access_events, public.ged_document_versions, public.ged_documents CASCADE");
   });
 
   afterAll(async () => { await pool?.end(); });
@@ -78,5 +91,48 @@ suite("#625 finance GED archive PostgreSQL integrity", () => {
       const row = await pool.query("SELECT encode(exact_pdf_bytes, 'hex') AS bytes, exact_pdf_sha256, exact_pdf_size_bytes::int AS size FROM public.authoritative_pdf_archives WHERE idempotency_key = $1", ["finance:concurrent"]);
       expect(row.rows[0]).toMatchObject({ bytes: pdf.toString("hex"), exact_pdf_sha256: pdfSha, size: pdf.byteLength });
     } finally { one.release(); two.release(); }
+  });
+
+  it("reads an archived PDF with its exact bytes and durable state through every joined repository lookup", async () => {
+    const document = await pool.query<{ id: string }>("INSERT INTO public.ged_documents DEFAULT VALUES RETURNING id::text");
+    const version = await pool.query<{ id: string }>("INSERT INTO public.ged_document_versions DEFAULT VALUES RETURNING id::text");
+    const created = await pool.query<{ id: string }>(`
+      INSERT INTO public.authoritative_pdf_archives
+        (entity_type, entity_id, document_kind, document_version, render_version, idempotency_key,
+         title, original_name, source_snapshot, source_revision, snapshot_sha256,
+         pdf_sha256, pdf_size_bytes, exact_pdf_bytes, exact_pdf_sha256, exact_pdf_size_bytes,
+         ged_document_id, ged_version_id, archived_at, created_by)
+      VALUES ('devis', '42', 'CUSTOMER_QUOTE', 1, 'devis-issued-v1', 'devis:42:issued:v1',
+              'Devis DV-42', 'DEVIS-42-v1.pdf', '{"id":42}'::jsonb, 'DV-42:1', repeat('b', 64),
+              $1, $2, $3, $1, $2, $4::uuid, $5::uuid, now(), 1)
+      RETURNING id::text
+    `, [pdfSha, pdf.byteLength, pdf, document.rows[0]!.id, version.rows[0]!.id]);
+    const archiveId = created.rows[0]!.id;
+    await pool.query(
+      `INSERT INTO public.authoritative_pdf_archive_outbox (archive_id, event_key, status, archived_at)
+       VALUES ($1::uuid, 'authoritative-pdf:devis:42:issued:v1', 'ARCHIVED', now())`,
+      [archiveId]
+    );
+
+    const listed = await repoListAuthoritativePdfs(pool, "devis", "42", "CUSTOMER_QUOTE");
+    const fetched = await repoGetAuthoritativePdf(pool, "devis", "42", archiveId, "CUSTOMER_QUOTE");
+    const latest = await repoFindLatestAuthoritativePdfForEntity(pool, "devis", "42", "CUSTOMER_QUOTE");
+
+    for (const record of [listed[0], fetched, latest]) {
+      expect(record).toMatchObject({
+        id: archiveId, state: "ARCHIVED", entityType: "devis", entityId: "42",
+        documentKind: "CUSTOMER_QUOTE", pdfSha256: pdfSha, pdfSizeBytes: pdf.byteLength,
+        exactPdfSha256: pdfSha, exactPdfSizeBytes: pdf.byteLength,
+        gedDocumentId: document.rows[0]!.id, gedVersionId: version.rows[0]!.id,
+      });
+      expect(record?.exactPdfBytes).toEqual(pdf);
+    }
+    await expect(repoGetAuthoritativePdf(pool, "devis", "42", archiveId, "OTHER_DOCUMENT")).resolves.toBeNull();
+
+    await expect(pool.query(
+      `INSERT INTO public.ged_access_events (document_id, version_id, event_type, actor_user_id)
+       VALUES ($1::uuid, $2::uuid, 'AUTHORITATIVE_PDF_PREVIEWED', 1)`,
+      [document.rows[0]!.id, version.rows[0]!.id]
+    )).resolves.toMatchObject({ rowCount: 1 });
   });
 });

--- a/src/shared/authoritative-documents/authoritative-document.repository.ts
+++ b/src/shared/authoritative-documents/authoritative-document.repository.ts
@@ -32,6 +32,16 @@ const ARCHIVE_COLUMNS = `id::text, entity_type, entity_id, document_kind, docume
   pdf_size_bytes::text, exact_pdf_bytes, exact_pdf_sha256, exact_pdf_size_bytes::text,
   ged_document_id::text, ged_version_id::text, archived_at::text, created_at::text, created_by`;
 
+/**
+ * Read queries join the archive to its durable outbox row. Keep the direct
+ * projection above for INSERT RETURNING and single-table lookups, while
+ * qualifying every archive field whenever another relation is in scope.
+ */
+const archiveColumnsFor = (tableAlias: string): string => ARCHIVE_COLUMNS
+  .split(/,\s*/u)
+  .map((column) => `${tableAlias}.${column}`)
+  .join(", ");
+
 /** Insert is intentionally idempotent; a repeated create transaction returns the same job. */
 export async function repoQueueAuthoritativePdf(
   tx: Pick<PoolClient, "query">,
@@ -127,7 +137,7 @@ export async function repoClaimAuthoritativePdfWork(
          FROM candidate WHERE o.id = candidate.id
        RETURNING o.id::text AS outbox_id, o.archive_id, o.claim_token::text AS claim_token
      )
-     SELECT c.outbox_id, c.claim_token, ${ARCHIVE_COLUMNS}
+     SELECT c.outbox_id, c.claim_token, ${archiveColumnsFor("a")}
        FROM claimed c JOIN public.authoritative_pdf_archives a ON a.id = c.archive_id`,
     [limit, workerId]
   );
@@ -195,7 +205,7 @@ export async function repoListAuthoritativePdfs(
   documentKind: string
 ): Promise<AuthoritativePdfListedRecord[]> {
   const result = await tx.query<ArchiveRow & { state: AuthoritativePdfListedRecord["state"] }>(
-    `SELECT ${ARCHIVE_COLUMNS}, o.status::text AS state
+    `SELECT ${archiveColumnsFor("a")}, o.status::text AS state
       FROM public.authoritative_pdf_archives a
        JOIN public.authoritative_pdf_archive_outbox o ON o.archive_id = a.id
       WHERE a.entity_type = $1 AND a.entity_id = $2 AND a.document_kind = $3
@@ -213,7 +223,7 @@ export async function repoGetAuthoritativePdf(
   documentKind: string
 ): Promise<AuthoritativePdfListedRecord | null> {
   const result = await tx.query<ArchiveRow & { state: AuthoritativePdfListedRecord["state"] }>(
-    `SELECT ${ARCHIVE_COLUMNS}, o.status::text AS state
+    `SELECT ${archiveColumnsFor("a")}, o.status::text AS state
        FROM public.authoritative_pdf_archives a
        JOIN public.authoritative_pdf_archive_outbox o ON o.archive_id = a.id
       WHERE a.id = $1::uuid AND a.entity_type = $2 AND a.entity_id = $3 AND a.document_kind = $4`,
@@ -248,7 +258,7 @@ export async function repoFindLatestAuthoritativePdfForEntity(
   documentKind: string
 ): Promise<AuthoritativePdfListedRecord | null> {
   const result = await tx.query<ArchiveRow & { state: AuthoritativePdfListedRecord["state"] }>(
-    `SELECT ${ARCHIVE_COLUMNS}, o.status::text AS state
+    `SELECT ${archiveColumnsFor("a")}, o.status::text AS state
       FROM public.authoritative_pdf_archives a
        JOIN public.authoritative_pdf_archive_outbox o ON o.archive_id = a.id
       WHERE a.entity_type = $1 AND a.entity_id = $2 AND a.document_kind = $3


### PR DESCRIPTION
Closes #636. Cause: the archive projection was unqualified in joins with the durable outbox; PostgreSQL rejects shared column names such as id with SQLSTATE 42702. Fix: qualify archive fields only in joined claim/list/get/latest reads, preserving direct selects and INSERT RETURNING. Coverage: contract assertions plus a real isolated PostgreSQL test after the #634 GED audit-event migration; it proves list/get/latest return ARCHIVED state, GED IDs, and exact archived bytes. Verified: focused contract 16 passing; PostgreSQL integration 4 passing; typecheck; production build.

## Summary by Sourcery

Qualify authoritative PDF archive fields in joined read projections while preserving existing direct projections and returning reliable archived document data.

Bug Fixes:
- Prevent PostgreSQL ambiguous-column errors when reading archived PDFs through joins with the durable outbox.

Tests:
- Add contract coverage for qualified archive projections and PostgreSQL integration coverage for claim and joined archive lookups, including durable state, GED identifiers, and exact PDF bytes.