### PR TITLE
fix(commandes): PDF AR exact et gamme vide non bloquante

### DIFF
--- a/src/__tests__/commande-ar-empty-gamme-880.contract.test.ts
+++ b/src/__tests__/commande-ar-empty-gamme-880.contract.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const read = (file: string) => readFileSync(resolve(root, file), "utf8");
+
+describe("#880 — archive AR exacte", () => {
+  it("file dans la GED les octets exacts du PDF préparé", () => {
+    const source = read("src/module/commande-client/repository/commande-ar.repository.ts");
+    const archiveCall = source.slice(
+      source.indexOf("await queueCreationPdfArchive(tx"),
+      source.indexOf("actorUserId: params.user_id", source.indexOf("await queueCreationPdfArchive(tx")) + 100
+    );
+
+    expect(archiveCall).toContain("exactPdfBytes: pdfBuffer");
+  });
+});
+
+describe("#880 — gamme vide non bloquante", () => {
+  it("conserve l'OF et expose un avertissement au lieu d'annuler la transaction", () => {
+    const source = read("src/module/production/domain/of-generation.ts");
+    const copy = source.slice(
+      source.indexOf("const operationsCount = await copyPieceOperationsToOf"),
+      source.indexOf("await tx.query(\n      `\n        INSERT INTO public.of_technical_snapshots")
+    );
+
+    expect(copy).toContain("GAMME_WITHOUT_OPERATION:");
+    expect(copy).not.toContain("PIECE_TECHNIQUE_OPERATION_REQUIRED");
+    expect(source).toContain("operations_count: operationsCount");
+  });
+
+  it("classe également la gamme vide en avertissement dans l'aperçu", () => {
+    const source = read("src/module/production/repository/production-generation.repository.ts");
+    const emptyGamme = source.slice(
+      source.indexOf("if (technical && operationsCount === 0)"),
+      source.indexOf("const documents", source.indexOf("if (technical && operationsCount === 0)"))
+    );
+
+    expect(emptyGamme).toContain("warnings.push");
+    expect(emptyGamme).not.toContain("blockers.push");
+  });
+
+  it("saute le planning inexistant et rend l'AR accessible", () => {
+    const source = read("src/module/commande-client/repository/commande-client.repository.ts");
+    expect(source).toContain('skip_reason: "no_plannable_operations"');
+    expect(source).toContain('nouveau_statut: "AR_PRET"');
+    expect(source).toContain("has_plannable_operations: generatedOfs.some");
+  });
+});

--- a/src/module/commande-client/domain/commande-ar-fingerprint.test.ts
+++ b/src/module/commande-client/domain/commande-ar-fingerprint.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCommandeArContentSnapshot,
+  isCommandeArSnapshotCurrent,
+} from "./commande-ar-fingerprint";
+
+const source = {
+  header: {
+    numero: "CMD-2026-0750",
+    customer_reference: "PO-999",
+    statut: "AR_PRET",
+    date_commande: "2026-08-26",
+    commentaire: null,
+    total_ht: 100,
+    total_ttc: 120,
+    client_company_name: "CROIX ROUSSE PRECISION SARL",
+    client_email: "lambert@croix-rousse-precision.fr",
+    client_phone: null,
+    bill_name: "CRP",
+    bill_street: "Rue de la Dombes",
+    bill_house_number: "530",
+    bill_postal_code: "01700",
+    bill_city: "MIRIBEL",
+    bill_country: "France",
+    deliv_name: "CRP",
+    deliv_street: "Rue de la Dombes",
+    deliv_house_number: "530",
+    deliv_postal_code: "01700",
+    deliv_city: "MIRIBEL",
+    deliv_country: "France",
+  },
+  lines: [{
+    designation: "Rail pare soleil",
+    code_piece: "ART-FAB-001",
+    quantite: 1,
+    unite: "pce",
+    prix_unitaire_ht: 100,
+    taux_tva: 20,
+    total_ttc: 120,
+    delai_client: "2026-09-10",
+    delai_interne: "2026-09-08",
+  }],
+};
+
+describe("empreinte documentaire AR", () => {
+  it("considère un snapshot v1 identique malgré les timestamps et identifiants techniques", () => {
+    const current = buildCommandeArContentSnapshot(source);
+    const legacy = {
+      schema_version: 1,
+      header: { ...current.header, updated_at: "2026-08-26T11:15:03.832746+02" },
+      lines: [{ id: 42, ...current.lines[0] }],
+      allocations: [{ id: "allocation-1", updated_at: "2026-08-26T11:15:20.414602+02" }],
+    };
+
+    expect(isCommandeArSnapshotCurrent({
+      storedSnapshot: legacy,
+      storedFingerprint: "legacy-hash",
+      currentSnapshot: current,
+    })).toBe(true);
+  });
+
+  it("rend la version obsolète quand un champ visible sur l’AR change", () => {
+    const stored = buildCommandeArContentSnapshot(source);
+    const current = buildCommandeArContentSnapshot({
+      ...source,
+      lines: [{ ...source.lines[0], quantite: 2 }],
+    });
+
+    expect(isCommandeArSnapshotCurrent({
+      storedSnapshot: stored,
+      storedFingerprint: null,
+      currentSnapshot: current,
+    })).toBe(false);
+  });
+});

