### PR TITLE
fix: remove obsolete internal stock destination constraint (#883)

### DIFF
--- a/db/patches/20260826_zzz_internal_order_auto_destination_883.sql
+++ b/db/patches/20260826_zzz_internal_order_auto_destination_883.sql
@@ -1,0 +1,10 @@
+-- Commandes internes: NEW-PF and the client location are resolved when the
+-- finished part is received. The order itself must therefore remain valid
+-- without a preselected stock destination.
+
+BEGIN;
+
+ALTER TABLE public.commande_client
+  DROP CONSTRAINT IF EXISTS commande_client_internal_stock_dest_check;
+
+COMMIT;

--- a/db/patches/support/20260826_zzz_internal_order_auto_destination_883.preflight.sql
+++ b/db/patches/support/20260826_zzz_internal_order_auto_destination_883.preflight.sql
@@ -1,0 +1,18 @@
+-- Read-only preflight for 20260826_zzz_internal_order_auto_destination_883.sql.
+BEGIN TRANSACTION READ ONLY;
+
+SELECT
+  c.oid IS NOT NULL AS has_commande_client,
+  pg_get_constraintdef(k.oid, true) AS current_constraint_definition,
+  count(cc.*) FILTER (
+    WHERE cc.order_type = 'INTERNE'
+      AND cc.dest_stock_magasin_id IS NULL
+  )::bigint AS internal_orders_without_preselected_warehouse
+FROM (SELECT to_regclass('public.commande_client') AS oid) c
+LEFT JOIN pg_constraint k
+  ON k.conrelid = c.oid
+ AND k.conname = 'commande_client_internal_stock_dest_check'
+LEFT JOIN public.commande_client cc ON true
+GROUP BY c.oid, k.oid;
+
+ROLLBACK;

--- a/db/patches/support/20260826_zzz_internal_order_auto_destination_883.rollback.sql
+++ b/db/patches/support/20260826_zzz_internal_order_auto_destination_883.rollback.sql
@@ -1,0 +1,24 @@
+-- Guarded rollback for 20260826_zzz_internal_order_auto_destination_883.sql.
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_setting('cerp.confirm_internal_order_destination_rollback', true) IS DISTINCT FROM 'APPROVED' THEN
+    RAISE EXCEPTION 'Set cerp.confirm_internal_order_destination_rollback=APPROVED after human validation';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.commande_client
+    WHERE order_type = 'INTERNE'
+      AND dest_stock_magasin_id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Rollback refused: internal orders depend on automatic stock destination resolution';
+  END IF;
+END $$;
+
+ALTER TABLE public.commande_client
+  ADD CONSTRAINT commande_client_internal_stock_dest_check
+  CHECK (order_type <> 'INTERNE' OR dest_stock_magasin_id IS NOT NULL);
+
+COMMIT;

--- a/db/patches/support/20260826_zzz_internal_order_auto_destination_883.verify.sql
+++ b/db/patches/support/20260826_zzz_internal_order_auto_destination_883.verify.sql
@@ -1,0 +1,29 @@
+-- Read-only verification for 20260826_zzz_internal_order_auto_destination_883.sql.
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+BEGIN
+  IF to_regclass('public.commande_client') IS NULL THEN
+    RAISE EXCEPTION 'Missing public.commande_client';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.commande_client'::regclass
+      AND conname = 'commande_client_internal_stock_dest_check'
+  ) THEN
+    RAISE EXCEPTION 'Obsolete internal stock destination constraint is still present';
+  END IF;
+END $$;
+
+SELECT
+  count(*) FILTER (WHERE order_type = 'INTERNE')::bigint AS internal_order_count,
+  count(*) FILTER (
+    WHERE order_type = 'INTERNE'
+      AND dest_stock_magasin_id IS NULL
+      AND dest_stock_emplacement_id IS NULL
+  )::bigint AS internal_orders_using_automatic_destination
+FROM public.commande_client;
+
+ROLLBACK;

--- a/src/__tests__/internal-order-auto-destination-883.migration-guards.test.ts
+++ b/src/__tests__/internal-order-auto-destination-883.migration-guards.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const basename = "20260826_zzz_internal_order_auto_destination_883";
+const readPatch = () => readFileSync(resolve(process.cwd(), "db/patches", `${basename}.sql`), "utf8");
+const readSupport = (kind: "preflight" | "verify" | "rollback") =>
+  readFileSync(resolve(process.cwd(), "db/patches/support", `${basename}.${kind}.sql`), "utf8");
+
+describe("internal order automatic stock destination migration", () => {
+  it("drops only the obsolete creation-time destination constraint", () => {
+    const patch = readPatch();
+
+    expect(patch).toMatch(/^BEGIN;/m);
+    expect(patch).toContain("DROP CONSTRAINT IF EXISTS commande_client_internal_stock_dest_check");
+    expect(patch).not.toMatch(/DROP\s+(?:TABLE|COLUMN)/i);
+    expect(patch).toMatch(/COMMIT;\s*$/);
+  });
+
+  it("keeps preflight and verification read-only", () => {
+    const preflight = readSupport("preflight");
+    const verify = readSupport("verify");
+    const mutatingSql = /\b(?:INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/i;
+
+    expect(preflight).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(verify).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(preflight).not.toMatch(mutatingSql);
+    expect(verify).not.toMatch(mutatingSql);
+    expect(verify).toContain("Obsolete internal stock destination constraint is still present");
+  });
+
+  it("refuses rollback once an internal order relies on automatic resolution", () => {
+    const rollback = readSupport("rollback");
+
+    expect(rollback).toContain("cerp.confirm_internal_order_destination_rollback");
+    expect(rollback).toContain("Rollback refused: internal orders depend on automatic stock destination resolution");
+    expect(rollback).toContain("ADD CONSTRAINT commande_client_internal_stock_dest_check");
+  });
+});


### PR DESCRIPTION
## Correctif complémentaire découvert en UI\n\nLa commande interne sans destination saisie atteint désormais le backend, mais la contrainte historique commande_client_internal_stock_dest_check rejetait encore l'insertion.\n\n- migration transactionnelle ciblée supprimant uniquement la contrainte obsolète\n- preflight, vérification read-only et rollback gardé\n- test de garde migration 3/3\n- typecheck et build production OK\n\nCloses #883

## Summary by Sourcery

Remove the obsolete internal stock destination constraint so automatic destination resolution can occur when internal orders are fulfilled.

Bug Fixes:
- Allow internal orders to be created without a preselected stock destination by removing the obsolete database constraint.

Enhancements:
- Add read-only preflight and verification checks plus a guarded rollback path for the migration.

Tests:
- Add migration guard tests covering scoped constraint removal, read-only checks, and rollback protection.