### PR TITLE
fix(ged): archive authoritative PDFs with canonical entity types

### DIFF
--- a/db/patches/20260823_authoritative_pdf_ged_compatibility_bridge.sql
+++ b/db/patches/20260823_authoritative_pdf_ged_compatibility_bridge.sql
@@ -1,0 +1,120 @@
+-- Compatibility bridge for the two historical GED schema profiles.
+--
+-- cerp_test owns the closed entity registry from the known external 360 patch.
+-- cerp_prod deliberately retained the legacy SOL-20 link guard.  The immutable
+-- entity-contract patch that follows needs the registry while it runs, so this
+-- patch creates a strictly temporary bridge only on the legacy, empty-link
+-- profile.  The matching cleanup patch removes it in the same maintenance
+-- window after the contract patch has been recorded.
+
+BEGIN;
+
+DO $bridge$
+BEGIN
+  IF to_regclass('public.ged_document_links') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_LINK_TABLE_MISSING';
+  END IF;
+
+  IF to_regclass('public.ged_entity_types') IS NOT NULL THEN
+    IF to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL
+       OR to_regprocedure('public.fn_ged_link_guard()') IS NULL
+       OR NOT EXISTS (
+         SELECT 1 FROM pg_trigger
+          WHERE tgname = 'trg_ged_link_guard'
+            AND tgrelid = 'public.ged_document_links'::regclass
+            AND tgfoid = to_regprocedure('public.fn_ged_link_guard()')
+            AND NOT tgisinternal
+       ) THEN
+      RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_CLOSED_PROFILE_INVALID';
+    END IF;
+    RETURN;
+  END IF;
+
+  IF to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()') IS NULL
+     OR NOT EXISTS (
+       SELECT 1 FROM pg_trigger
+        WHERE tgname = 'trg_ged_validate_canonical_entity_link_20'
+          AND tgrelid = 'public.ged_document_links'::regclass
+          AND tgfoid = to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()')
+          AND NOT tgisinternal
+     ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_LEGACY_PROFILE_INVALID';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.ged_document_links) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_LEGACY_LINKS_NOT_EMPTY';
+  END IF;
+  IF to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_MARKER_ALREADY_EXISTS';
+  END IF;
+
+  EXECUTE $ddl$
+    CREATE TABLE public.cerp_authoritative_pdf_ged_bridge_20260823 (
+      singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+      source_profile text NOT NULL CHECK (source_profile = 'LEGACY_SOL20'),
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  $ddl$;
+  EXECUTE $ddl$
+    INSERT INTO public.cerp_authoritative_pdf_ged_bridge_20260823(singleton, source_profile)
+    VALUES (true, 'LEGACY_SOL20')
+  $ddl$;
+  EXECUTE $ddl$
+    CREATE TABLE public.ged_entity_types (
+      entity_type text PRIMARY KEY CHECK (entity_type ~ '^[A-Z][A-Z0-9_]{1,63}$'),
+      label text NOT NULL,
+      module_key text NOT NULL,
+      target_table text NOT NULL,
+      target_pk_column text NOT NULL,
+      sort_order integer NOT NULL DEFAULT 100,
+      is_active boolean NOT NULL DEFAULT true,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  $ddl$;
+  EXECUTE $seed$
+    INSERT INTO public.ged_entity_types
+      (entity_type, label, module_key, target_table, target_pk_column, sort_order, is_active)
+    VALUES
+      ('CLIENT',                  'Client',              'clients',           'clients',                  'client_id',  10, true),
+      ('FOURNISSEUR',             'Fournisseur',         'fournisseurs',      'fournisseurs',             'id',         20, true),
+      ('ARTICLE',                 'Article',             'stock',             'articles',                 'id',         30, true),
+      ('PIECE_TECHNIQUE',         'Pièce technique',     'pieces-techniques', 'pieces_techniques',        'id',         40, true),
+      ('PIECE_TECHNIQUE_VERSION', 'Indice de pièce',     'pieces-techniques', 'piece_technique_versions', 'id',         50, true),
+      ('AFFAIRE',                 'Affaire',             'affaires',          'affaire',                  'id',         60, true),
+      ('COMMANDE_CLIENT',         'Commande client',     'commande-client',   'commande_client',          'id',         70, true),
+      ('OF',                      'Ordre de fabrication','production',        'ordres_fabrication',      'id',         80, true),
+      ('RECEPTION',               'Réception',           'receptions',        'receptions_fournisseurs',  'id',         90, true),
+      ('CONTROLE_QUALITE',        'Contrôle qualité',    'qualite',           'quality_control',          'id',        100, true),
+      ('MACHINE',                 'Machine',             'production',        'machines',                 'id',        110, true),
+      ('UTILISATEUR',             'Utilisateur',         'users',             'users',                    'id',        120, true)
+  $seed$;
+  EXECUTE $function$
+    CREATE FUNCTION public.fn_ged_link_guard()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $body$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM public.ged_entity_types t
+         WHERE t.entity_type = NEW.entity_type AND t.is_active
+      ) THEN
+        RAISE EXCEPTION 'GED_ENTITY_TYPE_UNKNOWN: type d''entité inconnu ou inactif (%)', NEW.entity_type
+          USING ERRCODE = 'check_violation';
+      END IF;
+      IF btrim(COALESCE(NEW.entity_id, '')) = '' THEN
+        RAISE EXCEPTION 'GED_ENTITY_ID_REQUIRED: un lien exige l''identifiant de la fiche visée'
+          USING ERRCODE = 'check_violation';
+      END IF;
+      RETURN NEW;
+    END
+    $body$
+  $function$;
+  EXECUTE $ddl$
+    CREATE TRIGGER trg_ged_link_guard
+      BEFORE INSERT OR UPDATE ON public.ged_document_links
+      FOR EACH ROW EXECUTE FUNCTION public.fn_ged_link_guard()
+  $ddl$;
+END
+$bridge$;
+
+COMMIT;

--- a/db/patches/20260823_authoritative_pdf_ged_entity_contract.sql
+++ b/db/patches/20260823_authoritative_pdf_ged_entity_contract.sql
@@ -1,0 +1,67 @@
+-- Hotfix — align every authoritative-PDF producer with GED's closed entity registry.
+--
+-- Strictly additive and deliberately one-shot. The five rows below were not
+-- part of the historical #360 registry, but are already supported business
+-- parents at the GED byte-authorization boundary.
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF to_regclass('public.ged_entity_types') IS NULL
+     OR to_regclass('public.ged_document_links') IS NULL
+     OR to_regprocedure('public.fn_ged_link_guard()') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_PREREQUISITE_MISSING';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+     WHERE tgname = 'trg_ged_link_guard'
+       AND tgrelid = 'public.ged_document_links'::regclass
+       AND tgfoid = to_regprocedure('public.fn_ged_link_guard()')
+       AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_LINK_GUARD_MISSING';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.ged_entity_types
+     WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR')
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_TARGET_ALREADY_EXISTS';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.ged_document_links
+     WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR')
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_UNREGISTERED_LINK_EXISTS';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'bon_livraison' AND column_name = 'id'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'devis' AND column_name = 'id'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'commande_fournisseur' AND column_name = 'id'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'facture' AND column_name = 'id'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'avoir' AND column_name = 'id'
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_PARENT_TABLE_MISSING';
+  END IF;
+END
+$guard$;
+
+INSERT INTO public.ged_entity_types
+  (entity_type, label, module_key, target_table, target_pk_column, sort_order, is_active)
+VALUES
+  ('DEVIS',                  'Devis',                'devis',                  'devis',                  'id',  65, true),
+  ('COMMANDE_FOURNISSEUR',   'Commande fournisseur', 'commandes-fournisseurs', 'commande_fournisseur',   'id',  75, true),
+  ('BON_LIVRAISON',          'Bon de livraison',     'livraisons',             'bon_livraison',          'id',  85, true),
+  ('FACTURE',                'Facture',              'facturation',            'facture',                'id', 125, true),
+  ('AVOIR',                  'Avoir',                'facturation',            'avoir',                  'id', 130, true);
+
+COMMIT;

--- a/db/patches/20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql
+++ b/db/patches/20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql
@@ -1,0 +1,64 @@
+-- Remove only the compatibility bridge created for the legacy production GED
+-- profile.  Closed-registry databases are deliberately left unchanged.
+
+BEGIN;
+
+DO $cleanup$
+DECLARE
+  marker_present boolean := to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL;
+  contract_recorded boolean := false;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.cerp_schema_migrations
+       WHERE filename = '20260823_authoritative_pdf_ged_entity_contract.sql'
+    ) INTO contract_recorded;
+  END IF;
+
+  IF NOT marker_present THEN
+    IF to_regclass('public.ged_entity_types') IS NULL
+       OR to_regprocedure('public.fn_ged_link_guard()') IS NULL
+       OR NOT contract_recorded THEN
+      RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_PROFILE_INVALID';
+    END IF;
+    RETURN;
+  END IF;
+
+  IF NOT contract_recorded
+     OR to_regclass('public.ged_entity_types') IS NULL
+     OR to_regprocedure('public.fn_ged_link_guard()') IS NULL
+     OR to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_PREREQUISITE_MISSING';
+  END IF;
+  IF (SELECT COUNT(*) FROM public.cerp_authoritative_pdf_ged_bridge_20260823
+       WHERE singleton AND source_profile = 'LEGACY_SOL20') <> 1 THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_MARKER_INVALID';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.ged_document_links) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_LINKS_NOT_EMPTY';
+  END IF;
+  IF (SELECT COUNT(*) FROM public.ged_entity_types) <> 17 THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_REGISTRY_DRIFT';
+  END IF;
+  IF EXISTS (
+    WITH expected(entity_type) AS (
+      VALUES ('CLIENT'), ('FOURNISSEUR'), ('ARTICLE'), ('PIECE_TECHNIQUE'),
+        ('PIECE_TECHNIQUE_VERSION'), ('AFFAIRE'), ('DEVIS'), ('COMMANDE_CLIENT'),
+        ('COMMANDE_FOURNISSEUR'), ('OF'), ('BON_LIVRAISON'), ('RECEPTION'),
+        ('CONTROLE_QUALITE'), ('MACHINE'), ('UTILISATEUR'), ('FACTURE'), ('AVOIR')
+    )
+    SELECT 1 FROM expected e
+    LEFT JOIN public.ged_entity_types t USING (entity_type)
+    WHERE t.entity_type IS NULL
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_REGISTRY_DRIFT';
+  END IF;
+
+  DROP TRIGGER trg_ged_link_guard ON public.ged_document_links;
+  DROP FUNCTION public.fn_ged_link_guard();
+  DROP TABLE public.ged_entity_types;
+  DROP TABLE public.cerp_authoritative_pdf_ged_bridge_20260823;
+END
+$cleanup$;
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_ged_compatibility_bridge.preflight.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_compatibility_bridge.preflight.sql
@@ -1,0 +1,45 @@
+BEGIN TRANSACTION READ ONLY;
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.ged_document_links') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_PREFLIGHT_LINK_TABLE_MISSING';
+  END IF;
+  IF to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_PREFLIGHT_MARKER_ALREADY_EXISTS';
+  END IF;
+  IF to_regclass('public.ged_entity_types') IS NOT NULL THEN
+    IF to_regprocedure('public.fn_ged_link_guard()') IS NULL
+       OR NOT EXISTS (
+         SELECT 1 FROM pg_trigger
+          WHERE tgname = 'trg_ged_link_guard'
+            AND tgrelid = 'public.ged_document_links'::regclass
+            AND tgfoid = to_regprocedure('public.fn_ged_link_guard()')
+            AND NOT tgisinternal
+       ) THEN
+      RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_PREFLIGHT_CLOSED_PROFILE_INVALID';
+    END IF;
+    RETURN;
+  END IF;
+  IF to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()') IS NULL
+     OR NOT EXISTS (
+       SELECT 1 FROM pg_trigger
+        WHERE tgname = 'trg_ged_validate_canonical_entity_link_20'
+          AND tgrelid = 'public.ged_document_links'::regclass
+          AND tgfoid = to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()')
+          AND NOT tgisinternal
+     ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_PREFLIGHT_LEGACY_PROFILE_INVALID';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.ged_document_links) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_PREFLIGHT_LEGACY_LINKS_NOT_EMPTY';
+  END IF;
+END
+$preflight$;
+
+SELECT CASE
+  WHEN to_regclass('public.ged_entity_types') IS NOT NULL THEN 'CLOSED_REGISTRY'
+  ELSE 'LEGACY_SOL20'
+END AS ged_profile;
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_ged_compatibility_bridge.rollback.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_compatibility_bridge.rollback.sql
@@ -1,0 +1,45 @@
+-- Test/maintenance rollback for the compatibility bridge.  Once the immutable
+-- contract or cleanup has consumed the bridge, rollback is deliberately refused.
+BEGIN;
+
+DO $rollback$
+DECLARE
+  bridge_recorded boolean := false;
+  contract_recorded boolean := false;
+  marker_present boolean := to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT
+      EXISTS (SELECT 1 FROM public.cerp_schema_migrations WHERE filename = '20260823_authoritative_pdf_ged_compatibility_bridge.sql'),
+      EXISTS (SELECT 1 FROM public.cerp_schema_migrations WHERE filename = '20260823_authoritative_pdf_ged_entity_contract.sql')
+      INTO bridge_recorded, contract_recorded;
+  END IF;
+  IF NOT bridge_recorded THEN
+    IF marker_present THEN
+      RAISE EXCEPTION 'Rollback refused: compatibility marker exists without migration-ledger ownership.';
+    END IF;
+    RETURN;
+  END IF;
+  IF marker_present THEN
+    IF contract_recorded THEN
+      RAISE EXCEPTION 'Rollback refused: immutable entity contract has consumed the compatibility bridge.';
+    END IF;
+    IF to_regclass('public.ged_entity_types') IS NULL
+       OR to_regprocedure('public.fn_ged_link_guard()') IS NULL
+       OR EXISTS (SELECT 1 FROM public.ged_document_links)
+       OR (SELECT COUNT(*) FROM public.ged_entity_types) <> 12 THEN
+      RAISE EXCEPTION 'Rollback refused: compatibility bridge state drifted.';
+    END IF;
+    DROP TRIGGER trg_ged_link_guard ON public.ged_document_links;
+    DROP FUNCTION public.fn_ged_link_guard();
+    DROP TABLE public.ged_entity_types;
+    DROP TABLE public.cerp_authoritative_pdf_ged_bridge_20260823;
+  ELSIF to_regclass('public.ged_entity_types') IS NULL THEN
+    RAISE EXCEPTION 'Rollback refused: legacy cleanup already consumed the compatibility bridge.';
+  END IF;
+  DELETE FROM public.cerp_schema_migrations
+   WHERE filename = '20260823_authoritative_pdf_ged_compatibility_bridge.sql';
+END
+$rollback$;
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_ged_compatibility_bridge.verify.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_compatibility_bridge.verify.sql
@@ -1,0 +1,24 @@
+BEGIN TRANSACTION READ ONLY;
+
+DO $verify$
+BEGIN
+  IF to_regclass('public.ged_entity_types') IS NULL
+     OR to_regprocedure('public.fn_ged_link_guard()') IS NULL
+     OR to_regclass('public.ged_document_links') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_VERIFY_BRIDGE_MISSING';
+  END IF;
+  IF to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL THEN
+    IF (SELECT COUNT(*) FROM public.cerp_authoritative_pdf_ged_bridge_20260823
+         WHERE singleton AND source_profile = 'LEGACY_SOL20') <> 1
+       OR (SELECT COUNT(*) FROM public.ged_entity_types) <> 12 THEN
+      RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_VERIFY_BRIDGE_DRIFT';
+    END IF;
+  END IF;
+END
+$verify$;
+
+SELECT
+  to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL AS temporary_legacy_bridge,
+  to_regprocedure('public.fn_ged_link_guard()') IS NOT NULL AS closed_guard_present;
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_ged_entity_contract.preflight.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_entity_contract.preflight.sql
@@ -1,0 +1,61 @@
+-- Authoritative PDF/GED entity contract preflight — read-only and fail-closed.
+BEGIN TRANSACTION READ ONLY;
+
+DO $guard$
+BEGIN
+  IF to_regclass('public.ged_entity_types') IS NULL
+     OR to_regclass('public.ged_document_links') IS NULL
+     OR to_regprocedure('public.fn_ged_link_guard()') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_PREFLIGHT_PREREQUISITE_MISSING';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+     WHERE tgname = 'trg_ged_link_guard'
+       AND tgrelid = 'public.ged_document_links'::regclass
+       AND tgfoid = to_regprocedure('public.fn_ged_link_guard()')
+       AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_PREFLIGHT_LINK_GUARD_MISSING';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.ged_entity_types
+     WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR')
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_PREFLIGHT_TARGET_ALREADY_EXISTS';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.ged_document_links
+     WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR')
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_PREFLIGHT_UNREGISTERED_LINK_EXISTS';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'bon_livraison' AND column_name = 'id'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'devis' AND column_name = 'id'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'commande_fournisseur' AND column_name = 'id'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'facture' AND column_name = 'id'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'avoir' AND column_name = 'id'
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_PREFLIGHT_PARENT_TABLE_MISSING';
+  END IF;
+END
+$guard$;
+
+SELECT
+  to_regclass('public.ged_entity_types') IS NOT NULL AS entity_registry_present,
+  to_regprocedure('public.fn_ged_link_guard()') IS NOT NULL AS link_guard_present,
+  NOT EXISTS (
+    SELECT 1 FROM public.ged_entity_types
+     WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR')
+  ) AS target_types_absent;
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_ged_entity_contract.rollback.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_entity_contract.rollback.sql
@@ -1,0 +1,71 @@
+-- Rollback is safe only while this patch still owns unused, exact registry rows.
+BEGIN;
+
+DO $rollback$
+DECLARE
+  patch_recorded boolean := false;
+  target_exists boolean := false;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    EXECUTE 'SELECT EXISTS (SELECT 1 FROM public.cerp_schema_migrations WHERE filename = $1)'
+      INTO patch_recorded
+      USING '20260823_authoritative_pdf_ged_entity_contract.sql';
+  END IF;
+  IF to_regclass('public.ged_entity_types') IS NOT NULL THEN
+    EXECUTE $sql$
+      SELECT EXISTS (
+        SELECT 1 FROM public.ged_entity_types
+         WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR')
+      )
+    $sql$ INTO target_exists;
+  END IF;
+  IF NOT patch_recorded THEN
+    IF target_exists THEN
+      RAISE EXCEPTION 'Rollback refused: authoritative PDF GED entity rows exist without migration-ledger ownership.';
+    END IF;
+    RETURN;
+  END IF;
+  IF to_regclass('public.ged_entity_types') IS NULL
+     OR to_regclass('public.ged_document_links') IS NULL
+     OR NOT target_exists THEN
+    RAISE EXCEPTION 'Rollback refused: migration ledger is present but GED entity-contract artifacts are incomplete.';
+  END IF;
+  IF EXISTS (
+    WITH expected(entity_type, label, module_key, target_table, target_pk_column, sort_order, is_active) AS (
+      VALUES
+        ('DEVIS',                'Devis',                'devis',                  'devis',                'id',  65, true),
+        ('COMMANDE_FOURNISSEUR', 'Commande fournisseur', 'commandes-fournisseurs', 'commande_fournisseur', 'id',  75, true),
+        ('BON_LIVRAISON',        'Bon de livraison',     'livraisons',             'bon_livraison',        'id',  85, true),
+        ('FACTURE',              'Facture',              'facturation',            'facture',              'id', 125, true),
+        ('AVOIR',                'Avoir',                'facturation',            'avoir',                'id', 130, true)
+    )
+    SELECT 1 FROM expected e
+    LEFT JOIN public.ged_entity_types t USING (entity_type)
+    WHERE t.entity_type IS NULL
+       OR (t.label, t.module_key, t.target_table, t.target_pk_column, t.sort_order, t.is_active)
+          IS DISTINCT FROM
+          (e.label, e.module_key, e.target_table, e.target_pk_column, e.sort_order, e.is_active)
+  ) THEN
+    RAISE EXCEPTION 'Rollback refused: owned GED entity-contract configuration changed.';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.ged_document_links
+     WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR')
+  ) THEN
+    RAISE EXCEPTION 'Rollback refused: authoritative PDF GED entity links exist.';
+  END IF;
+  IF to_regclass('public.ged_entity_class_bindings') IS NOT NULL AND EXISTS (
+    SELECT 1 FROM public.ged_entity_class_bindings
+     WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR')
+  ) THEN
+    RAISE EXCEPTION 'Rollback refused: GED class bindings reference authoritative PDF entity types.';
+  END IF;
+
+  DELETE FROM public.ged_entity_types
+   WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR');
+  EXECUTE 'DELETE FROM public.cerp_schema_migrations WHERE filename = $1'
+    USING '20260823_authoritative_pdf_ged_entity_contract.sql';
+END
+$rollback$;
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_ged_entity_contract.verify.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_entity_contract.verify.sql
@@ -1,0 +1,48 @@
+-- Authoritative PDF/GED entity contract verification — read-only exact-state proof.
+BEGIN TRANSACTION READ ONLY;
+
+DO $verify$
+BEGIN
+  IF to_regclass('public.ged_entity_types') IS NULL
+     OR to_regclass('public.ged_document_links') IS NULL
+     OR to_regprocedure('public.fn_ged_link_guard()') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_VERIFY_PREREQUISITE_MISSING';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+     WHERE tgname = 'trg_ged_link_guard'
+       AND tgrelid = 'public.ged_document_links'::regclass
+       AND tgfoid = to_regprocedure('public.fn_ged_link_guard()')
+       AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_VERIFY_LINK_GUARD_MISSING';
+  END IF;
+  IF EXISTS (
+    WITH expected(entity_type, label, module_key, target_table, target_pk_column, sort_order, is_active) AS (
+      VALUES
+        ('DEVIS',                'Devis',                'devis',                  'devis',                'id',  65, true),
+        ('COMMANDE_FOURNISSEUR', 'Commande fournisseur', 'commandes-fournisseurs', 'commande_fournisseur', 'id',  75, true),
+        ('BON_LIVRAISON',        'Bon de livraison',     'livraisons',             'bon_livraison',        'id',  85, true),
+        ('FACTURE',              'Facture',              'facturation',            'facture',              'id', 125, true),
+        ('AVOIR',                'Avoir',                'facturation',            'avoir',                'id', 130, true)
+    )
+    SELECT 1
+      FROM expected e
+      LEFT JOIN public.ged_entity_types t USING (entity_type)
+     WHERE t.entity_type IS NULL
+        OR (t.label, t.module_key, t.target_table, t.target_pk_column, t.sort_order, t.is_active)
+           IS DISTINCT FROM
+           (e.label, e.module_key, e.target_table, e.target_pk_column, e.sort_order, e.is_active)
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_VERIFY_ROW_MISMATCH';
+  END IF;
+END
+$verify$;
+
+SELECT
+  COUNT(*) = 5 AS all_required_types_present,
+  bool_and(is_active) AS all_required_types_active
+FROM public.ged_entity_types
+WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR');
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_ged_legacy_profile_cleanup.preflight.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_legacy_profile_cleanup.preflight.sql
@@ -1,0 +1,31 @@
+BEGIN TRANSACTION READ ONLY;
+
+DO $preflight$
+DECLARE
+  marker_present boolean := to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL;
+BEGIN
+  IF to_regclass('public.ged_entity_types') IS NULL
+     OR to_regprocedure('public.fn_ged_link_guard()') IS NULL
+     OR to_regclass('public.ged_document_links') IS NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_PREFLIGHT_PROFILE_INVALID';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.cerp_schema_migrations
+     WHERE filename = '20260823_authoritative_pdf_ged_entity_contract.sql'
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_PREFLIGHT_CONTRACT_NOT_RECORDED';
+  END IF;
+  IF marker_present THEN
+    IF (SELECT COUNT(*) FROM public.cerp_authoritative_pdf_ged_bridge_20260823
+         WHERE singleton AND source_profile = 'LEGACY_SOL20') <> 1
+       OR (SELECT COUNT(*) FROM public.ged_entity_types) <> 17
+       OR EXISTS (SELECT 1 FROM public.ged_document_links) THEN
+      RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_PREFLIGHT_BRIDGE_DRIFT';
+    END IF;
+  END IF;
+END
+$preflight$;
+
+SELECT to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL AS cleanup_required;
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_ged_legacy_profile_cleanup.rollback.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_legacy_profile_cleanup.rollback.sql
@@ -1,0 +1,32 @@
+-- Closed-registry databases treat cleanup as a no-op and may unregister it in
+-- test.  Rehydrating a consumed production bridge is intentionally refused.
+BEGIN;
+
+DO $rollback$
+DECLARE
+  cleanup_recorded boolean := false;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.cerp_schema_migrations
+       WHERE filename = '20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql'
+    ) INTO cleanup_recorded;
+  END IF;
+  IF NOT cleanup_recorded THEN
+    RETURN;
+  END IF;
+  IF to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL THEN
+    RAISE EXCEPTION 'Rollback refused: compatibility marker unexpectedly remains after cleanup.';
+  END IF;
+  IF to_regclass('public.ged_entity_types') IS NULL THEN
+    RAISE EXCEPTION 'Rollback refused: production legacy cleanup is not automatically reversible.';
+  END IF;
+  IF to_regprocedure('public.fn_ged_link_guard()') IS NULL THEN
+    RAISE EXCEPTION 'Rollback refused: closed GED registry profile drifted.';
+  END IF;
+  DELETE FROM public.cerp_schema_migrations
+   WHERE filename = '20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql';
+END
+$rollback$;
+
+COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_ged_legacy_profile_cleanup.verify.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_legacy_profile_cleanup.verify.sql
@@ -1,0 +1,35 @@
+BEGIN TRANSACTION READ ONLY;
+
+DO $verify$
+BEGIN
+  IF to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_VERIFY_MARKER_REMAINS';
+  END IF;
+  IF to_regclass('public.ged_entity_types') IS NOT NULL THEN
+    IF to_regprocedure('public.fn_ged_link_guard()') IS NULL
+       OR (SELECT COUNT(*) FROM public.ged_entity_types
+            WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR')) <> 5 THEN
+      RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_VERIFY_CLOSED_PROFILE_INVALID';
+    END IF;
+    RETURN;
+  END IF;
+  IF to_regprocedure('public.fn_ged_link_guard()') IS NOT NULL
+     OR to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()') IS NULL
+     OR NOT EXISTS (
+       SELECT 1 FROM pg_trigger
+        WHERE tgname = 'trg_ged_validate_canonical_entity_link_20'
+          AND tgrelid = 'public.ged_document_links'::regclass
+          AND tgfoid = to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()')
+          AND NOT tgisinternal
+     ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_LEGACY_CLEANUP_VERIFY_LEGACY_PROFILE_INVALID';
+  END IF;
+END
+$verify$;
+
+SELECT CASE
+  WHEN to_regclass('public.ged_entity_types') IS NOT NULL THEN 'CLOSED_REGISTRY'
+  ELSE 'LEGACY_SOL20'
+END AS restored_ged_profile;
+
+COMMIT;

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -26,6 +26,23 @@ du même nom dans `db/patches/support/`, puis suivre
 suppression après création d'une preuve métier ; la restauration du dump devient
 alors la seule stratégie de retrait de schéma.
 
+## PDF autoritatifs — contrat de liens GED
+
+`20260823_authoritative_pdf_ged_entity_contract.sql` enregistre les cinq parents
+PDF absents du registre GED fermé de `cerp_test`. Il est immuable et reste
+encadré par son preflight, son verify et son rollback fail-closed.
+
+La production conserve volontairement le profil GED historique SOL-20, sans ce
+registre externe. Les patches ordonnés
+`20260823_authoritative_pdf_ged_compatibility_bridge.sql` puis
+`20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql` permettent d'exécuter
+le contrat avec le runner normal sans changer durablement ce profil : le pont
+refuse tout lien GED existant, installe un registre strict temporaire, puis le
+cleanup vérifie les 17 types exacts avant de retirer uniquement les artefacts du
+pont. Appliquer les trois patches dans une même fenêtre de maintenance, service
+arrêté, après backup et preflight ; ne jamais baseliner le contrat sur le profil
+legacy.
+
 ## Commands
 
 Show patch status:

--- a/src/__tests__/authoritative-document.domain.test.ts
+++ b/src/__tests__/authoritative-document.domain.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { authoritativePdfFilename, assertAuthoritativePdfFilename } from "../shared/authoritative-documents/authoritative-document.filename";
 import { repoAssertAuthoritativePdfClaim, repoClaimAuthoritativePdfWork, repoFindLatestAuthoritativePdfForEntity, repoGetAuthoritativePdf, repoListAuthoritativePdfs, repoMarkAuthoritativePdfArchived, repoMarkAuthoritativePdfFailure } from "../shared/authoritative-documents/authoritative-document.repository";
-import { archiveClaimedAuthoritativePdf, AuthoritativePdfProducerRegistry, authoritativePdfGedPolicy, canonicalJson, officialDocumentGenerationEnvelope, queueCreationPdfArchive, sha256Text } from "../shared/authoritative-documents/authoritative-document.service";
+import { archiveClaimedAuthoritativePdf, AuthoritativePdfProducerRegistry, authoritativePdfGedEntityType, authoritativePdfGedPolicy, canonicalJson, officialDocumentGenerationEnvelope, queueCreationPdfArchive, sha256Text } from "../shared/authoritative-documents/authoritative-document.service";
 import type { ArchiveQueueItem } from "../shared/authoritative-documents/authoritative-document.types";
 
 function archiveItem(overrides: Partial<ArchiveQueueItem["archive"]> = {}): ArchiveQueueItem {
@@ -39,6 +39,32 @@ describe("authoritative PDF archive foundation (#612)", () => {
     expect(authoritativePdfGedPolicy("CLIENT_CREATION_SNAPSHOT")).toEqual({ classKey: "CERP_SYSTEM_SNAPSHOT", linkRole: "CREATION_SNAPSHOT", eventType: "CREATION_SNAPSHOT_ARCHIVED" });
     expect(authoritativePdfGedPolicy("CUSTOMER_QUOTE")).toEqual({ classKey: "CERP_AUTHORITATIVE_PDF", linkRole: "AUTHORITATIVE_PDF", eventType: "AUTHORITATIVE_PDF_ARCHIVED" });
     expect(authoritativePdfGedPolicy("INVENTED_CREATION_SNAPSHOT").classKey).toBe("CERP_AUTHORITATIVE_PDF");
+  });
+  it.each([
+    ["client", "CLIENT"],
+    ["fournisseur", "FOURNISSEUR"],
+    ["commande-client", "COMMANDE_CLIENT"],
+    ["ordre-fabrication", "OF"],
+    ["piece-technique", "PIECE_TECHNIQUE"],
+    ["affaire", "AFFAIRE"],
+    ["stock-article", "ARTICLE"],
+    ["bon-livraison", "BON_LIVRAISON"],
+    ["devis", "DEVIS"],
+    ["commande-fournisseur", "COMMANDE_FOURNISSEUR"],
+    ["facture", "FACTURE"],
+    ["avoir", "AVOIR"],
+  ])("maps archive entity %s to the canonical GED type %s", (archiveType, gedType) => {
+    expect(authoritativePdfGedEntityType(archiveType)).toBe(gedType);
+  });
+
+  it("fails closed before queueing an entity family absent from the GED contract", async () => {
+    let queried = false;
+    await expect(queueCreationPdfArchive({ query: async () => { queried = true; return { rows: [] }; } }, {
+      entityType: "invented-entity", entityId: "42", documentKind: "INVENTED_DOCUMENT", documentVersion: 1,
+      renderVersion: "invented-v1", idempotencyKey: "invented:42:v1", title: "Invented",
+      originalName: "Invented-42-v1.pdf", sourceRevision: "revision-1", sourceSnapshot: {}, actorUserId: 1,
+    })).rejects.toThrow("AUTHORITATIVE_PDF_GED_ENTITY_TYPE_UNSUPPORTED");
+    expect(queried).toBe(false);
   });
   it("canonicalizes a creation snapshot independently of source key order", () => {
     const left = { entity: { id: "42", lines: [{ quantity: 2, ref: "P-01" }] }, created: "2026-08-23T10:00:00Z" };

--- a/src/__tests__/authoritative-pdf-ged-entity-contract.migration.test.ts
+++ b/src/__tests__/authoritative-pdf-ged-entity-contract.migration.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const base = "20260823_authoritative_pdf_ged_entity_contract";
+const patch = fs.readFileSync(path.join(root, "db/patches", `${base}.sql`), "utf8");
+const preflight = fs.readFileSync(path.join(root, "db/patches/support", `${base}.preflight.sql`), "utf8");
+const verify = fs.readFileSync(path.join(root, "db/patches/support", `${base}.verify.sql`), "utf8");
+const rollback = fs.readFileSync(path.join(root, "db/patches/support", `${base}.rollback.sql`), "utf8");
+const requiredTypes = ["BON_LIVRAISON", "DEVIS", "COMMANDE_FOURNISSEUR", "FACTURE", "AVOIR"];
+
+describe("authoritative PDF/GED entity-contract migration", () => {
+  it("adds every PDF parent missing from the historical GED registry", () => {
+    for (const entityType of requiredTypes) {
+      expect(patch).toContain(`'${entityType}'`);
+      expect(verify).toContain(`'${entityType}'`);
+    }
+    expect(patch).toContain("'bon_livraison'");
+    expect(patch).toContain("'commande_fournisseur'");
+    expect(patch).toContain("'facture'");
+    expect(patch).toContain("'avoir'");
+    expect(patch).toContain("'devis'");
+    expect(patch).not.toContain("ON CONFLICT");
+  });
+
+  it("ships read-only gates that require the closed GED link guard", () => {
+    for (const script of [preflight, verify]) {
+      expect(script).toContain("BEGIN TRANSACTION READ ONLY");
+      expect(script).toContain("fn_ged_link_guard()");
+      expect(script).toContain("trg_ged_link_guard");
+      expect(script).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE|GRANT|REVOKE)\b/im);
+    }
+    expect(preflight).toContain("PREFLIGHT_TARGET_ALREADY_EXISTS");
+    expect(verify).toContain("VERIFY_ROW_MISMATCH");
+    expect(verify).toContain("COUNT(*) = 5");
+  });
+
+  it("refuses rollback without ledger ownership or after links/configuration exist", () => {
+    expect(rollback).toContain("20260823_authoritative_pdf_ged_entity_contract.sql");
+    expect(rollback).toContain("without migration-ledger ownership");
+    expect(rollback).toContain("authoritative PDF GED entity links exist");
+    expect(rollback).toContain("GED class bindings reference authoritative PDF entity types");
+    expect(rollback).toContain("owned GED entity-contract configuration changed");
+  });
+});

--- a/src/__tests__/authoritative-pdf-ged-entity-contract.migration.test.ts
+++ b/src/__tests__/authoritative-pdf-ged-entity-contract.migration.test.ts
@@ -8,6 +8,16 @@ const patch = fs.readFileSync(path.join(root, "db/patches", `${base}.sql`), "utf
 const preflight = fs.readFileSync(path.join(root, "db/patches/support", `${base}.preflight.sql`), "utf8");
 const verify = fs.readFileSync(path.join(root, "db/patches/support", `${base}.verify.sql`), "utf8");
 const rollback = fs.readFileSync(path.join(root, "db/patches/support", `${base}.rollback.sql`), "utf8");
+const bridgeBase = "20260823_authoritative_pdf_ged_compatibility_bridge";
+const cleanupBase = "20260823_authoritative_pdf_ged_legacy_profile_cleanup";
+const bridge = fs.readFileSync(path.join(root, "db/patches", `${bridgeBase}.sql`), "utf8");
+const bridgePreflight = fs.readFileSync(path.join(root, "db/patches/support", `${bridgeBase}.preflight.sql`), "utf8");
+const bridgeVerify = fs.readFileSync(path.join(root, "db/patches/support", `${bridgeBase}.verify.sql`), "utf8");
+const bridgeRollback = fs.readFileSync(path.join(root, "db/patches/support", `${bridgeBase}.rollback.sql`), "utf8");
+const cleanup = fs.readFileSync(path.join(root, "db/patches", `${cleanupBase}.sql`), "utf8");
+const cleanupPreflight = fs.readFileSync(path.join(root, "db/patches/support", `${cleanupBase}.preflight.sql`), "utf8");
+const cleanupVerify = fs.readFileSync(path.join(root, "db/patches/support", `${cleanupBase}.verify.sql`), "utf8");
+const cleanupRollback = fs.readFileSync(path.join(root, "db/patches/support", `${cleanupBase}.rollback.sql`), "utf8");
 const requiredTypes = ["BON_LIVRAISON", "DEVIS", "COMMANDE_FOURNISSEUR", "FACTURE", "AVOIR"];
 
 describe("authoritative PDF/GED entity-contract migration", () => {
@@ -42,5 +52,25 @@ describe("authoritative PDF/GED entity-contract migration", () => {
     expect(rollback).toContain("authoritative PDF GED entity links exist");
     expect(rollback).toContain("GED class bindings reference authoritative PDF entity types");
     expect(rollback).toContain("owned GED entity-contract configuration changed");
+  });
+
+  it("bridges the legacy SOL-20 profile only for the immutable contract window", () => {
+    expect(bridgeBase.localeCompare(base)).toBeLessThan(0);
+    expect(cleanupBase.localeCompare(base)).toBeGreaterThan(0);
+    expect(bridge).toContain("fn_ged_validate_canonical_entity_link_20()");
+    expect(bridge).toContain("cerp_authoritative_pdf_ged_bridge_20260823");
+    expect(bridge).toContain("LEGACY_LINKS_NOT_EMPTY");
+    expect(cleanup).toContain("20260823_authoritative_pdf_ged_entity_contract.sql");
+    expect(cleanup).toContain("DROP TABLE public.ged_entity_types");
+    expect(cleanup).toContain("DROP TABLE public.cerp_authoritative_pdf_ged_bridge_20260823");
+
+    for (const script of [bridgePreflight, bridgeVerify, cleanupPreflight, cleanupVerify]) {
+      expect(script).toContain("BEGIN TRANSACTION READ ONLY");
+      expect(script).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE|GRANT|REVOKE)\b/im);
+    }
+    expect(cleanupVerify).toContain("LEGACY_SOL20");
+    expect(cleanupVerify).toContain("CLOSED_REGISTRY");
+    expect(bridgeRollback).toContain("immutable entity contract has consumed");
+    expect(cleanupRollback).toContain("production legacy cleanup is not automatically reversible");
   });
 });

--- a/src/__tests__/authoritative-pdf-ged-entity-contract.postgres.integration.test.ts
+++ b/src/__tests__/authoritative-pdf-ged-entity-contract.postgres.integration.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const integrationUrl = process.env.AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_TEST_DATABASE_URL;
+const suite = integrationUrl ? describe : describe.skip;
+const root = process.cwd();
+const base = "20260823_authoritative_pdf_ged_entity_contract";
+const requiredTypes = ["BON_LIVRAISON", "DEVIS", "COMMANDE_FOURNISSEUR", "FACTURE", "AVOIR"];
+
+suite("authoritative PDF/GED entity contract: PostgreSQL migration", () => {
+  let client: import("pg").Client;
+  let patch: string;
+  let preflight: string;
+  let verify: string;
+  let rollback: string;
+
+  beforeAll(async () => {
+    const pg = await import("pg");
+    client = new pg.Client({ connectionString: integrationUrl });
+    await client.connect();
+    const database = await client.query<{ current_database: string }>("SELECT current_database()");
+    if (!/test|sandbox|local/i.test(database.rows[0]?.current_database ?? "")) {
+      throw new Error("AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_TEST_DATABASE_URL must target a test/local/sandbox database");
+    }
+    [patch, preflight, verify, rollback] = await Promise.all([
+      fs.readFile(path.join(root, "db/patches", `${base}.sql`), "utf8"),
+      fs.readFile(path.join(root, "db/patches/support", `${base}.preflight.sql`), "utf8"),
+      fs.readFile(path.join(root, "db/patches/support", `${base}.verify.sql`), "utf8"),
+      fs.readFile(path.join(root, "db/patches/support", `${base}.rollback.sql`), "utf8"),
+    ]);
+  });
+
+  afterAll(async () => { await client?.end(); });
+
+  it("registers all canonical parents, enforces the trigger, verifies exact state, and rolls back only while unused", async () => {
+    await client.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+    await client.query(`
+      CREATE TABLE public.ged_entity_types (
+        entity_type text PRIMARY KEY CHECK (entity_type ~ '^[A-Z][A-Z0-9_]{1,63}$'),
+        label text NOT NULL, module_key text NOT NULL, target_table text NOT NULL,
+        target_pk_column text NOT NULL, sort_order integer NOT NULL DEFAULT 100,
+        is_active boolean NOT NULL DEFAULT true, created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      );
+      CREATE TABLE public.ged_entity_class_bindings (entity_type text NOT NULL REFERENCES public.ged_entity_types(entity_type));
+      CREATE TABLE public.ged_document_links (id uuid PRIMARY KEY, document_id uuid NOT NULL, entity_type text NOT NULL, entity_id text NOT NULL);
+      CREATE TABLE public.bon_livraison (id uuid PRIMARY KEY);
+      CREATE TABLE public.devis (id bigint PRIMARY KEY);
+      CREATE TABLE public.commande_fournisseur (id uuid PRIMARY KEY);
+      CREATE TABLE public.facture (id bigint PRIMARY KEY);
+      CREATE TABLE public.avoir (id bigint PRIMARY KEY);
+      CREATE TABLE public.cerp_schema_migrations (filename text PRIMARY KEY);
+      CREATE FUNCTION public.fn_ged_link_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM public.ged_entity_types WHERE entity_type = NEW.entity_type AND is_active) THEN
+          RAISE EXCEPTION 'GED_ENTITY_TYPE_UNKNOWN' USING ERRCODE = 'check_violation';
+        END IF;
+        RETURN NEW;
+      END $$;
+      CREATE TRIGGER trg_ged_link_guard BEFORE INSERT OR UPDATE ON public.ged_document_links
+        FOR EACH ROW EXECUTE FUNCTION public.fn_ged_link_guard();
+    `);
+
+    await expect(client.query(preflight)).resolves.toBeDefined();
+    await client.query(patch);
+    await expect(client.query(verify)).resolves.toBeDefined();
+    expect((await client.query("SELECT entity_type FROM public.ged_entity_types ORDER BY entity_type")).rows.map((row) => row.entity_type)).toEqual([...requiredTypes].sort());
+
+    for (const [index, entityType] of requiredTypes.entries()) {
+      await expect(client.query(
+        "INSERT INTO public.ged_document_links(id, document_id, entity_type, entity_id) VALUES ($1::uuid, $2::uuid, $3, $4)",
+        [`00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`, `10000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`, entityType, String(index + 1)]
+      )).resolves.toMatchObject({ rowCount: 1 });
+    }
+    await expect(client.query(
+      "INSERT INTO public.ged_document_links(id, document_id, entity_type, entity_id) VALUES ('90000000-0000-4000-8000-000000000001', '90000000-0000-4000-8000-000000000002', 'client', '1')"
+    )).rejects.toMatchObject({ code: "23514" });
+
+    await client.query("INSERT INTO public.cerp_schema_migrations(filename) VALUES ($1)", [`${base}.sql`]);
+    await expect(client.query(rollback)).rejects.toMatchObject({ message: expect.stringContaining("authoritative PDF GED entity links exist") });
+    await client.query("ROLLBACK");
+    await client.query("DELETE FROM public.ged_document_links");
+    await client.query(rollback);
+    expect((await client.query("SELECT COUNT(*)::int AS count FROM public.ged_entity_types")).rows[0]?.count).toBe(0);
+  }, 60_000);
+});

--- a/src/__tests__/authoritative-pdf-ged-entity-contract.postgres.integration.test.ts
+++ b/src/__tests__/authoritative-pdf-ged-entity-contract.postgres.integration.test.ts
@@ -6,6 +6,8 @@ const integrationUrl = process.env.AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_TEST_DA
 const suite = integrationUrl ? describe : describe.skip;
 const root = process.cwd();
 const base = "20260823_authoritative_pdf_ged_entity_contract";
+const bridgeBase = "20260823_authoritative_pdf_ged_compatibility_bridge";
+const cleanupBase = "20260823_authoritative_pdf_ged_legacy_profile_cleanup";
 const requiredTypes = ["BON_LIVRAISON", "DEVIS", "COMMANDE_FOURNISSEUR", "FACTURE", "AVOIR"];
 
 suite("authoritative PDF/GED entity contract: PostgreSQL migration", () => {
@@ -14,6 +16,12 @@ suite("authoritative PDF/GED entity contract: PostgreSQL migration", () => {
   let preflight: string;
   let verify: string;
   let rollback: string;
+  let bridge: string;
+  let bridgePreflight: string;
+  let bridgeVerify: string;
+  let cleanup: string;
+  let cleanupPreflight: string;
+  let cleanupVerify: string;
 
   beforeAll(async () => {
     const pg = await import("pg");
@@ -23,11 +31,17 @@ suite("authoritative PDF/GED entity contract: PostgreSQL migration", () => {
     if (!/test|sandbox|local/i.test(database.rows[0]?.current_database ?? "")) {
       throw new Error("AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_TEST_DATABASE_URL must target a test/local/sandbox database");
     }
-    [patch, preflight, verify, rollback] = await Promise.all([
+    [patch, preflight, verify, rollback, bridge, bridgePreflight, bridgeVerify, cleanup, cleanupPreflight, cleanupVerify] = await Promise.all([
       fs.readFile(path.join(root, "db/patches", `${base}.sql`), "utf8"),
       fs.readFile(path.join(root, "db/patches/support", `${base}.preflight.sql`), "utf8"),
       fs.readFile(path.join(root, "db/patches/support", `${base}.verify.sql`), "utf8"),
       fs.readFile(path.join(root, "db/patches/support", `${base}.rollback.sql`), "utf8"),
+      fs.readFile(path.join(root, "db/patches", `${bridgeBase}.sql`), "utf8"),
+      fs.readFile(path.join(root, "db/patches/support", `${bridgeBase}.preflight.sql`), "utf8"),
+      fs.readFile(path.join(root, "db/patches/support", `${bridgeBase}.verify.sql`), "utf8"),
+      fs.readFile(path.join(root, "db/patches", `${cleanupBase}.sql`), "utf8"),
+      fs.readFile(path.join(root, "db/patches/support", `${cleanupBase}.preflight.sql`), "utf8"),
+      fs.readFile(path.join(root, "db/patches/support", `${cleanupBase}.verify.sql`), "utf8"),
     ]);
   });
 
@@ -83,5 +97,88 @@ suite("authoritative PDF/GED entity contract: PostgreSQL migration", () => {
     await client.query("DELETE FROM public.ged_document_links");
     await client.query(rollback);
     expect((await client.query("SELECT COUNT(*)::int AS count FROM public.ged_entity_types")).rows[0]?.count).toBe(0);
+  }, 60_000);
+
+  it("temporarily bridges the empty legacy production profile and restores it exactly", async () => {
+    await client.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+    await client.query(`
+      CREATE TABLE public.ged_document_links (
+        id uuid PRIMARY KEY, document_id uuid NOT NULL, entity_type text NOT NULL,
+        entity_id text NOT NULL, link_role text NULL
+      );
+      CREATE TABLE public.bon_livraison (id uuid PRIMARY KEY);
+      CREATE TABLE public.devis (id bigint PRIMARY KEY);
+      CREATE TABLE public.commande_fournisseur (id uuid PRIMARY KEY);
+      CREATE TABLE public.facture (id bigint PRIMARY KEY);
+      CREATE TABLE public.avoir (id bigint PRIMARY KEY);
+      CREATE TABLE public.cerp_schema_migrations (filename text PRIMARY KEY);
+      CREATE FUNCTION public.fn_ged_validate_canonical_entity_link_20()
+      RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+      CREATE TRIGGER trg_ged_validate_canonical_entity_link_20
+        BEFORE INSERT OR UPDATE OF entity_type, entity_id ON public.ged_document_links
+        FOR EACH ROW EXECUTE FUNCTION public.fn_ged_validate_canonical_entity_link_20();
+    `);
+
+    await expect(client.query(bridgePreflight)).resolves.toBeDefined();
+    await client.query(bridge);
+    await expect(client.query(bridgeVerify)).resolves.toBeDefined();
+    expect((await client.query("SELECT COUNT(*)::int AS count FROM public.ged_entity_types")).rows[0]?.count).toBe(12);
+    await client.query("INSERT INTO public.cerp_schema_migrations(filename) VALUES ($1)", [`${bridgeBase}.sql`]);
+
+    await expect(client.query(preflight)).resolves.toBeDefined();
+    await client.query(patch);
+    await expect(client.query(verify)).resolves.toBeDefined();
+    await client.query("INSERT INTO public.cerp_schema_migrations(filename) VALUES ($1)", [`${base}.sql`]);
+
+    await expect(client.query(cleanupPreflight)).resolves.toBeDefined();
+    await client.query(cleanup);
+    await client.query("INSERT INTO public.cerp_schema_migrations(filename) VALUES ($1)", [`${cleanupBase}.sql`]);
+    await expect(client.query(cleanupVerify)).resolves.toBeDefined();
+
+    expect((await client.query("SELECT to_regclass('public.ged_entity_types') AS registry")).rows[0]?.registry).toBeNull();
+    expect((await client.query("SELECT to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') AS marker")).rows[0]?.marker).toBeNull();
+    expect((await client.query("SELECT to_regprocedure('public.fn_ged_link_guard()') AS strict_guard")).rows[0]?.strict_guard).toBeNull();
+    expect((await client.query("SELECT to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()') IS NOT NULL AS legacy_guard")).rows[0]?.legacy_guard).toBe(true);
+    await expect(client.query(
+      "INSERT INTO public.ged_document_links(id, document_id, entity_type, entity_id) VALUES ('90000000-0000-4000-8000-000000000001', '90000000-0000-4000-8000-000000000002', 'client', '1')"
+    )).resolves.toMatchObject({ rowCount: 1 });
+  }, 60_000);
+
+  it("leaves an existing closed-registry profile unchanged", async () => {
+    await client.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+    await client.query(`
+      CREATE TABLE public.ged_entity_types (
+        entity_type text PRIMARY KEY, label text NOT NULL, module_key text NOT NULL,
+        target_table text NOT NULL, target_pk_column text NOT NULL,
+        sort_order integer NOT NULL, is_active boolean NOT NULL
+      );
+      CREATE TABLE public.ged_document_links (
+        id uuid PRIMARY KEY, document_id uuid NOT NULL, entity_type text NOT NULL,
+        entity_id text NOT NULL, link_role text NULL
+      );
+      CREATE TABLE public.bon_livraison (id uuid PRIMARY KEY);
+      CREATE TABLE public.devis (id bigint PRIMARY KEY);
+      CREATE TABLE public.commande_fournisseur (id uuid PRIMARY KEY);
+      CREATE TABLE public.facture (id bigint PRIMARY KEY);
+      CREATE TABLE public.avoir (id bigint PRIMARY KEY);
+      CREATE TABLE public.cerp_schema_migrations (filename text PRIMARY KEY);
+      CREATE FUNCTION public.fn_ged_link_guard()
+      RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+      CREATE TRIGGER trg_ged_link_guard BEFORE INSERT OR UPDATE ON public.ged_document_links
+        FOR EACH ROW EXECUTE FUNCTION public.fn_ged_link_guard();
+    `);
+    await client.query(patch);
+    await client.query("INSERT INTO public.cerp_schema_migrations(filename) VALUES ($1)", [`${base}.sql`]);
+
+    await expect(client.query(bridgePreflight)).resolves.toBeDefined();
+    await client.query(bridge);
+    await client.query("INSERT INTO public.cerp_schema_migrations(filename) VALUES ($1)", [`${bridgeBase}.sql`]);
+    await expect(client.query(cleanupPreflight)).resolves.toBeDefined();
+    await client.query(cleanup);
+    await client.query("INSERT INTO public.cerp_schema_migrations(filename) VALUES ($1)", [`${cleanupBase}.sql`]);
+    await expect(client.query(cleanupVerify)).resolves.toBeDefined();
+
+    expect((await client.query("SELECT entity_type FROM public.ged_entity_types ORDER BY entity_type")).rows.map((row) => row.entity_type)).toEqual([...requiredTypes].sort());
+    expect((await client.query("SELECT to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') AS marker")).rows[0]?.marker).toBeNull();
   }, 60_000);
 });

--- a/src/module/ged/services/ged-parent-authorization.service.test.ts
+++ b/src/module/ged/services/ged-parent-authorization.service.test.ts
@@ -40,7 +40,7 @@ describe("GED parent-record download authorization", () => {
     expect(mocks.exists).toHaveBeenCalledWith(canonicalType, "42");
   });
 
-  it.each(["STOCK_ARTICLE", "STOCK-ARTICLE"])("accepts the live UUID identity used by %s", async (entityType) => {
+  it.each(["ARTICLE", "STOCK_ARTICLE", "STOCK-ARTICLE"])("accepts the live UUID identity used by %s", async (entityType) => {
     const articleId = "22222222-2222-4222-8222-222222222222";
     mocks.links.mockResolvedValue([{ entity_type: entityType, entity_id: articleId }]);
     mocks.exists.mockResolvedValue(true);

--- a/src/module/ged/services/ged-parent-authorization.service.ts
+++ b/src/module/ged/services/ged-parent-authorization.service.ts
@@ -27,6 +27,7 @@ const PARENT_POLICIES: Readonly<Record<string, ParentPolicy>> = {
   PIECE_TECHNIQUE: { moduleKey: "pieces-techniques", canonicalType: "PIECE_TECHNIQUE", identity: "uuid" },
   "PIECE-TECHNIQUE": { moduleKey: "pieces-techniques", canonicalType: "PIECE_TECHNIQUE", identity: "uuid" },
   PIECE_TECHNIQUE_VERSION: { moduleKey: "pieces-techniques", canonicalType: "PIECE_TECHNIQUE_VERSION", identity: "uuid" },
+  ARTICLE: { moduleKey: "stock", canonicalType: "STOCK_ARTICLE", identity: "uuid" },
   STOCK_ARTICLE: { moduleKey: "stock", canonicalType: "STOCK_ARTICLE", identity: "uuid" },
   "STOCK-ARTICLE": { moduleKey: "stock", canonicalType: "STOCK_ARTICLE", identity: "uuid" },
   OUTIL: { moduleKey: "outillage", canonicalType: "OUTIL", identity: "integer" },

--- a/src/shared/authoritative-documents/authoritative-document.service.ts
+++ b/src/shared/authoritative-documents/authoritative-document.service.ts
@@ -11,6 +11,20 @@ import type { ArchiveQueueItem, AuthoritativePdfArchiveRecord, AuthoritativePdfC
 const PDF_CLASS = "CERP_AUTHORITATIVE_PDF";
 const SYSTEM_SNAPSHOT_CLASS = "CERP_SYSTEM_SNAPSHOT";
 const PDF_DOMAIN = "CERP";
+const GED_ENTITY_TYPE_BY_ARCHIVE_ENTITY: Readonly<Record<string, string>> = Object.freeze({
+  client: "CLIENT",
+  fournisseur: "FOURNISSEUR",
+  "commande-client": "COMMANDE_CLIENT",
+  "ordre-fabrication": "OF",
+  "piece-technique": "PIECE_TECHNIQUE",
+  affaire: "AFFAIRE",
+  "stock-article": "ARTICLE",
+  "bon-livraison": "BON_LIVRAISON",
+  devis: "DEVIS",
+  "commande-fournisseur": "COMMANDE_FOURNISSEUR",
+  facture: "FACTURE",
+  avoir: "AVOIR",
+});
 export const INTERNAL_CREATION_SNAPSHOT_KINDS = new Set([
   "CLIENT_CREATION_SNAPSHOT", "SUPPLIER_CREATION_SNAPSHOT", "CUSTOMER_ORDER_CREATION_SNAPSHOT",
   "OF_CREATION_SNAPSHOT", "TECHNICAL_PIECE_CREATION_SNAPSHOT", "AFFAIR_CREATION_SNAPSHOT", "STOCK_ARTICLE_CREATION_SNAPSHOT",
@@ -22,6 +36,17 @@ export function authoritativePdfGedPolicy(documentKind: string): { classKey: str
   return INTERNAL_CREATION_SNAPSHOT_KINDS.has(documentKind)
     ? { classKey: SYSTEM_SNAPSHOT_CLASS, linkRole: "CREATION_SNAPSHOT", eventType: "CREATION_SNAPSHOT_ARCHIVED" }
     : { classKey: PDF_CLASS, linkRole: "AUTHORITATIVE_PDF", eventType: "AUTHORITATIVE_PDF_ARCHIVED" };
+}
+
+/**
+ * Archive producers use stable, lower-case application identifiers; GED links
+ * use the closed vocabulary enforced by `fn_ged_link_guard`. Keep the bridge
+ * explicit so a spelling change cannot create a second business tree.
+ */
+export function authoritativePdfGedEntityType(entityType: string): string {
+  const gedEntityType = GED_ENTITY_TYPE_BY_ARCHIVE_ENTITY[entityType];
+  if (!gedEntityType) throw new Error("AUTHORITATIVE_PDF_GED_ENTITY_TYPE_UNSUPPORTED");
+  return gedEntityType;
 }
 /** Must stay aligned with the generated-PDF GED class in migration #612. */
 const MAX_AUTHORITATIVE_PDF_BYTES = 52_428_800;
@@ -44,6 +69,7 @@ export function sha256Text(value: string): string {
 
 function assertCreationInput(input: AuthoritativePdfCreationInput): void {
   if (!/^[a-z][a-z0-9_-]{1,63}$/.test(input.entityType)) throw new Error("AUTHORITATIVE_PDF_ENTITY_TYPE_INVALID");
+  authoritativePdfGedEntityType(input.entityType);
   if (
     !input.entityId.trim() || input.entityId.length > 160 ||
     !/^[A-Z][A-Z0-9_]{1,63}$/.test(input.documentKind)
@@ -245,6 +271,7 @@ export async function archiveClaimedAuthoritativePdf(
   });
   const existingDocumentId = await repoFindLatestGedDocumentForAuthoritativePdf(tx, item.archive.entityType, item.archive.entityId, item.archive.documentKind);
   const gedPolicy = authoritativePdfGedPolicy(item.archive.documentKind);
+  const gedEntityType = authoritativePdfGedEntityType(item.archive.entityType);
   const changeReason = `Édition ${item.archive.documentVersion}; rendu ${item.archive.renderVersion}; instantané ${item.archive.snapshotSha256}`;
   let documentId: string;
   let versionId: string;
@@ -260,8 +287,8 @@ export async function archiveClaimedAuthoritativePdf(
   await repoObsoletePreviousApplicable(tx, documentId, versionId);
   await repoSetVersionStatus(tx, versionId, "APPLICABLE", item.archive.actorUserId);
   await repoSetCurrentVersion(tx, documentId, versionId);
-  await repoAddLink(tx, { document_id: documentId, entity_type: item.archive.entityType, entity_id: item.archive.entityId, link_role: gedPolicy.linkRole, created_by: item.archive.actorUserId });
-  await repoLogAccess(tx, { document_id: documentId, version_id: versionId, event_type: gedPolicy.eventType, actor_id: item.archive.actorUserId, details: { entity_type: item.archive.entityType, entity_id: item.archive.entityId, document_kind: item.archive.documentKind, document_version: item.archive.documentVersion, source_revision: item.archive.sourceRevision, snapshot_sha256: item.archive.snapshotSha256, pdf_sha256: sha256, render_version: item.archive.renderVersion } });
+  await repoAddLink(tx, { document_id: documentId, entity_type: gedEntityType, entity_id: item.archive.entityId, link_role: gedPolicy.linkRole, created_by: item.archive.actorUserId });
+  await repoLogAccess(tx, { document_id: documentId, version_id: versionId, event_type: gedPolicy.eventType, actor_id: item.archive.actorUserId, details: { entity_type: gedEntityType, archive_entity_type: item.archive.entityType, entity_id: item.archive.entityId, document_kind: item.archive.documentKind, document_version: item.archive.documentVersion, source_revision: item.archive.sourceRevision, snapshot_sha256: item.archive.snapshotSha256, pdf_sha256: sha256, render_version: item.archive.renderVersion } });
   await repoMarkAuthoritativePdfArchived(tx, { archiveId: item.archive.id, outboxId: item.outboxId, claimToken: item.claimToken, pdfSha256: sha256, pdfSizeBytes: exact.length, gedDocumentId: documentId, gedVersionId: versionId, actorUserId: item.archive.actorUserId });
 }
 


### PR DESCRIPTION
## Résultat\n- mappe chaque famille PDF vers le type GED canonique\n- ajoute les types GED manquants via une migration additive\n- garde les pièces de stock téléchargeables via l’alias ARTICLE\n\n## Validation\n- 5 093 tests réussis, 26 ignorés\n- test d’intégration PostgreSQL réel réussi\n- typecheck et build OpenAPI réussis\n- déploiement dev sain\n- échec exact client 194 rejoué et archivé dans la GED

## Summary by Sourcery

Align authoritative PDF archiving with the canonical GED entity contract while preserving compatibility for legacy production profiles.

New Features:
- Map authoritative PDF archive families to canonical GED entity types and reject unsupported families before queuing.
- Add the five missing GED entity types for delivery notes, quotes, supplier orders, invoices, and credit notes.
- Allow stock article documents to remain downloadable through the ARTICLE alias.

Bug Fixes:
- Ensure authoritative PDFs are archived with entity types accepted by the closed GED registry across both supported schema profiles.

Enhancements:
- Introduce a temporary, fail-closed compatibility bridge for the legacy SOL-20 GED profile and remove it after the contract migration.
- Add preflight, verification, rollback, cleanup, and PostgreSQL integration coverage for the migration paths.

Documentation:
- Document the authoritative PDF GED contract and the required maintenance-window migration sequence.

Tests:
- Test canonical entity mapping, unsupported-family rejection, alias-based article authorization, exact migration state, and legacy-profile restoration.