--- a/src/module/commande-client/domain/commande-ar-fingerprint.ts
+++ b/src/module/commande-client/domain/commande-ar-fingerprint.ts
@@ -1,0 +1,173 @@
+import crypto from "node:crypto";
+
+type AddressSource = {
+  name?: unknown;
+  street?: unknown;
+  house_number?: unknown;
+  postal_code?: unknown;
+  city?: unknown;
+  country?: unknown;
+};
+
+type CommandeArFingerprintSource = {
+  header: {
+    numero: unknown;
+    customer_reference: unknown;
+    statut: unknown;
+    date_commande: unknown;
+    commentaire: unknown;
+    total_ht: unknown;
+    total_ttc: unknown;
+    client_company_name: unknown;
+    client_email: unknown;
+    client_phone: unknown;
+    bill_name?: unknown;
+    bill_street?: unknown;
+    bill_house_number?: unknown;
+    bill_postal_code?: unknown;
+    bill_city?: unknown;
+    bill_country?: unknown;
+    deliv_name?: unknown;
+    deliv_street?: unknown;
+    deliv_house_number?: unknown;
+    deliv_postal_code?: unknown;
+    deliv_city?: unknown;
+    deliv_country?: unknown;
+  };
+  lines: Array<{
+    designation: unknown;
+    code_piece: unknown;
+    quantite: unknown;
+    unite: unknown;
+    prix_unitaire_ht: unknown;
+    taux_tva: unknown;
+    total_ttc: unknown;
+    delai_client?: unknown;
+    delai_interne?: unknown;
+  }>;
+};
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(",")}}`;
+}
+
+export function sha256Canonical(value: unknown): string {
+  return crypto.createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+function normalizedAddress(source: AddressSource): Record<string, unknown> {
+  return {
+    name: source.name,
+    street: source.street,
+    house_number: source.house_number,
+    postal_code: source.postal_code,
+    city: source.city,
+    country: source.country,
+  };
+}
+
+function normalizedLine(source: Record<string, unknown>): Record<string, unknown> {
+  return {
+    designation: source.designation,
+    code_piece: source.code_piece,
+    quantite: source.quantite,
+    unite: source.unite,
+    prix_unitaire_ht: source.prix_unitaire_ht,
+    taux_tva: source.taux_tva,
+    total_ttc: source.total_ttc,
+    delai_client: source.delai_client ?? null,
+    delai_interne: source.delai_interne ?? null,
+  };
+}
+
+/**
+ * Snapshot of the customer-facing AR content only.
+ *
+ * Technical identifiers, allocation rows and update timestamps are deliberately
+ * excluded: they are not rendered in the acknowledgement and must not make a
+ * freshly generated document obsolete.
+ */
+export function buildCommandeArContentSnapshot(data: CommandeArFingerprintSource) {
+  return {
+    schema_version: 2,
+    header: {
+      numero: data.header.numero,
+      customer_reference: data.header.customer_reference,
+      statut: data.header.statut,
+      date_commande: data.header.date_commande,
+      commentaire: data.header.commentaire,
+      total_ht: data.header.total_ht,
+      total_ttc: data.header.total_ttc,
+      client_company_name: data.header.client_company_name,
+      client_email: data.header.client_email,
+      client_phone: data.header.client_phone,
+      bill_address: normalizedAddress({
+        name: data.header.bill_name,
+        street: data.header.bill_street,
+        house_number: data.header.bill_house_number,
+        postal_code: data.header.bill_postal_code,
+        city: data.header.bill_city,
+        country: data.header.bill_country,
+      }),
+      delivery_address: normalizedAddress({
+        name: data.header.deliv_name,
+        street: data.header.deliv_street,
+        house_number: data.header.deliv_house_number,
+        postal_code: data.header.deliv_postal_code,
+        city: data.header.deliv_city,
+        country: data.header.deliv_country,
+      }),
+    },
+    lines: data.lines.map((line) => normalizedLine(line as Record<string, unknown>)),
+  };
+}
+
+/** Normalizes both legacy v1 snapshots and current v2 snapshots for comparison. */
+export function normalizeCommandeArContentSnapshot(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const snapshot = value as Record<string, unknown>;
+  if (!snapshot.header || typeof snapshot.header !== "object" || Array.isArray(snapshot.header) || !Array.isArray(snapshot.lines)) return null;
+  const header = snapshot.header as Record<string, unknown>;
+  const billAddress = header.bill_address && typeof header.bill_address === "object" && !Array.isArray(header.bill_address)
+    ? header.bill_address as AddressSource
+    : {};
+  const deliveryAddress = header.delivery_address && typeof header.delivery_address === "object" && !Array.isArray(header.delivery_address)
+    ? header.delivery_address as AddressSource
+    : {};
+
+  return {
+    header: {
+      numero: header.numero,
+      customer_reference: header.customer_reference,
+      statut: header.statut,
+      date_commande: header.date_commande,
+      commentaire: header.commentaire,
+      total_ht: header.total_ht,
+      total_ttc: header.total_ttc,
+      client_company_name: header.client_company_name,
+      client_email: header.client_email,
+      client_phone: header.client_phone,
+      bill_address: normalizedAddress(billAddress),
+      delivery_address: normalizedAddress(deliveryAddress),
+    },
+    lines: snapshot.lines.map((line) => normalizedLine(
+      line && typeof line === "object" && !Array.isArray(line) ? line as Record<string, unknown> : {}
+    )),
+  };
+}
+
+export function isCommandeArSnapshotCurrent(params: {
+  storedSnapshot: unknown;
+  storedFingerprint: string | null;
+  currentSnapshot: unknown;
+}): boolean {
+  const currentNormalized = normalizeCommandeArContentSnapshot(params.currentSnapshot);
+  const storedNormalized = normalizeCommandeArContentSnapshot(params.storedSnapshot);
+  if (currentNormalized && storedNormalized) {
+    return sha256Canonical(currentNormalized) === sha256Canonical(storedNormalized);
+  }
+  return Boolean(params.storedFingerprint) && params.storedFingerprint === sha256Canonical(params.currentSnapshot);
+}

--- a/src/module/commande-client/domain/commande-client-launch.test.ts
+++ b/src/module/commande-client/domain/commande-client-launch.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCustomerOrderLaunchMode } from "./commande-client-launch";
+
+describe("parcours de lancement d'une commande client", () => {
+  it("conserve le planning lorsqu'au moins une opération existe", () => {
+    expect(resolveCustomerOrderLaunchMode({ needsProduction: true, generatedOperationsCount: 2 }))
+      .toBe("PRODUCTION_WITH_PLANNING");
+  });
+
+  it("saute le planning lorsqu'un OF ne contient aucune opération", () => {
+    expect(resolveCustomerOrderLaunchMode({ needsProduction: true, generatedOperationsCount: 0 }))
+      .toBe("PRODUCTION_WITHOUT_PLANNING");
+  });
+
+  it("conserve le parcours stock lorsqu'aucune production n'est nécessaire", () => {
+    expect(resolveCustomerOrderLaunchMode({ needsProduction: false, generatedOperationsCount: 0 }))
+      .toBe("STOCK_ONLY");
+  });
+});

--- a/src/module/commande-client/domain/commande-client-launch.ts
+++ b/src/module/commande-client/domain/commande-client-launch.ts
@@ -1,0 +1,19 @@
+export type CustomerOrderLaunchMode =
+  | "STOCK_ONLY"
+  | "PRODUCTION_WITH_PLANNING"
+  | "PRODUCTION_WITHOUT_PLANNING";
+
+/**
+ * Planning is meaningful only when at least one generated OF operation can be
+ * scheduled. An empty gamme remains traceable through its OF but must not trap
+ * the customer order on an impossible planning checkpoint.
+ */
+export function resolveCustomerOrderLaunchMode(params: {
+  needsProduction: boolean;
+  generatedOperationsCount: number;
+}): CustomerOrderLaunchMode {
+  if (!params.needsProduction) return "STOCK_ONLY";
+  return params.generatedOperationsCount > 0
+    ? "PRODUCTION_WITH_PLANNING"
+    : "PRODUCTION_WITHOUT_PLANNING";
+}

--- a/src/module/commande-client/repository/commande-ar.repository.test.ts
+++ b/src/module/commande-client/repository/commande-ar.repository.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   release: vi.fn(),
   applyMilestone: vi.fn(),
   ensureStatus: vi.fn(),
+  snapshotCurrent: vi.fn(),
 }));
 
 vi.mock("../../../config/database", () => ({
@@ -18,7 +19,13 @@ vi.mock("./commande-client.repository", () => ({
   repoEnsureCommandeWorkflowStatus: mocks.ensureStatus,
 }));
 
+vi.mock("../domain/commande-ar-fingerprint", () => ({
+  buildCommandeArContentSnapshot: vi.fn(() => ({})),
+  isCommandeArSnapshotCurrent: mocks.snapshotCurrent,
+}));
+
 import {
+  buildCommandeArRecipientSuggestions,
   repoAuthorizeCommandeArGeneration,
   repoClaimCommandeArSend,
   repoFinalizeCommandeArSend,
@@ -69,6 +76,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.connect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.release });
   mocks.applyMilestone.mockResolvedValue({ notifications: [] });
+  mocks.snapshotCurrent.mockReturnValue(true);
 });
 
 describe("commande AR durable send claim", () => {
@@ -80,6 +88,7 @@ describe("commande AR durable send claim", () => {
       if (q.includes("checkpoint_status")) {
         return { rows: [{ raw_statut: "AR_PRET", checkpoint_status: "active", responsible_role: "secretariat", assigned_user_id: null }] };
       }
+      if (q.includes("FROM public.commande_client cc")) return { rows: [{ commande_id: 123, client_id: null }] };
       if (q.includes("SET status = 'SENDING'")) return { rows: [{ send_attempt_count: 1 }] };
       return { rows: [] };
     });
@@ -99,6 +108,7 @@ describe("commande AR durable send claim", () => {
       if (q.includes("checkpoint_status")) {
         return { rows: [{ raw_statut: "AR_PRET", checkpoint_status: "active", responsible_role: "secretariat", assigned_user_id: null }] };
       }
+      if (q.includes("FROM public.commande_client cc")) return { rows: [{ commande_id: 123, client_id: null }] };
       return { rows: [] };
     });
 
@@ -107,6 +117,50 @@ describe("commande AR durable send claim", () => {
       code: "COMMANDE_AR_SEND_IN_PROGRESS",
     });
     expect(mocks.clientQuery.mock.calls.map(([sql]) => String(sql))).toContain("ROLLBACK");
+  });
+
+  it("rejects a draft whose customer-facing content changed", async () => {
+    mocks.snapshotCurrent.mockReturnValueOnce(false);
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q.includes("SELECT client_id FROM public.commande_client")) return { rows: [{ client_id: null }] };
+      if (q.includes("FROM public.commande_ar_log ar")) return { rows: [draftRow] };
+      if (q.includes("FROM public.commande_client cc")) return { rows: [{ commande_id: 123, client_id: null }] };
+      return { rows: [] };
+    });
+
+    await expect(repoClaimCommandeArSend(claimParams)).rejects.toMatchObject({
+      status: 409,
+      code: "COMMANDE_AR_OBSOLETE",
+    });
+    expect(mocks.clientQuery.mock.calls.map(([sql]) => String(sql))).toContain("ROLLBACK");
+  });
+});
+
+describe("commande AR recipient suggestions", () => {
+  it("deduplicates recipients by email and keeps the selected contact first", () => {
+    const suggestions = buildCommandeArRecipientSuggestions({
+      header: {
+        selected_contact_id: "selected",
+        client_email: "ACHATS@CLIENT.TEST",
+        client_company_name: "Client Exemple",
+      },
+      contacts: [
+        { contact_id: "other", first_name: "Autre", last_name: "Contact", email: "other@client.test", role: null, civility: null },
+        { contact_id: "duplicate", first_name: "Doublon", last_name: "Client", email: "achats@client.test", role: null, civility: null },
+        { contact_id: "selected", first_name: "Contact", last_name: "Choisi", email: "achats@client.test", role: "Achats", civility: null },
+      ],
+      lines: [],
+      allocations: [],
+    } as never);
+
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions[0]).toMatchObject({
+      email: "achats@client.test",
+      contact_id: "selected",
+      is_default: true,
+    });
+    expect(suggestions.filter((item) => item.is_default)).toHaveLength(1);
   });
 });
 

--- a/src/module/commande-client/repository/commande-ar.repository.ts
+++ b/src/module/commande-client/repository/commande-ar.repository.ts
@@ -19,6 +19,7 @@ import {
   repoEnsureCommandeWorkflowStatus,
 } from "./commande-client.repository";
 import { canActOnCommandeWorkflowCheckpoint } from "../domain/commande-client-rbac";
+import { buildCommandeArContentSnapshot, isCommandeArSnapshotCurrent } from "../domain/commande-ar-fingerprint";
 import { normalizeCommandeWorkflowStatus } from "../workflow/commande-client-workflow.definition";
 import type { AppNotification } from "../../notifications/types/notifications.types";
 import type {
@@ -185,15 +186,21 @@ function recipientKey(source: "CLIENT" | "CONTACT", email: string, contactId: st
 
 export function buildCommandeArRecipientSuggestions(data: CommandeArGenerationData): CommandeArRecipientSuggestion[] {
   const out: CommandeArRecipientSuggestion[] = [];
-  const seen = new Set<string>();
+  const seenEmails = new Set<string>();
   const selectedContactId = data.header.selected_contact_id;
   const push = (suggestion: CommandeArRecipientSuggestion) => {
-    if (seen.has(suggestion.key)) return;
-    seen.add(suggestion.key);
+    const normalizedEmail = suggestion.email.toLowerCase();
+    if (seenEmails.has(normalizedEmail)) return;
+    seenEmails.add(normalizedEmail);
     out.push(suggestion);
   };
 
-  for (const contact of data.contacts) {
+  const orderedContacts = [...data.contacts].sort((left, right) => {
+    const leftSelected = left.contact_id === selectedContactId ? 1 : 0;
+    const rightSelected = right.contact_id === selectedContactId ? 1 : 0;
+    return rightSelected - leftSelected;
+  });
+  for (const contact of orderedContacts) {
     const email = cleanEmail(contact.email);
     if (!email) continue;
     const key = recipientKey("CONTACT", email, contact.contact_id);
@@ -664,16 +671,9 @@ export async function repoCreateCommandeArDraft(params: {
     let archivedSourceRevision: string | null = null;
     let documentVersion: number | null = null;
     if (params.official_source_snapshot) {
-      // Updating the parent first makes the stored revision exactly the token
-      // returned by the order API after this acknowledgement is created.
-      const revisionResult = await tx.query<{ source_revision: string | null }>(
-        `UPDATE public.commande_client
-            SET updated_at = now()
-          WHERE id = $1
-        RETURNING updated_at::text AS source_revision`,
-        [params.commande_id]
-      );
-      archivedSourceRevision = revisionResult.rows[0]?.source_revision?.trim() ?? null;
+      // AR generation freezes the current business source; it must not mutate
+      // the parent order and make its own fingerprint immediately obsolete.
+      archivedSourceRevision = exists.rows[0].updated_at?.trim() ?? null;
       if (!archivedSourceRevision) throw new HttpError(409, "OFFICIAL_DOCUMENT_SOURCE_REVISION_UNAVAILABLE", "La révision source du document est indisponible.");
       const versionResult = await tx.query<{ count: string }>(
         `SELECT count(*)::text AS count
