### PR TITLE
fix(stock): fiabiliser les requêtes OLD puis NEW

### DIFF
--- a/src/__tests__/commande-stock-sql-contract.test.ts
+++ b/src/__tests__/commande-stock-sql-contract.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function repositorySource(): string {
+  return fs.readFileSync(
+    path.join(process.cwd(), "src/module/commande-client/repository/commande-client.repository.ts"),
+    "utf8"
+  );
+}
+
+function functionSource(source: string, name: string, nextName: string): string {
+  const start = source.indexOf(`async function ${name}`);
+  const end = source.indexOf(`function ${nextName}`, start + 1);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("commande stock SQL contract", () => {
+  it("groups OLD/NEW availability by the same effective scope that it selects", () => {
+    const source = functionSource(
+      repositorySource(),
+      "loadScopedAvailableQtyByArticle",
+      "computeCommandeStockAnalysis"
+    );
+
+    expect(source).toMatch(
+      /SELECT[\s\S]*COALESCE\(lot\.source_scope, warehouse\.stock_scope, 'NEW'\) AS stock_scope[\s\S]*GROUP BY[\s\S]*availability\.article_id,[\s\S]*COALESCE\(lot\.source_scope, warehouse\.stock_scope, 'NEW'\)/
+    );
+  });
+
+  it("joins lots before using their scope and FIFO dates for delivery candidates", () => {
+    const source = functionSource(
+      repositorySource(),
+      "loadScopedDeliveryStockCandidates",
+      "planDeliveryAllocations"
+    );
+
+    expect(source).toMatch(/JOIN public\.lots lot ON lot\.id = availability\.lot_id/);
+    expect(source).toMatch(
+      /COALESCE\(lot\.source_scope, warehouse\.stock_scope, 'NEW'\) AS stock_scope/
+    );
+    expect(source).toMatch(
+      /CASE COALESCE\(lot\.source_scope, warehouse\.stock_scope, 'NEW'\) WHEN 'OLD' THEN 0 ELSE 1 END/
+    );
+  });
+});

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -5072,7 +5072,9 @@ async function loadScopedAvailableQtyByArticle(
       WHERE availability.article_id = ANY($1::uuid[])
         AND availability.managed_in_stock = true
         AND warehouse.stock_scope IN ('OLD', 'NEW')
-      GROUP BY availability.article_id, warehouse.stock_scope
+      GROUP BY
+        availability.article_id,
+        COALESCE(lot.source_scope, warehouse.stock_scope, 'NEW')
     `,
     [articleIds]
   );
@@ -5209,7 +5211,7 @@ async function loadScopedDeliveryStockCandidates(
     `
       SELECT
         availability.article_id::text AS article_id,
-        warehouse.stock_scope,
+        COALESCE(lot.source_scope, warehouse.stock_scope, 'NEW') AS stock_scope,
         availability.stock_level_id::text AS stock_level_id,
         availability.stock_batch_id::text AS stock_batch_id,
         availability.location_id::text AS location_id,
@@ -5219,12 +5221,13 @@ async function loadScopedDeliveryStockCandidates(
         availability.qty_available::float8 AS qty_available
       FROM public.v_stock_availability_225 availability
       JOIN public.warehouses warehouse ON warehouse.id = availability.warehouse_id
+      JOIN public.lots lot ON lot.id = availability.lot_id
       JOIN public.emplacements emplacement ON emplacement.location_id = availability.location_id
       JOIN public.magasins magasin ON magasin.id = emplacement.magasin_id
       WHERE availability.article_id = ANY($1::uuid[])
         AND availability.managed_in_stock = true
         AND availability.qty_available > 0
-        AND warehouse.stock_scope IN ('OLD', 'NEW')
+        AND COALESCE(lot.source_scope, warehouse.stock_scope, 'NEW') IN ('OLD', 'NEW')
         AND COALESCE(lot.lot_status, 'LIBERE') = 'LIBERE'
       ORDER BY
         CASE COALESCE(lot.source_scope, warehouse.stock_scope, 'NEW') WHEN 'OLD' THEN 0 ELSE 1 END,

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -2991,8 +2991,11 @@ export async function repoGetArticle(id: string, includeCosts = false): Promise<
         a.piece_technique_id::text AS piece_technique_id,
         pt.code_piece AS piece_code,
         pt.designation AS piece_designation,
+        pt.code_client AS piece_client_code,
         pt.code_client AS client_code,
-        av.plan_reference AS plan_reference,
+        latest_version.plan_reference AS piece_plan_reference,
+        latest_version.indice AS piece_indice,
+        latest_version.plan_reference AS plan_reference,
         a.unite,
          a.lot_tracking,
          a.is_sold,
@@ -3066,6 +3069,13 @@ export async function repoGetArticle(id: string, includeCosts = false): Promise<
          ORDER BY v.date_application DESC NULLS LAST, v.created_at DESC
          LIMIT 1
        ) av ON TRUE
+       LEFT JOIN LATERAL (
+         SELECT v.indice, v.plan_reference
+         FROM public.piece_technique_versions v
+         WHERE v.piece_technique_id = a.piece_technique_id
+         ORDER BY v.is_current DESC, v.version_interne DESC, v.created_at DESC
+         LIMIT 1
+       ) latest_version ON TRUE
        LEFT JOIN (
          SELECT
            article_id::text AS article_id,


### PR DESCRIPTION
## Résumé
- corrige le GROUP BY responsable du SQLSTATE 42803 sur check_stock
- joint les lots dans les candidats de réservation/livraison
- conserve l'ordre FIFO OLD puis NEW
- expose le dernier indice lié dans la fiche Article

## Validation
- tests SQL de non-régression et 25 tests stock/fulfillment
- typecheck et build production
- requêtes corrigées exécutées sur cerp_test / commande 24

## Summary by Sourcery

Stabilize stock availability and fulfillment queries while exposing the latest technical-piece revision on article records.

Bug Fixes:
- Correct stock availability grouping so OLD/NEW quantities use the effective lot or warehouse scope without triggering SQL grouping errors.
- Ensure delivery candidates use lot-derived scopes and preserve FIFO ordering with OLD stock before NEW stock.

Enhancements:
- Expose the latest technical-piece plan reference and revision index in article details.

Tests:
- Add SQL contract tests covering effective-scope grouping and lot-aware delivery candidate selection.