### PR TITLE
fix: lock order-launch creation PDF sources safely

### DIFF
--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -4728,9 +4728,9 @@ async function queueAffaireCreationPdf(
              a.devis_id::text AS devis_id
         FROM public.affaire a
         LEFT JOIN public.clients c ON c.client_id = a.client_id
-        LEFT JOIN public.commande_client cc ON cc.id = a.commande_id
+       LEFT JOIN public.commande_client cc ON cc.id = a.commande_id
        WHERE a.id = $1::bigint
-       FOR UPDATE
+       FOR UPDATE OF a
     `,
     [params.affaireId]
   );

--- a/src/module/commande-client/repository/commande-creation-pdf.contract.test.ts
+++ b/src/module/commande-client/repository/commande-creation-pdf.contract.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 const source = fs.readFileSync(path.join(__dirname, "commande-client.repository.ts"), "utf8");
 const productionSource = fs.readFileSync(path.join(__dirname, "../../production/repository/production.repository.ts"), "utf8");
 const generationSource = fs.readFileSync(path.join(__dirname, "../../production/repository/production-generation.repository.ts"), "utf8");
+const ofCreationPdfSource = fs.readFileSync(path.join(__dirname, "../../production/domain/of-creation-pdf.ts"), "utf8");
 
 describe("commande creation PDF transaction contract", () => {
   it("queues the sanitized internal snapshot before the create transaction returns", () => {
@@ -58,5 +59,18 @@ describe("commande creation PDF transaction contract", () => {
     expect(source).toContain('idempotencyKey: `affaire:${affaire.id}:creation:v1`');
     // Existing mappings return before any create helper call, so a replay has no queue side effect.
     expect(source).toContain("if (existingLivraisons.length >= requestedLivraisonCount)");
+  });
+
+  it("locks only the generated business rows when creation snapshots use optional client joins", () => {
+    const affaireStart = source.indexOf("async function queueAffaireCreationPdf");
+    const affaire = source.slice(affaireStart, source.indexOf("const affaire = source.rows[0]", affaireStart));
+    expect(affaire).toContain("LEFT JOIN public.clients c");
+    expect(affaire).toContain("LEFT JOIN public.commande_client cc");
+    expect(affaire).toContain("FOR UPDATE OF a");
+    expect(affaire.match(/FOR UPDATE/g)).toHaveLength(1);
+
+    expect(ofCreationPdfSource).toContain("LEFT JOIN public.clients c");
+    expect(ofCreationPdfSource).toContain("FOR UPDATE OF o");
+    expect(ofCreationPdfSource.match(/FOR UPDATE/g)).toHaveLength(1);
   });
 });

--- a/src/module/production/domain/of-creation-pdf.test.ts
+++ b/src/module/production/domain/of-creation-pdf.test.ts
@@ -46,6 +46,7 @@ describe("root OF creation PDF queue", () => {
     expect(input).toMatchObject({ entityType: "ordre-fabrication", entityId: "42", documentKind: "OF_CREATION_SNAPSHOT", documentVersion: 1, idempotencyKey: "ordre-fabrication:42:creation:v1", sourceRevision: root.updated_at, actorUserId: 7 });
     expect(input.sourceSnapshot).toMatchObject({ type: "INTERNAL_CREATION_SNAPSHOT", reference: "OF-00042" });
     expect(JSON.stringify(input.sourceSnapshot)).not.toContain("technical_snapshot\"");
+    expect(String(tx.query.mock.calls[0]?.[0])).toContain("FOR UPDATE OF o");
   });
 
   it("excludes a child OF before it can enqueue", async () => {

--- a/src/module/production/domain/of-creation-pdf.ts
+++ b/src/module/production/domain/of-creation-pdf.ts
@@ -61,7 +61,7 @@ export async function queueRootOfCreationPdf(
        WHERE o.id = $1::bigint
          AND o.parent_of_id IS NULL
          AND (o.root_of_id IS NULL OR o.root_of_id = o.id)
-       FOR UPDATE
+       FOR UPDATE OF o
     `,
     [params.ofId]
   );


### PR DESCRIPTION
Closes #638\n\nFixes the real PostgreSQL

## Summary by Sourcery

Safely scope creation PDF queue locks to the generated business records.

Bug Fixes:
- Restrict PostgreSQL row locks to the generated affaire and ordre-fabrication records when queuing creation PDF snapshots, avoiding unintended locks from optional joined tables.

Tests:
- Add contract and domain coverage verifying that creation PDF queries lock only their target business rows.