@@ -1360,6 +1360,15 @@ export async function repoClaimCommandeArSend(params: {
           already_sent: true,
         },
       };
+    }
+    const currentData = await repoLoadCommandeArGenerationData(client, params.commande_id);
+    if (!currentData) throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable");
+    if (!isCommandeArSnapshotCurrent({
+      storedSnapshot: draft.content_snapshot,
+      storedFingerprint: draft.content_fingerprint,
+      currentSnapshot: buildCommandeArContentSnapshot(currentData),
+    })) {
+      throw new HttpError(409, "COMMANDE_AR_OBSOLETE", "La commande a changé depuis la génération de cet accusé de réception.");
     }
 
     await repoAuthorizeCommandeArGeneration({

--- a/src/module/commande-client/repository/commande-ar.repository.ts
+++ b/src/module/commande-client/repository/commande-ar.repository.ts
@@ -698,6 +698,11 @@ export async function repoCreateCommandeArDraft(params: {
           acknowledgement_id: arId,
           acknowledgement_number: version.reference,
         },
+        // The reviewed working PDF is the legal issuance. Filing these exact
+        // bytes prevents the background worker from rendering a subtly
+        // different document (timestamps, customer reference, PDF metadata)
+        // and guarantees that preview, GED archive and email attachment match.
+        exactPdfBytes: pdfBuffer,
         actorUserId: params.user_id,
       });
     } else {

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -60,6 +60,7 @@ import {
 } from "../../production/domain/of-generation";
 import { queueRootOfCreationPdf } from "../../production/domain/of-creation-pdf";
 import { canActOnCommandeWorkflowCheckpoint, canLaunchInternalOrder } from "../domain/commande-client-rbac";
+import { resolveCustomerOrderLaunchMode } from "../domain/commande-client-launch";
 import {
   assertCommandeFullyInvoiced,
   assertCommandeFullyShipped,
@@ -880,19 +881,21 @@ async function listGeneratedOfRefs(db: Queryable, commandeId: number): Promise<G
     parent_of_id: number | null;
     generation_level: number;
     commande_ligne_id: number;
+    operations_count: number;
   }>(
     `
       SELECT
-        id::bigint::int AS id,
-        COALESCE(root_of_id, id)::bigint::int AS root_of_id,
-        parent_of_id::bigint::int AS parent_of_id,
-        generation_level::int AS generation_level,
-        commande_ligne_id::bigint::int AS commande_ligne_id
-      FROM public.ordres_fabrication
-      WHERE commande_id = $1
-        AND generation_batch_id IS NOT NULL
-        AND statut::text <> 'ANNULE'
-      ORDER BY generation_level ASC, id ASC
+        o.id::bigint::int AS id,
+        COALESCE(o.root_of_id, o.id)::bigint::int AS root_of_id,
+        o.parent_of_id::bigint::int AS parent_of_id,
+        o.generation_level::int AS generation_level,
+        o.commande_ligne_id::bigint::int AS commande_ligne_id,
+        (SELECT count(*)::int FROM public.of_operations op WHERE op.of_id = o.id) AS operations_count
+      FROM public.ordres_fabrication o
+      WHERE o.commande_id = $1
+        AND o.generation_batch_id IS NOT NULL
+        AND o.statut::text <> 'ANNULE'
+      ORDER BY o.generation_level ASC, o.id ASC
     `,
     [commandeId]
   );
@@ -903,6 +906,7 @@ async function listGeneratedOfRefs(db: Queryable, commandeId: number): Promise<G
     parent_of_id: row.parent_of_id === null ? null : Number(row.parent_of_id),
     generation_level: Number(row.generation_level),
     commande_ligne_id: Number(row.commande_ligne_id),
+    operations_count: Number(row.operations_count ?? 0),
   }));
 }
 
@@ -1531,10 +1535,59 @@ async function advanceCustomerOrderWorkflowAfterLaunch(params: {
   commande_id: number;
   user_id: number;
   needs_production: boolean;
+  has_plannable_operations: boolean;
   bon_livraison_id: string | null;
   of_ids: number[];
 }) {
-  if (params.needs_production) {
+  const launchMode = resolveCustomerOrderLaunchMode({
+    needsProduction: params.needs_production,
+    generatedOperationsCount: params.has_plannable_operations ? 1 : 0,
+  });
+
+  if (launchMode === "PRODUCTION_WITHOUT_PLANNING") {
+    await params.tx.query(
+      `
+        UPDATE public.commande_client_workflow_checkpoint
+        SET status = CASE
+              WHEN checkpoint_code IN ('of_generation', 'ar_preparation') THEN 'done'
+              WHEN checkpoint_code = 'planning_validation' THEN 'skipped'
+              WHEN checkpoint_code = 'ar_sent' THEN 'active'
+              ELSE status
+            END,
+            completed_at = CASE
+              WHEN checkpoint_code = 'ar_sent' THEN NULL
+              ELSE COALESCE(completed_at, now())
+            END,
+            completed_by = CASE
+              WHEN checkpoint_code = 'ar_sent' THEN NULL
+              ELSE COALESCE(completed_by, $2::int)
+            END,
+            metadata = COALESCE(metadata, '{}'::jsonb) || $3::jsonb,
+            updated_at = now()
+        WHERE commande_id = $1
+          AND checkpoint_code IN ('of_generation', 'planning_validation', 'ar_preparation', 'ar_sent')
+      `,
+      [
+        params.commande_id,
+        params.user_id,
+        JSON.stringify({
+          skip_reason: "no_plannable_operations",
+          no_operation_flow: true,
+          of_ids: params.of_ids,
+        }),
+      ]
+    );
+    return repoEnsureCommandeWorkflowStatus({
+      tx: params.tx,
+      commande_id: params.commande_id,
+      nouveau_statut: "AR_PRET",
+      cause: "customer_order_launch",
+      commentaire: "OF sans opération généré ; planning non applicable et AR prêt à préparer",
+      user_id: params.user_id,
+    });
+  }
+
+  if (launchMode === "PRODUCTION_WITH_PLANNING") {
     await params.tx.query(
       `
         UPDATE public.commande_client_workflow_checkpoint
@@ -4342,9 +4395,14 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           child_of_ids: existingOfs.filter((of) => of.parent_of_id !== null).map((of) => of.id),
           ofs: existingOfs,
           warnings:
-            orderType === "INTERNE" && existingLivraisons.length > 1
-              ? ["LEGACY_MULTIPLE_DELIVERY_AFFAIRS"]
-              : [],
+            [
+              ...(orderType === "INTERNE" && existingLivraisons.length > 1
+                ? ["LEGACY_MULTIPLE_DELIVERY_AFFAIRS"]
+                : []),
+              ...existingOfs
+                .filter((of) => of.operations_count === 0)
+                .map((of) => `GAMME_WITHOUT_OPERATION:OF-${of.id}`),
+            ],
         };
       }
 
@@ -4618,6 +4676,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
     const bonLivraisonId = preparedDelivery?.bon_livraison_id ?? null;
 
     const generatedOfs: GeneratedOfRef[] = [];
+    const generationWarnings: string[] = [];
     if (needsProduction) {
       const byLine = new Map<number, CommandeLineRef>(refs.map((r) => [r.commande_ligne_id, r] as const));
 
@@ -4647,6 +4706,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           user_id: audit.user_id,
         });
         generatedOfs.push(...generated.ofs);
+        generationWarnings.push(...generated.warnings);
       }
     }
 
@@ -4685,6 +4745,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         commande_id: commandeId,
         user_id: audit.user_id,
         needs_production: needsProduction,
+        has_plannable_operations: generatedOfs.some((of) => of.operations_count > 0),
         bon_livraison_id: bonLivraisonId,
         of_ids: ofIds,
       });
@@ -4755,7 +4816,10 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       generation_mode: orderType === "INTERNE" ? "INTERNAL_ORDER" : "CUSTOMER_ORDER",
       idempotent_replay: false,
       workflow_status: workflowStatus,
-      warnings: recoveredInvalidPlanningState ? ["RECOVERED_PLANNING_WITHOUT_OF_OR_DELIVERY"] : [],
+      warnings: [...new Set([
+        ...(recoveredInvalidPlanningState ? ["RECOVERED_PLANNING_WITHOUT_OF_OR_DELIVERY"] : []),
+        ...generationWarnings,
+      ])],
     };
   });
 }

--- a/src/module/commande-client/services/commande-ar.service.ts
+++ b/src/module/commande-client/services/commande-ar.service.ts
@@ -31,6 +31,11 @@ import {
 import pool from "../../../config/database";
 import type { AuthoritativePdfArchiveRecord } from "../../../shared/authoritative-documents/authoritative-document.types";
 import { getOfficialDocumentGenerationEnvelope, getOfficialPdfDto, readOfficialPdfBytes, recordOfficialPdfPrintIntent } from "../../../shared/authoritative-documents/authoritative-document.service";
+import {
+  buildCommandeArContentSnapshot,
+  isCommandeArSnapshotCurrent,
+  sha256Canonical,
+} from "../domain/commande-ar-fingerprint";
 
 const ACKNOWLEDGEMENT_DOCUMENT_KIND = "CUSTOMER_ORDER_ACKNOWLEDGEMENT";
 
@@ -82,16 +87,7 @@ function escapeHtml(text: string): string {
     .replace(/'/g, "&#039;");
 }
 
-function canonicalJson(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(",")}}`;
-}
-
-export function sha256Canonical(value: unknown): string {
-  return crypto.createHash("sha256").update(canonicalJson(value)).digest("hex");
-}
+export { sha256Canonical } from "../domain/commande-ar-fingerprint";
 
 export function renderCommandeArEmailHtml(text: string): string {
   const paragraphs = text
@@ -399,26 +395,7 @@ export async function svcGenerateCommandeAr(params: {
       delivery_address: { name: data.header.deliv_name, street: data.header.deliv_street, house_number: data.header.deliv_house_number, postal_code: data.header.deliv_postal_code, city: data.header.deliv_city, country: data.header.deliv_country },
       lines: data.lines.map((line) => ({ designation: line.designation, code_piece: line.code_piece, quantite: String(line.quantite), unite: line.unite, prix_unitaire_ht: String(line.prix_unitaire_ht), taux_tva: line.taux_tva == null ? null : String(line.taux_tva), total_ttc: String(line.total_ttc) })), issuer,
     };
-    const contentSnapshot = {
-      schema_version: 1,
-      header: {
-        numero: data.header.numero,
-        customer_reference: data.header.customer_reference,
-        statut: data.header.statut,
-        updated_at: data.header.updated_at,
-        date_commande: data.header.date_commande,
-        commentaire: data.header.commentaire,
-        total_ht: data.header.total_ht,
-        total_ttc: data.header.total_ttc,
-        client_company_name: data.header.client_company_name,
-        client_email: data.header.client_email,
-        client_phone: data.header.client_phone,
-        bill_address: officialSnapshot.bill_address,
-        delivery_address: officialSnapshot.delivery_address,
-      },
-      lines: data.lines,
-      allocations: data.allocations,
-    };
+    const contentSnapshot = buildCommandeArContentSnapshot(data);
     const contentFingerprint = sha256Canonical(contentSnapshot);
     const defaultContact = recipientSuggestions.filter((suggestion) => suggestion.is_default && suggestion.contact_id).length === 1
       ? data.contacts.find((contact) => contact.contact_id === recipientSuggestions.find((suggestion) => suggestion.is_default)?.contact_id) ?? null
@@ -637,41 +614,7 @@ export async function svcListCommandeArVersions(params: {
   const data = await repoLoadCommandeArGenerationData(pool, params.commande_id);
   if (!data) throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable");
 
-  const contentSnapshot = {
-    schema_version: 1,
-    header: {
-      numero: data.header.numero,
-      customer_reference: data.header.customer_reference,
-      statut: data.header.statut,
-      updated_at: data.header.updated_at,
-      date_commande: data.header.date_commande,
-      commentaire: data.header.commentaire,
-      total_ht: data.header.total_ht,
-      total_ttc: data.header.total_ttc,
-      client_company_name: data.header.client_company_name,
-      client_email: data.header.client_email,
-      client_phone: data.header.client_phone,
-      bill_address: {
-        name: data.header.bill_name,
-        street: data.header.bill_street,
-        house_number: data.header.bill_house_number,
-        postal_code: data.header.bill_postal_code,
-        city: data.header.bill_city,
-        country: data.header.bill_country,
-      },
-      delivery_address: {
-        name: data.header.deliv_name,
-        street: data.header.deliv_street,
-        house_number: data.header.deliv_house_number,
-        postal_code: data.header.deliv_postal_code,
-        city: data.header.deliv_city,
-        country: data.header.deliv_country,
-      },
-    },
-    lines: data.lines,
-    allocations: data.allocations,
-  };
-  const currentFingerprint = sha256Canonical(contentSnapshot);
+  const contentSnapshot = buildCommandeArContentSnapshot(data);
   const recipientSuggestions = buildCommandeArRecipientSuggestions(data);
   const versions = (await repoListCommandeArDrafts({ commande_id: params.commande_id })).map((draft) => ({
     ar_id: draft.ar_id,
@@ -688,7 +631,11 @@ export async function svcListCommandeArVersions(params: {
     status: draft.status,
     sent_at: draft.sent_at,
     preview_path: draft.preview_path,
-    is_obsolete: draft.content_fingerprint !== currentFingerprint,
+    is_obsolete: !isCommandeArSnapshotCurrent({
+      storedSnapshot: draft.content_snapshot,
+      storedFingerprint: draft.content_fingerprint,
+      currentSnapshot: contentSnapshot,
+    }),
     reused_draft: false,
     recipient_suggestions: recipientSuggestions,
   }));

--- a/src/module/production/domain/of-generation.ts
+++ b/src/module/production/domain/of-generation.ts
@@ -609,6 +609,7 @@ export type GeneratedOfRef = {
   parent_of_id: number | null;
   generation_level: number;
   commande_ligne_id: number | null;
+  operations_count: number;
 };
 
 export type RecursiveOfGenerationResult = {
@@ -617,6 +618,7 @@ export type RecursiveOfGenerationResult = {
   ofs: GeneratedOfRef[];
   source_hash: string;
   purchase_requirements: PurchaseRequirement[];
+  warnings: string[];
 };
 
 export type OfGenerationSourceType = "COMMANDE_CLIENT" | "AFFAIRE" | "MANUAL";
@@ -715,6 +717,7 @@ export async function createRecursiveOrdresFabrication(tx: Queryable, params: {
 
   const generatedOfs: GeneratedOfRef[] = [];
   const purchaseRequirements: PurchaseRequirement[] = [];
+  const warnings: string[] = [];
 
   for (const node of tree) {
     const ofId = ofIdByKey.get(node.key);
@@ -806,11 +809,10 @@ export async function createRecursiveOrdresFabrication(tx: Queryable, params: {
       gamme_id: technical.gamme_id,
     });
     if (operationsCount === 0) {
-      throw new HttpError(
-        409,
-        "PIECE_TECHNIQUE_OPERATION_REQUIRED",
-        `Cannot create complete OF: piece technique ${node.code_piece} has no operation for line ${params.commande_ligne_id ?? "?"}`
-      );
+      // A legitimate article may not require workshop operations yet. Keep a
+      // traceable OF and its immutable technical snapshot, but let the order
+      // workflow bypass the planning checkpoint that has nothing to schedule.
+      warnings.push(`GAMME_WITHOUT_OPERATION:${node.code_piece}`);
     }
 
     await tx.query(
@@ -881,6 +883,7 @@ export async function createRecursiveOrdresFabrication(tx: Queryable, params: {
       parent_of_id: parentOfId,
       generation_level: node.level,
       commande_ligne_id: params.commande_ligne_id,
+      operations_count: operationsCount,
     });
   }
 
@@ -902,6 +905,7 @@ export async function createRecursiveOrdresFabrication(tx: Queryable, params: {
         max_level: generatedOfs.reduce((acc, of) => Math.max(acc, of.generation_level), 0),
         source_hash: sourceHash,
         purchase_requirements: purchaseRequirements,
+        warnings,
       }),
     ]
   );
@@ -912,5 +916,6 @@ export async function createRecursiveOrdresFabrication(tx: Queryable, params: {
     ofs: generatedOfs,
     source_hash: sourceHash,
     purchase_requirements: purchaseRequirements,
+    warnings,
   };
 }

--- a/src/module/production/repository/production-generation.repository.ts
+++ b/src/module/production/repository/production-generation.repository.ts
@@ -266,12 +266,7 @@ export async function repoPreviewOfGeneration(params: {
       const qtyLancee = Number((source.quantity * node.quantite_cumulee).toFixed(3));
       const operationsCount = Array.isArray(snapshot.operations) ? snapshot.operations.length : 0;
       if (technical && operationsCount === 0) {
-        blockers.push({
-          code: "PIECE_TECHNIQUE_OPERATION_REQUIRED",
-          message: `La pièce ${node.code_piece} n'a aucune opération de gamme applicable.`,
-          piece_technique_id: node.piece_technique_id,
-          structure_path: node.key,
-        });
+        warnings.push(`GAMME_WITHOUT_OPERATION:${node.code_piece}`);
       }
       const documents = Array.isArray(snapshot.documents) ? snapshot.documents : [];
       if (technical && documents.length === 0) {

--- a/src/module/production/repository/production.repository.ts
+++ b/src/module/production/repository/production.repository.ts
@@ -3589,14 +3589,9 @@ export async function repoCreateOrdreFabrication(params: {
       piece_technique_id: b.piece_technique_id,
       gamme_id: technical.gamme_id,
     });
-    // #170 : même refus que la génération récursive — pas d'OF sans gamme/opérations.
-    if (operationsCount === 0) {
-      throw new HttpError(
-        409,
-        "PIECE_TECHNIQUE_OPERATION_REQUIRED",
-        "Impossible de créer l'OF : la pièce technique n'a aucune opération de gamme applicable."
-      );
-    }
+    // An empty gamme is non-blocking: the OF and immutable technical evidence
+    // still exist, while callers can explicitly skip an inapplicable planning
+    // checkpoint instead of losing the whole creation transaction.
 
     await client.query(
       `INSERT INTO public.of_technical_snapshots (of_id, piece_technique_version_id, snapshot, snapshot_sha256, created_by)


### PR DESCRIPTION
Corrige le décalage entre le PDF AR préparé, le PDF GED officiel et la pièce jointe envoyée en archivant les octets exacts validés. Autorise également le lancement d'une commande avec OF sans opération en sautant explicitement le planning non applicable. Tests ciblés, typecheck et build validés. Lié à BigFootLime/crp-systems-web#880.

## Summary by Sourcery

Ensure AR documents remain content-consistent and let orders with non-plannable manufacturing operations complete through an explicit non-planning workflow.

Bug Fixes:
- Archive the exact reviewed AR PDF bytes so the preview, GED document, and emailed attachment remain identical.
- Allow orders whose generated manufacturing orders have no operations to proceed without planning and expose the condition as a warning.
- Reject AR drafts as obsolete when customer-visible order content changes after generation.
- Deduplicate AR recipients by email while prioritizing the selected contact.

Enhancements:
- Centralize version-tolerant canonical snapshots and fingerprints for customer-facing AR content.
- Preserve traceable manufacturing orders and technical snapshots for empty gammes while reporting their warnings.

Tests:
- Add focused coverage for exact AR archiving, empty-gamme workflow handling, snapshot compatibility, obsolete drafts, launch modes, and recipient suggestions.