### PR TITLE
release: fiabiliser stocks, commandes internes, planning et AR (#883)

### DIFF
--- a/contracts/commande-client-workflow.v1.json
+++ b/contracts/commande-client-workflow.v1.json
@@ -272,6 +272,11 @@
       "cause": "customer_order_launch"
     },
     {
+      "from": "AR_PRET",
+      "to": "ATTENTE_PLANNING",
+      "cause": "planning_repair"
+    },
+    {
       "from": "ATTENTE_TECHNIQUE",
       "to": "ATTENTE_PLANNING",
       "cause": "internal_order_launch"

--- a/db/patches/20260826_zzz_internal_order_auto_destination_883.sql
+++ b/db/patches/20260826_zzz_internal_order_auto_destination_883.sql
@@ -1,0 +1,10 @@
+-- Commandes internes: NEW-PF and the client location are resolved when the
+-- finished part is received. The order itself must therefore remain valid
+-- without a preselected stock destination.
+
+BEGIN;
+
+ALTER TABLE public.commande_client
+  DROP CONSTRAINT IF EXISTS commande_client_internal_stock_dest_check;
+
+COMMIT;

--- a/db/patches/support/20260826_zzz_internal_order_auto_destination_883.preflight.sql
+++ b/db/patches/support/20260826_zzz_internal_order_auto_destination_883.preflight.sql
@@ -1,0 +1,18 @@
+-- Read-only preflight for 20260826_zzz_internal_order_auto_destination_883.sql.
+BEGIN TRANSACTION READ ONLY;
+
+SELECT
+  c.oid IS NOT NULL AS has_commande_client,
+  pg_get_constraintdef(k.oid, true) AS current_constraint_definition,
+  count(cc.*) FILTER (
+    WHERE cc.order_type = 'INTERNE'
+      AND cc.dest_stock_magasin_id IS NULL
+  )::bigint AS internal_orders_without_preselected_warehouse
+FROM (SELECT to_regclass('public.commande_client') AS oid) c
+LEFT JOIN pg_constraint k
+  ON k.conrelid = c.oid
+ AND k.conname = 'commande_client_internal_stock_dest_check'
+LEFT JOIN public.commande_client cc ON true
+GROUP BY c.oid, k.oid;
+
+ROLLBACK;

--- a/db/patches/support/20260826_zzz_internal_order_auto_destination_883.rollback.sql
+++ b/db/patches/support/20260826_zzz_internal_order_auto_destination_883.rollback.sql
@@ -1,0 +1,24 @@
+-- Guarded rollback for 20260826_zzz_internal_order_auto_destination_883.sql.
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_setting('cerp.confirm_internal_order_destination_rollback', true) IS DISTINCT FROM 'APPROVED' THEN
+    RAISE EXCEPTION 'Set cerp.confirm_internal_order_destination_rollback=APPROVED after human validation';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.commande_client
+    WHERE order_type = 'INTERNE'
+      AND dest_stock_magasin_id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Rollback refused: internal orders depend on automatic stock destination resolution';
+  END IF;
+END $$;
+
+ALTER TABLE public.commande_client
+  ADD CONSTRAINT commande_client_internal_stock_dest_check
+  CHECK (order_type <> 'INTERNE' OR dest_stock_magasin_id IS NOT NULL);
+
+COMMIT;

--- a/db/patches/support/20260826_zzz_internal_order_auto_destination_883.verify.sql
+++ b/db/patches/support/20260826_zzz_internal_order_auto_destination_883.verify.sql
@@ -1,0 +1,29 @@
+-- Read-only verification for 20260826_zzz_internal_order_auto_destination_883.sql.
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+BEGIN
+  IF to_regclass('public.commande_client') IS NULL THEN
+    RAISE EXCEPTION 'Missing public.commande_client';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.commande_client'::regclass
+      AND conname = 'commande_client_internal_stock_dest_check'
+  ) THEN
+    RAISE EXCEPTION 'Obsolete internal stock destination constraint is still present';
+  END IF;
+END $$;
+
+SELECT
+  count(*) FILTER (WHERE order_type = 'INTERNE')::bigint AS internal_order_count,
+  count(*) FILTER (
+    WHERE order_type = 'INTERNE'
+      AND dest_stock_magasin_id IS NULL
+      AND dest_stock_emplacement_id IS NULL
+  )::bigint AS internal_orders_using_automatic_destination
+FROM public.commande_client;
+
+ROLLBACK;

--- a/docs/http/commande-interne.md
+++ b/docs/http/commande-interne.md
@@ -1,24 +1,10 @@
-# Commande interne : validation et lancement
+# Commande interne : fabrication, planning et mise en stock
 
-Ce document décrit le contrat backend du flux cible de commande interne. Il complète la décision fonctionnelle portée par l'issue frontend `crp-systems-web#153` et l'issue backend `erp-crp-backend#85`.
+Ce document décrit le contrat backend validé le 2026-08-26 pour `order_type = INTERNE` (`crp-systems-web#883`).
 
-## Objectif
-
-Une commande dont `order_type = INTERNE` est le point d'entrée unique du besoin interne. Sa validation génère, dans une seule transaction :
-
-1. exactement une affaire de livraison ;
-2. les allocations de toutes les lignes ;
-3. un OF racine par ligne et les OF enfants issus de la nomenclature ;
-4. le passage du workflow à `ATTENTE_PLANNING` ;
-5. les événements et l'audit associés.
-
-Le flux ne génère ni AR client, ni facture, ni BL. Le BL reste un résultat ultérieur du processus logistique, après libération qualité.
-
-## Endpoint
+## Lancement
 
 `POST /api/v1/commandes/:id/generate-affaires`
-
-La route exige une session authentifiée. Pour une commande interne, le lancement est réservé à un rôle d'administration, de direction ou de responsabilité production/atelier.
 
 Requête canonique :
 
@@ -30,86 +16,54 @@ Requête canonique :
 }
 ```
 
-Les choix de stock d'expédition et les découpages en plusieurs affaires restent disponibles pour les commandes client historiques, mais sont interdits pour les commandes internes.
+Le nom historique de l’endpoint reste compatible, mais une commande interne ne crée plus d’affaire :
 
-## Préconditions internes
+- `affaire_ids`, `livraison_affaire_ids` : tableaux vides ;
+- `livraison_affaire_id` : `null` ;
+- aucune allocation de livraison ;
+- aucune réservation de stock ;
+- un OF racine par ligne et les OF enfants requis ;
+- workflow placé sur `ATTENTE_PLANNING`, même lorsque les OF n’ont aucune opération.
 
-- la commande contient au moins une ligne ;
-- chaque ligne référence une `piece_technique_id` applicable ;
-- une seule destination interne est définie par `dest_stock_magasin_id` et `dest_stock_emplacement_id` ;
-- la destination correspond à un emplacement de stock existant ;
-- l'utilisateur possède un rôle autorisé ;
-- aucune génération précédente incohérente n'est déjà liée à la commande.
+Le rejeu est idempotent et retourne les OF existants. Une affaire interne historique est conservée en lecture et signalée par `LEGACY_INTERNAL_DELIVERY_AFFAIRE_IGNORED`.
 
-L'absence de stock disponible ne réduit pas le besoin à fabriquer : la quantité complète demandée alimente les OF.
+## Préconditions
 
-## Réponse
+- au moins une ligne ;
+- quantité positive ;
+- pièce technique et version applicable sur chaque ligne ;
+- rôle autorisé à lancer une commande interne ;
+- `decision = null` et aucune surcharge de stock dans `lines`.
 
-Exemple simplifié :
+Le client commercial, le contact, la destination de livraison, une cadence, des documents qualité et une disponibilité stock ne sont pas des préconditions internes.
 
-```json
-{
-  "affaire_ids": [7],
-  "livraison_affaire_id": 7,
-  "livraison_affaire_ids": [7],
-  "generation_mode": "INTERNAL_ORDER",
-  "idempotent_replay": false,
-  "workflow_status": "ATTENTE_PLANNING",
-  "of_ids": [9, 10],
-  "root_of_ids": [9],
-  "child_of_ids": [10],
-  "ofs": [
-    {
-      "id": 9,
-      "root_of_id": 9,
-      "parent_of_id": null,
-      "generation_level": 0,
-      "commande_ligne_id": 1
-    },
-    {
-      "id": 10,
-      "root_of_id": 9,
-      "parent_of_id": 9,
-      "generation_level": 1,
-      "commande_ligne_id": 1
-    }
-  ],
-  "warnings": []
-}
-```
+## Réception d’un OF interne
 
-`ofs` expose la topologie utile au frontend sans obliger celui-ci à reconstruire la hiérarchie.
+`POST /api/v1/production/of/:id/receipts`
 
-## Idempotence
+Pour un OF issu d’une commande interne, `location_id` est facultatif et ignoré s’il est fourni. Dans la transaction, le backend :
 
-Une nouvelle demande après génération ne crée ni affaire ni OF supplémentaire. La réponse contient les identifiants et la topologie existants avec `idempotent_replay = true`.
+1. lit le numéro client de la pièce technique ;
+2. verrouille la destination logique ;
+3. retrouve le magasin actif `NEW-PF` lié à un entrepôt ;
+4. crée ou réutilise la location et l’emplacement dont le code est le numéro client ;
+5. met le stock reçu à cette destination ;
+6. ne crée aucune réservation de commande/livraison.
 
-Une ancienne commande interne possédant plusieurs affaires de livraison peut être relue, mais renvoie l'avertissement `LEGACY_MULTIPLE_DELIVERY_AFFAIRS`. Cette tolérance ne permet pas de créer un nouveau découpage.
-
-## Erreurs métier principales
+Erreurs principales :
 
 | Statut | Code | Signification |
 | --- | --- | --- |
-| 403 | `INTERNAL_ORDER_LAUNCH_FORBIDDEN` | rôle insuffisant pour lancer la commande interne |
-| 400 | `INTERNAL_ORDER_SINGLE_AFFAIRE_REQUIRED` | `livraison_count` différent de 1 |
-| 400 | `INTERNAL_ORDER_STOCK_DECISION_FORBIDDEN` | décision ou surcharge de stock fournie |
-| 400 | `INTERNAL_ORDER_LINE_REQUIRED` | aucune ligne à fabriquer |
-| 400 | `PIECE_TECHNIQUE_REQUIRED` | pièce technique absente sur une ligne |
-| 400 | `DEST_STOCK_LOCATION_REQUIRED` | destination interne absente ou invalide |
-| 409 | `INTERNAL_ORDER_AFFAIRE_MAPPING_INVALID` | liaison historique d'affaire incompatible |
+| 403 | `INTERNAL_ORDER_LAUNCH_FORBIDDEN` | rôle insuffisant |
+| 400 | `INTERNAL_ORDER_STOCK_DECISION_FORBIDDEN` | décision stock interdite |
+| 400 | `INTERNAL_ORDER_LINE_REQUIRED` | aucune pièce à fabriquer |
+| 400 | `PIECE_TECHNIQUE_REQUIRED` | pièce technique absente |
+| 422 | `INTERNAL_ORDER_CLIENT_CODE_REQUIRED` | numéro client absent de la pièce |
+| 503 | `NEW_PF_MAGASIN_REQUIRED` | magasin actif `NEW-PF` non configuré |
+| 422 | `RECEIPT_LOCATION_REQUIRED` | emplacement absent pour un OF non interne |
 
-## Traçabilité
+## Compatibilité et réparation
 
-Le succès écrit notamment :
-
-- l'événement `AFFAIRES_GENERATED` commun au flux existant ;
-- l'événement `INTERNAL_ORDER_LAUNCHED` avec affaire, destination, OF racines/enfants et statut ;
-- le changement de statut dans `commande_historique` ;
-- les métadonnées `internal_order_flow` dans les checkpoints ;
-- l'audit applicatif de génération.
-
-## Compatibilité
-
-Le comportement des commandes client (`FERME`, `OUVERTE`, etc.) est conservé : analyse de stock d'expédition, confirmation éventuelle et livraisons fractionnées continuent d'utiliser le contrat historique.
-
-Cette évolution ne nécessite ni nouveau patch SQL ni migration de production.
+- Les commandes `FERME` et `CADRE` conservent analyse OLD → NEW, réservation, AR et livraison.
+- Une commande historique marquée `AR_PRET` par l’ancien contournement `no_plannable_operations` est replacée de façon auditée sur `ATTENTE_PLANNING` lors du rejeu, si l’AR n’a pas été envoyé.
+- Aucune migration PostgreSQL n’est requise.

--- a/src/__tests__/commande-ar-empty-gamme-880.contract.test.ts
+++ b/src/__tests__/commande-ar-empty-gamme-880.contract.test.ts
@@ -41,10 +41,10 @@ describe("#880 — gamme vide non bloquante", () => {
     expect(emptyGamme).not.toContain("blockers.push");
   });
 
-  it("saute le planning inexistant et rend l'AR accessible", () => {
+  it("conserve le planning obligatoire même quand la gamme ne contient aucune opération", () => {
     const source = read("src/module/commande-client/repository/commande-client.repository.ts");
-    expect(source).toContain('skip_reason: "no_plannable_operations"');
-    expect(source).toContain('nouveau_statut: "AR_PRET"');
-    expect(source).toContain("has_plannable_operations: generatedOfs.some");
+    expect(source).toContain('nouveau_statut: "ATTENTE_PLANNING"');
+    expect(source).toContain('cause: "planning_repair"');
+    expect(source).not.toContain('skip_reason: "no_plannable_operations"');
   });
 });

--- a/src/__tests__/commande-stock-sql-contract.test.ts
+++ b/src/__tests__/commande-stock-sql-contract.test.ts
@@ -25,9 +25,8 @@ describe("commande stock SQL contract", () => {
       "computeCommandeStockAnalysis"
     );
 
-    expect(source).toMatch(
-      /SELECT[\s\S]*COALESCE\(lot\.source_scope, warehouse\.stock_scope, 'NEW'\) AS stock_scope[\s\S]*GROUP BY[\s\S]*availability\.article_id,[\s\S]*COALESCE\(lot\.source_scope, warehouse\.stock_scope, 'NEW'\)/
-    );
+    expect(source.match(/WHEN lot\.origin_stock_scope = 'OLD' THEN 'OLD'/g)).toHaveLength(2);
+    expect(source).toContain("ELSE COALESCE(lot.source_scope, lot.stock_scope, warehouse.stock_scope, 'NEW')");
   });
 
   it("joins lots before using their scope and FIFO dates for delivery candidates", () => {
@@ -38,11 +37,8 @@ describe("commande stock SQL contract", () => {
     );
 
     expect(source).toMatch(/JOIN public\.lots lot ON lot\.id = availability\.lot_id/);
-    expect(source).toMatch(
-      /COALESCE\(lot\.source_scope, warehouse\.stock_scope, 'NEW'\) AS stock_scope/
-    );
-    expect(source).toMatch(
-      /CASE COALESCE\(lot\.source_scope, warehouse\.stock_scope, 'NEW'\) WHEN 'OLD' THEN 0 ELSE 1 END/
-    );
+    expect(source).toContain("WHEN lot.origin_stock_scope = 'OLD' THEN 'OLD'");
+    expect(source).toContain("ELSE COALESCE(lot.source_scope, lot.stock_scope, warehouse.stock_scope, 'NEW')");
+    expect(source).toContain("WHEN lot.origin_stock_scope = 'OLD' THEN 0");
   });
 });

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -1782,7 +1782,7 @@ describe("/api/v1/commandes", () => {
       }
 
       // One OLD/NEW unit is already covered by a legacy grouped-delivery reservation.
-      if (q.includes("GROUP BY availability.article_id") && q.includes("warehouse.stock_scope")) {
+      if (q.includes("FROM public.v_stock_availability_225 availability") && q.includes("warehouse.stock_scope")) {
         return { rows: [{ article_id: ARTICLE_ID, stock_scope: "OLD", qty_available: 1 }] };
       }
 
@@ -2089,7 +2089,7 @@ describe("/api/v1/commandes", () => {
     expect(childParams[19]).toBe(6);
   });
 
-  it("POST /api/v1/commandes/:id/generate-affaires protects internal-order launch and single-affair invariant", async () => {
+  it("POST /api/v1/commandes/:id/generate-affaires protects internal-order launch and forbids stock decisions", async () => {
     mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const q = String(sql);
       const authoritativePdf = authoritativePdfQueueDbMock(sql, params);
@@ -2122,13 +2122,13 @@ describe("/api/v1/commandes", () => {
     expect(forbidden.status).toBe(403);
     expect(forbidden.body).toMatchObject({ code: "INTERNAL_ORDER_LAUNCH_FORBIDDEN" });
 
-    const split = await request(app)
+    const stockDecision = await request(app)
       .post("/api/v1/commandes/123/generate-affaires")
       .set("x-test-role", "Directeur")
-      .send({ decision: null, livraison_count: 2, lines: [] });
+      .send({ decision: "SHIP_ALL_TOGETHER", livraison_count: 1, lines: [] });
 
-    expect(split.status).toBe(400);
-    expect(split.body).toMatchObject({ code: "INTERNAL_ORDER_SINGLE_AFFAIRE_REQUIRED" });
+    expect(stockDecision.status).toBe(400);
+    expect(stockDecision.body).toMatchObject({ code: "INTERNAL_ORDER_STOCK_DECISION_FORBIDDEN" });
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
   });
 
@@ -2168,7 +2168,7 @@ describe("/api/v1/commandes", () => {
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO ordres_fabrication"))).toBe(false);
   });
 
-  it("POST /api/v1/commandes/:id/generate-affaires requires an internal stock destination", async () => {
+  it("POST /api/v1/commandes/:id/generate-affaires does not require an internal stock destination", async () => {
     const ARTICLE_ID = "11111111-1111-1111-1111-111111111111";
     const PIECE_ID = "22222222-2222-2222-2222-222222222222";
 
@@ -2215,12 +2215,12 @@ describe("/api/v1/commandes", () => {
       .set("x-test-role", "Responsable Production")
       .send({ decision: null, livraison_count: 1, lines: [] });
 
-    expect(res.status).toBe(400);
-    expect(res.body).toMatchObject({ code: "DEST_STOCK_LOCATION_REQUIRED" });
+    expect(res.status).toBe(422);
+    expect(res.body.code).not.toBe("DEST_STOCK_LOCATION_REQUIRED");
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
   });
 
-  it("POST /api/v1/commandes/:id/generate-affaires launches one internal affair with complete OF topology", async () => {
+  it("POST /api/v1/commandes/:id/generate-affaires launches internal OF topology without a delivery affair", async () => {
     const MAGASIN_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
     const LOCATION_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
     const ARTICLE_ID = "11111111-1111-1111-1111-111111111111";
@@ -2243,8 +2243,8 @@ describe("/api/v1/commandes", () => {
               order_type: "INTERNE",
               devis_id: null,
               numero: "CI-123",
-              dest_stock_magasin_id: MAGASIN_ID,
-              dest_stock_emplacement_id: "1",
+              dest_stock_magasin_id: null,
+              dest_stock_emplacement_id: null,
               ar_sent_at: null,
             },
           ],
@@ -2345,9 +2345,9 @@ describe("/api/v1/commandes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
-      affaire_ids: [7],
-      livraison_affaire_id: 7,
-      livraison_affaire_ids: [7],
+      affaire_ids: [],
+      livraison_affaire_id: null,
+      livraison_affaire_ids: [],
       generation_mode: "INTERNAL_ORDER",
       idempotent_replay: false,
       workflow_status: "ATTENTE_PLANNING",
@@ -2360,7 +2360,7 @@ describe("/api/v1/commandes", () => {
       expect.objectContaining({ id: 9, root_of_id: 9, parent_of_id: null, generation_level: 0 }),
       expect.objectContaining({ id: 10, root_of_id: 9, parent_of_id: 9, generation_level: 1 }),
     ]);
-    expect(mocks.clientQuery.mock.calls.filter((call) => String(call[0]).includes("INSERT INTO affaire"))).toHaveLength(1);
+    expect(mocks.clientQuery.mock.calls.filter((call) => String(call[0]).includes("INSERT INTO affaire"))).toHaveLength(0);
     expect(
       mocks.clientQuery.mock.calls.some(
         (call) => String(call[0]).includes("UPDATE public.commande_client_workflow_checkpoint") && String(call[0]).includes("internal_order_flow")
@@ -2419,13 +2419,20 @@ describe("/api/v1/commandes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
-      affaire_ids: [7],
+      affaire_ids: [],
+      livraison_affaire_id: null,
+      livraison_affaire_ids: [],
       generation_mode: "INTERNAL_ORDER",
       idempotent_replay: true,
       workflow_status: "ATTENTE_PLANNING",
       of_ids: [9, 10],
       root_of_ids: [9],
       child_of_ids: [10],
+      warnings: [
+        "LEGACY_INTERNAL_DELIVERY_AFFAIRE_IGNORED",
+        "GAMME_WITHOUT_OPERATION:OF-9",
+        "GAMME_WITHOUT_OPERATION:OF-10",
+      ],
     });
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO public.ordres_fabrication"))).toBe(false);

--- a/src/__tests__/internal-order-auto-destination-883.migration-guards.test.ts
+++ b/src/__tests__/internal-order-auto-destination-883.migration-guards.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const basename = "20260826_zzz_internal_order_auto_destination_883";
+const readPatch = () => readFileSync(resolve(process.cwd(), "db/patches", `${basename}.sql`), "utf8");
+const readSupport = (kind: "preflight" | "verify" | "rollback") =>
+  readFileSync(resolve(process.cwd(), "db/patches/support", `${basename}.${kind}.sql`), "utf8");
+
+describe("internal order automatic stock destination migration", () => {
+  it("drops only the obsolete creation-time destination constraint", () => {
+    const patch = readPatch();
+
+    expect(patch).toMatch(/^BEGIN;/m);
+    expect(patch).toContain("DROP CONSTRAINT IF EXISTS commande_client_internal_stock_dest_check");
+    expect(patch).not.toMatch(/DROP\s+(?:TABLE|COLUMN)/i);
+    expect(patch).toMatch(/COMMIT;\s*$/);
+  });
+
+  it("keeps preflight and verification read-only", () => {
+    const preflight = readSupport("preflight");
+    const verify = readSupport("verify");
+    const mutatingSql = /\b(?:INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/i;
+
+    expect(preflight).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(verify).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(preflight).not.toMatch(mutatingSql);
+    expect(verify).not.toMatch(mutatingSql);
+    expect(verify).toContain("Obsolete internal stock destination constraint is still present");
+  });
+
+  it("refuses rollback once an internal order relies on automatic resolution", () => {
+    const rollback = readSupport("rollback");
+
+    expect(rollback).toContain("cerp.confirm_internal_order_destination_rollback");
+    expect(rollback).toContain("Rollback refused: internal orders depend on automatic stock destination resolution");
+    expect(rollback).toContain("ADD CONSTRAINT commande_client_internal_stock_dest_check");
+  });
+});

--- a/src/__tests__/production-receipts-223.contract.test.ts
+++ b/src/__tests__/production-receipts-223.contract.test.ts
@@ -14,6 +14,17 @@ const base = {
 };
 
 describe("#223 production receipt contract", () => {
+  it("allows the API to omit the location for an internal-order auto destination", () => {
+    const parsed = ofReceiptBodySchema.parse({
+      qty_ok: 4,
+      lot_mode: "NEW",
+      quality_status: "QUARANTAINE",
+      quality_reason: "Reception commande interne",
+      expected_of_updated_at: base.expected_of_updated_at,
+    });
+    expect(parsed.location_id).toBeUndefined();
+  });
+
   it("normalizes optional scrap and rework quantities", () => {
     const parsed = ofReceiptBodySchema.parse({
       qty_ok: 4,

--- a/src/__tests__/stock-delivery-reservation.contract.test.ts
+++ b/src/__tests__/stock-delivery-reservation.contract.test.ts
@@ -102,7 +102,7 @@ describe("Commande → stock → OF receipt → delivery contracts", () => {
   });
 
   it("enforces OLD→NEW FIFO, released lots, row locks and idempotent preparation/shipment/correction ledgers", () => {
-    expect(commandRepository).toMatch(/CASE COALESCE\(lot\.source_scope, warehouse\.stock_scope, 'NEW'\) WHEN 'OLD' THEN 0 ELSE 1 END/);
+    expect(commandRepository).toMatch(/WHEN lot\.origin_stock_scope = 'OLD' THEN 0[\s\S]*COALESCE\(lot\.source_scope, lot\.stock_scope, warehouse\.stock_scope, 'NEW'\) = 'OLD' THEN 0/);
     expect(commandRepository).toMatch(/COALESCE\(lot\.lot_status, 'LIBERE'\) = 'LIBERE'/);
     expect(commandRepository).toMatch(/FROM public\.lots WHERE id = \$1::uuid FOR UPDATE/);
     expect(commandRepository).toMatch(/FROM public\.stock_levels[\s\S]*FOR UPDATE/);

--- a/src/module/auth/services/password-reset-email.service.ts
+++ b/src/module/auth/services/password-reset-email.service.ts
@@ -1,3 +1,5 @@
+import { resolveOutboundEmailRecipients, testSafeEmailSubject } from "../../../shared/email/test-email-routing";
+
 type ResendConfig = {
   apiKey: string;
   from: string;
@@ -167,14 +169,15 @@ export async function sendPasswordResetEmail(params: {
     resetUrl: params.resetUrl,
     expiresMinutes: params.expiresMinutes,
   });
+  const delivery = resolveOutboundEmailRecipients([params.to]);
 
   return await postResendEmail({
     cfg,
     idempotencyKey: params.request_id ?? null,
     payload: {
       from: cfg.from,
-      to: [params.to],
-      subject: email.subject,
+      to: delivery.recipients,
+      subject: testSafeEmailSubject(email.subject, delivery.rerouted),
       text: email.text,
       html: email.html,
     },

--- a/src/module/client-portal/services/client-portal-email.service.ts
+++ b/src/module/client-portal/services/client-portal-email.service.ts
@@ -1,3 +1,5 @@
+import { sendTransactionalEmail } from "../../../shared/email/resend.service";
+
 type EmailDelivery =
   | { status: "SENT"; provider_id: string | null }
   | { status: "NOT_CONFIGURED"; provider_id: null }
@@ -30,10 +32,6 @@ export async function sendPortalAccessEmail(input: {
   expiresMinutes: number;
   idempotencyKey: string;
 }): Promise<EmailDelivery> {
-  const apiKey = (process.env.RESEND_API_KEY ?? "").trim();
-  const from = (process.env.RESEND_FROM ?? "").trim();
-  if (!apiKey || !from) return { status: "NOT_CONFIGURED", provider_id: null };
-
   const url = buildPortalUrl(input.path);
   const action = input.kind === "INVITATION" ? "Activer mon accès client" : "Réinitialiser mon mot de passe";
   const subject = input.kind === "INVITATION"
@@ -54,27 +52,15 @@ export async function sendPortalAccessEmail(input: {
     `<p style="font-size:12px;color:#6b7280">Ignorez ce message si vous n'êtes pas à l'origine de la demande.</p>` +
     `</div>`;
 
-  try {
-    const response = await fetch(
-      `${(process.env.RESEND_API_BASE_URL ?? "https://api.resend.com").replace(/\/+$/, "")}/emails`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          "Idempotency-Key": input.idempotencyKey.slice(0, 256),
-        },
-        body: JSON.stringify({ from, to: [input.to], subject, text, html }),
-      }
-    );
-    if (!response.ok) return { status: "FAILED", provider_id: null };
-    const payload = await response.json().catch(() => null) as { id?: unknown } | null;
-    return {
-      status: "SENT",
-      provider_id: typeof payload?.id === "string" ? payload.id : null,
-    };
-  } catch {
-    return { status: "FAILED", provider_id: null };
-  }
+  const delivery = await sendTransactionalEmail({
+    to: [input.to],
+    subject,
+    text,
+    html,
+    idempotencyKey: input.idempotencyKey,
+  });
+  if ("skipped" in delivery) return { status: "NOT_CONFIGURED", provider_id: null };
+  if (!delivery.ok) return { status: "FAILED", provider_id: null };
+  return { status: "SENT", provider_id: delivery.id ?? null };
 }
 

--- a/src/module/commande-client/domain/commande-client-launch.test.ts
+++ b/src/module/commande-client/domain/commande-client-launch.test.ts
@@ -8,9 +8,9 @@ describe("parcours de lancement d'une commande client", () => {
       .toBe("PRODUCTION_WITH_PLANNING");
   });
 
-  it("saute le planning lorsqu'un OF ne contient aucune opération", () => {
+  it("conserve la validation planning lorsqu'un OF ne contient aucune opération", () => {
     expect(resolveCustomerOrderLaunchMode({ needsProduction: true, generatedOperationsCount: 0 }))
-      .toBe("PRODUCTION_WITHOUT_PLANNING");
+      .toBe("PRODUCTION_WITH_PLANNING");
   });
 
   it("conserve le parcours stock lorsqu'aucune production n'est nécessaire", () => {

--- a/src/module/commande-client/domain/commande-client-launch.ts
+++ b/src/module/commande-client/domain/commande-client-launch.ts
@@ -1,19 +1,16 @@
 export type CustomerOrderLaunchMode =
   | "STOCK_ONLY"
-  | "PRODUCTION_WITH_PLANNING"
-  | "PRODUCTION_WITHOUT_PLANNING";
+  | "PRODUCTION_WITH_PLANNING";
 
 /**
- * Planning is meaningful only when at least one generated OF operation can be
- * scheduled. An empty gamme remains traceable through its OF but must not trap
- * the customer order on an impossible planning checkpoint.
+ * Every generated OF requires an explicit planning validation. An empty gamme
+ * is allowed, but it must remain visible to planning instead of silently moving
+ * the customer order to AR preparation.
  */
 export function resolveCustomerOrderLaunchMode(params: {
   needsProduction: boolean;
   generatedOperationsCount: number;
 }): CustomerOrderLaunchMode {
   if (!params.needsProduction) return "STOCK_ONLY";
-  return params.generatedOperationsCount > 0
-    ? "PRODUCTION_WITH_PLANNING"
-    : "PRODUCTION_WITHOUT_PLANNING";
+  return "PRODUCTION_WITH_PLANNING";
 }

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -1470,7 +1470,6 @@ async function advanceInternalOrderWorkflowAfterGeneration(params: {
   tx: Queryable;
   commande_id: number;
   user_id: number;
-  livraison_affaire_id: number;
   of_ids: number[];
 }) {
   const transition = await repoEnsureCommandeWorkflowStatus({
@@ -1521,7 +1520,6 @@ async function advanceInternalOrderWorkflowAfterGeneration(params: {
       params.user_id,
       JSON.stringify({
         internal_order_flow: true,
-        livraison_affaire_id: params.livraison_affaire_id,
         of_ids: params.of_ids,
       }),
     ]
@@ -1530,62 +1528,86 @@ async function advanceInternalOrderWorkflowAfterGeneration(params: {
   return transition;
 }
 
+async function repairLegacyNoOperationPlanningBypass(params: {
+  tx: Queryable;
+  commande_id: number;
+  user_id: number;
+  ar_sent_at: string | null;
+  of_ids: number[];
+}): Promise<boolean> {
+  if (params.ar_sent_at || params.of_ids.length === 0) return false;
+
+  const header = await loadCommandeWorkflowHeaderWithStatus(params.tx, params.commande_id);
+  if (!header || header.statut !== "AR_PRET") return false;
+
+  const planning = await params.tx.query<{ status: string; metadata: Record<string, unknown> | null }>(
+    `
+      SELECT status, metadata
+      FROM public.commande_client_workflow_checkpoint
+      WHERE commande_id = $1
+        AND checkpoint_code = 'planning_validation'
+      LIMIT 1
+      FOR UPDATE
+    `,
+    [params.commande_id]
+  );
+  const row = planning.rows[0] ?? null;
+  if (
+    !row ||
+    row.status !== "skipped" ||
+    row.metadata?.skip_reason !== "no_plannable_operations" ||
+    row.metadata?.no_operation_flow !== true
+  ) {
+    return false;
+  }
+
+  await params.tx.query(
+    `
+      UPDATE public.commande_client_workflow_checkpoint
+      SET
+        status = CASE
+          WHEN checkpoint_code = 'of_generation' THEN 'done'
+          WHEN checkpoint_code = 'planning_validation' THEN 'active'
+          ELSE 'pending'
+        END,
+        completed_at = CASE WHEN checkpoint_code = 'of_generation' THEN completed_at ELSE NULL END,
+        completed_by = CASE WHEN checkpoint_code = 'of_generation' THEN completed_by ELSE NULL END,
+        metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb,
+        updated_at = now()
+      WHERE commande_id = $1
+        AND checkpoint_code IN ('of_generation', 'planning_validation', 'ar_preparation', 'ar_sent')
+    `,
+    [
+      params.commande_id,
+      JSON.stringify({
+        repair_reason: "planning_required_for_of_without_operations",
+        repaired_of_ids: params.of_ids,
+      }),
+    ]
+  );
+  await repoEnsureCommandeWorkflowStatus({
+    tx: params.tx,
+    commande_id: params.commande_id,
+    nouveau_statut: "ATTENTE_PLANNING",
+    cause: "planning_repair",
+    commentaire: "Correction automatique : tout OF, même sans opération, doit être validé au planning",
+    user_id: params.user_id,
+  });
+  return true;
+}
+
 async function advanceCustomerOrderWorkflowAfterLaunch(params: {
   tx: Queryable;
   commande_id: number;
   user_id: number;
   needs_production: boolean;
-  has_plannable_operations: boolean;
   bon_livraison_id: string | null;
   of_ids: number[];
 }) {
   const launchMode = resolveCustomerOrderLaunchMode({
     needsProduction: params.needs_production,
-    generatedOperationsCount: params.has_plannable_operations ? 1 : 0,
+    generatedOperationsCount: 0,
   });
-
-  if (launchMode === "PRODUCTION_WITHOUT_PLANNING") {
-    await params.tx.query(
-      `
-        UPDATE public.commande_client_workflow_checkpoint
-        SET status = CASE
-              WHEN checkpoint_code IN ('of_generation', 'ar_preparation') THEN 'done'
-              WHEN checkpoint_code = 'planning_validation' THEN 'skipped'
-              WHEN checkpoint_code = 'ar_sent' THEN 'active'
-              ELSE status
-            END,
-            completed_at = CASE
-              WHEN checkpoint_code = 'ar_sent' THEN NULL
-              ELSE COALESCE(completed_at, now())
-            END,
-            completed_by = CASE
-              WHEN checkpoint_code = 'ar_sent' THEN NULL
-              ELSE COALESCE(completed_by, $2::int)
-            END,
-            metadata = COALESCE(metadata, '{}'::jsonb) || $3::jsonb,
-            updated_at = now()
-        WHERE commande_id = $1
-          AND checkpoint_code IN ('of_generation', 'planning_validation', 'ar_preparation', 'ar_sent')
-      `,
-      [
-        params.commande_id,
-        params.user_id,
-        JSON.stringify({
-          skip_reason: "no_plannable_operations",
-          no_operation_flow: true,
-          of_ids: params.of_ids,
-        }),
-      ]
-    );
-    return repoEnsureCommandeWorkflowStatus({
-      tx: params.tx,
-      commande_id: params.commande_id,
-      nouveau_statut: "AR_PRET",
-      cause: "customer_order_launch",
-      commentaire: "OF sans opération généré ; planning non applicable et AR prêt à préparer",
-      user_id: params.user_id,
-    });
-  }
 
   if (launchMode === "PRODUCTION_WITH_PLANNING") {
     await params.tx.query(
@@ -4328,13 +4350,6 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           "Production manager or administrator role required to launch an internal order"
         );
       }
-      if (requestedLivraisonCount !== 1) {
-        throw new HttpError(
-          400,
-          "INTERNAL_ORDER_SINGLE_AFFAIRE_REQUIRED",
-          "Internal orders generate exactly one delivery affair"
-        );
-      }
       if (body.decision !== null || (body.lines?.length ?? 0) > 0) {
         throw new HttpError(
           400,
@@ -4346,19 +4361,53 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
 
     const internalClientId = orderType === "INTERNE" ? await getInternalClientIdSetting(client) : null;
     const clientId = commande.client_id ?? internalClientId;
-    if (!clientId) {
+    if (orderType !== "INTERNE" && !clientId) {
       throw new HttpError(
         400,
-        orderType === "INTERNE" ? "INTERNAL_CLIENT_REQUIRED" : "COMMANDE_CLIENT_REQUIRED",
-        orderType === "INTERNE"
-          ? "Internal orders require client_id (or erp_settings 'commandes.internal_client_id')"
-          : "Cannot generate affaire from a commande without client_id"
+        "COMMANDE_CLIENT_REQUIRED",
+        "Cannot generate affaire from a commande without client_id"
       );
     }
 
     // Idempotency + split delivery support: allow multiple LIVRAISON mappings per commande.
     const existingMappings = await listCommandeToAffaireMappings(client, commandeId);
     const existingLivraisons = existingMappings.filter((r) => r.role === "LIVRAISON");
+
+    if (orderType === "INTERNE") {
+      const existingOfs = await listGeneratedOfRefs(client, commandeId);
+      if (existingOfs.length > 0) {
+        const planningRepaired = await repairLegacyNoOperationPlanningBypass({
+          tx: client,
+          commande_id: commandeId,
+          user_id: audit.user_id,
+          ar_sent_at: commande.ar_sent_at,
+          of_ids: existingOfs.map((of) => of.id),
+        });
+        const workflowHeader = planningRepaired
+          ? null
+          : await loadCommandeWorkflowHeaderWithStatus(client, commandeId);
+        return {
+          affaire_ids: [],
+          livraison_affaire_id: null,
+          requires_confirmation: false,
+          livraison_affaire_ids: [],
+          generation_mode: "INTERNAL_ORDER",
+          idempotent_replay: true,
+          workflow_status: planningRepaired ? "ATTENTE_PLANNING" : workflowHeader?.statut ?? null,
+          of_ids: existingOfs.map((of) => of.id),
+          root_of_ids: existingOfs.filter((of) => of.parent_of_id === null).map((of) => of.id),
+          child_of_ids: existingOfs.filter((of) => of.parent_of_id !== null).map((of) => of.id),
+          ofs: existingOfs,
+          warnings: [
+            ...(planningRepaired ? ["LEGACY_NO_OPERATION_PLANNING_BYPASS_REPAIRED"] : []),
+            ...(existingLivraisons.length > 0 ? ["LEGACY_INTERNAL_DELIVERY_AFFAIRE_IGNORED"] : []),
+            ...existingOfs
+              .filter((of) => of.operations_count === 0)
+              .map((of) => `GAMME_WITHOUT_OPERATION:OF-${of.id}`),
+          ],
+        };
+      }
+    }
 
     if (recoveredInvalidPlanningState && existingMappings.length > 0 && existingLivraisons.length === 0) {
       throw new HttpError(
@@ -4368,37 +4417,31 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       );
     }
 
-    if (existingMappings.length > 0 && !recoveredInvalidPlanningState) {
-      if (orderType === "INTERNE" && existingLivraisons.length === 0) {
-        throw new HttpError(
-          409,
-          "INTERNAL_ORDER_AFFAIRE_MAPPING_INVALID",
-          "The existing affair mapping is not identified as a delivery affair"
-        );
-      }
-
+    if (orderType !== "INTERNE" && existingMappings.length > 0 && !recoveredInvalidPlanningState) {
       if (existingLivraisons.length >= requestedLivraisonCount) {
         const livraison = existingLivraisons[0]?.affaire_id ?? null;
         const existingOfs = await listGeneratedOfRefs(client, commandeId);
-        const workflowHeader =
-          orderType === "INTERNE" ? await loadCommandeWorkflowHeaderWithStatus(client, commandeId) : null;
+        const planningRepaired = await repairLegacyNoOperationPlanningBypass({
+          tx: client,
+          commande_id: commandeId,
+          user_id: audit.user_id,
+          ar_sent_at: commande.ar_sent_at,
+          of_ids: existingOfs.map((of) => of.id),
+        });
         return {
           affaire_ids: existingLivraisons.map((r) => r.affaire_id),
           livraison_affaire_id: livraison,
           requires_confirmation: false,
           livraison_affaire_ids: existingLivraisons.map((l) => l.affaire_id),
-          generation_mode: orderType === "INTERNE" ? "INTERNAL_ORDER" : "CUSTOMER_ORDER",
+          generation_mode: "CUSTOMER_ORDER",
           idempotent_replay: true,
-          workflow_status: workflowHeader?.statut ?? null,
+          workflow_status: planningRepaired ? "ATTENTE_PLANNING" : null,
           of_ids: existingOfs.map((of) => of.id),
           root_of_ids: existingOfs.filter((of) => of.parent_of_id === null).map((of) => of.id),
           child_of_ids: existingOfs.filter((of) => of.parent_of_id !== null).map((of) => of.id),
           ofs: existingOfs,
-          warnings:
-            [
-              ...(orderType === "INTERNE" && existingLivraisons.length > 1
-                ? ["LEGACY_MULTIPLE_DELIVERY_AFFAIRS"]
-                : []),
+          warnings: [
+              ...(planningRepaired ? ["LEGACY_NO_OPERATION_PLANNING_BYPASS_REPAIRED"] : []),
               ...existingOfs
                 .filter((of) => of.operations_count === 0)
                 .map((of) => `GAMME_WITHOUT_OPERATION:OF-${of.id}`),
@@ -4413,7 +4456,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         const livraisonId = await createAffaire(client, {
           commande_id: commandeId,
           devis_id: commande.devis_id ? toNullableInt(commande.devis_id, "commande.devis_id") : null,
-          client_id: clientId,
+          client_id: clientId as string,
         });
         await insertCommandeToAffaireMapping(client, {
           commande_id: commandeId,
@@ -4454,25 +4497,6 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           `Cannot launch internal order: missing piece_technique_id for line ${missingPiece.commande_ligne_id}`
         );
       }
-    }
-
-    let stockLocationId: string | null = null;
-    if (orderType === "INTERNE") {
-      const magasinId = commande.dest_stock_magasin_id;
-      const emplacementIdRaw = commande.dest_stock_emplacement_id;
-      const emplacementId = typeof emplacementIdRaw === "string" && /^\d+$/.test(emplacementIdRaw) ? Number(emplacementIdRaw) : null;
-      if (!magasinId || typeof emplacementId !== "number" || !Number.isFinite(emplacementId)) {
-        throw new HttpError(
-          400,
-          "DEST_STOCK_LOCATION_REQUIRED",
-          "dest_stock_magasin_id and dest_stock_emplacement_id are required for internal orders"
-        );
-      }
-      stockLocationId = await resolveLocationIdForEmplacement(client, {
-        magasin_id: magasinId,
-        emplacement_id: emplacementId,
-        label: "dest_stock_location",
-      });
     }
 
     let analysis: CommandeStockAnalysis;
@@ -4577,15 +4601,15 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       immediateDeliveryByLine.set(line.commande_ligne_id, qtyToDeliverNow);
     }
 
-    const livraisonAffaireIds: number[] = recoveredInvalidPlanningState
+    const livraisonAffaireIds: number[] = orderType !== "INTERNE" && recoveredInvalidPlanningState
       ? existingLivraisons.map((mapping) => mapping.affaire_id)
       : [];
 
-    if (livraisonAffaireIds.length === 0) {
+    if (orderType !== "INTERNE" && livraisonAffaireIds.length === 0) {
       const createdId = await createAffaire(client, {
         commande_id: commandeId,
         devis_id: commande.devis_id ? toNullableInt(commande.devis_id, "commande.devis_id") : null,
-        client_id: clientId,
+        client_id: clientId as string,
       });
       await insertCommandeToAffaireMapping(client, {
         commande_id: commandeId,
@@ -4597,11 +4621,11 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       livraisonAffaireIds.push(createdId);
     }
 
-    for (let i = livraisonAffaireIds.length; i < requestedLivraisonCount; i += 1) {
+    for (let i = livraisonAffaireIds.length; orderType !== "INTERNE" && i < requestedLivraisonCount; i += 1) {
       const extraId = await createAffaire(client, {
         commande_id: commandeId,
         devis_id: commande.devis_id ? toNullableInt(commande.devis_id, "commande.devis_id") : null,
-        client_id: clientId,
+        client_id: clientId as string,
       });
       await insertCommandeToAffaireMapping(client, {
         commande_id: commandeId,
@@ -4613,8 +4637,8 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       livraisonAffaireIds.push(extraId);
     }
 
-    const livraisonAffaireId = livraisonAffaireIds[0];
-    if (!livraisonAffaireId) {
+    const livraisonAffaireId = livraisonAffaireIds[0] ?? null;
+    if (orderType !== "INTERNE" && !livraisonAffaireId) {
       throw new HttpError(500, "LIVRAISON_AFFAIRE_REQUIRED", "Aucune affaire de livraison n'a pu être préparée.");
     }
 
@@ -4636,19 +4660,21 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           ? "AUTO_OF"
           : "AUTO_STOCK";
 
-    await upsertCommandeAllocations(client, {
-      commande_id: commandeId,
-      livraison_affaire_id: livraisonAffaireId,
-      allocation_mode: allocationMode,
-      reserve_stock: false,
-      reserved_qty_by_line: orderType !== "INTERNE" ? stockCoveredByLine : null,
-      lines: planLines,
-    });
+    if (orderType !== "INTERNE" && livraisonAffaireId !== null) {
+      await upsertCommandeAllocations(client, {
+        commande_id: commandeId,
+        livraison_affaire_id: livraisonAffaireId,
+        allocation_mode: allocationMode,
+        reserve_stock: false,
+        reserved_qty_by_line: stockCoveredByLine,
+        lines: planLines,
+      });
+    }
 
     const holdsStockForGroupedDelivery =
       orderType !== "INTERNE" && needsProduction && decision === "SHIP_ALL_TOGETHER";
     const preparedDelivery =
-      orderType !== "INTERNE" && !holdsStockForGroupedDelivery
+      orderType !== "INTERNE" && livraisonAffaireId !== null && !holdsStockForGroupedDelivery
         ? await createPreparedLivraisonForStock(client, {
             commande_id: commandeId,
             user_id: audit.user_id,
@@ -4666,7 +4692,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
             : null) ??
           await reserveCommandeStockForLaterDelivery(client, {
             commande_id: commandeId,
-            livraison_affaire_id: livraisonAffaireId,
+            livraison_affaire_id: livraisonAffaireId as number,
             user_id: audit.user_id,
             analysis_lines: stockAnalysis.lines,
             quantities_by_line: stockCoveredByLine,
@@ -4699,7 +4725,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           commande_numero: commande.numero,
           commande_ligne_id: l.commande_ligne_id,
           livraison_affaire_id: livraisonAffaireId,
-          client_id: clientId,
+          client_id: orderType === "INTERNE" ? ref?.piece_client_id ?? clientId : clientId,
           root_article_id: l.article_id,
           root_piece_technique_id: pieceTechniqueId,
           qty_to_produce: qtyToProduce,
@@ -4722,7 +4748,6 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         tx: client,
         commande_id: commandeId,
         user_id: audit.user_id,
-        livraison_affaire_id: livraisonAffaireId,
         of_ids: ofIds,
       });
       workflowStatus = "ATTENTE_PLANNING";
@@ -4731,8 +4756,8 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         commande_id: commandeId,
         event_type: "INTERNAL_ORDER_LAUNCHED",
         new_values: {
-          livraison_affaire_id: livraisonAffaireId,
-          stock_location_id: stockLocationId,
+          delivery_affair_created: false,
+          stock_reserved: false,
           root_of_ids: generatedOfs.filter((of) => of.parent_of_id === null).map((of) => of.id),
           child_of_ids: generatedOfs.filter((of) => of.parent_of_id !== null).map((of) => of.id),
           workflow_status: workflowStatus,
@@ -4745,7 +4770,6 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         commande_id: commandeId,
         user_id: audit.user_id,
         needs_production: needsProduction,
-        has_plannable_operations: generatedOfs.some((of) => of.operations_count > 0),
         bon_livraison_id: bonLivraisonId,
         of_ids: ofIds,
       });
@@ -4754,11 +4778,10 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
 
     await insertCommandeEvent(client, {
       commande_id: commandeId,
-      event_type: "AFFAIRES_GENERATED",
+      event_type: orderType === "INTERNE" ? "INTERNAL_ORDER_OFS_GENERATED" : "AFFAIRES_GENERATED",
       new_values: {
         order_type: orderType,
         decision,
-        stock_location_id: stockLocationId,
         livraison_affaire_ids: livraisonAffaireIds,
         bon_livraison_id: bonLivraisonId,
         reservations_created: reservationsCreated.length,
@@ -4787,13 +4810,12 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
 
     if (reservationsCreated.length > 0) {
       await insertAuditLog(client, audit, {
-        action: "stock.reservations.create",
+      action: "stock.reservations.create",
         entity_type: "commande_client",
         entity_id: String(commandeId),
         details: {
           commande_id: commandeId,
           decision,
-          stock_location_id: stockLocationId,
           bon_livraison_id: bonLivraisonId,
           reservation_ids: reservationsCreated,
         },
@@ -5001,6 +5023,8 @@ type CommandeLineRef = {
   piece_technique_id: string | null;
   piece_code: string | null;
   piece_designation: string | null;
+  piece_client_id: string | null;
+  piece_client_code: string | null;
 };
 
 async function selectCommandeLineRefs(db: PoolClient, commandeId: number): Promise<CommandeLineRef[]> {
@@ -5014,6 +5038,8 @@ async function selectCommandeLineRefs(db: PoolClient, commandeId: number): Promi
     piece_technique_id: string | null;
     piece_code: string | null;
     piece_designation: string | null;
+    piece_client_id: string | null;
+    piece_client_code: string | null;
   }>(
     `
       SELECT
@@ -5025,7 +5051,9 @@ async function selectCommandeLineRefs(db: PoolClient, commandeId: number): Promi
         COALESCE(a.designation, legacy.article_designation, cl.designation) AS article_designation,
         COALESCE(cl.piece_technique_id::text, a.piece_technique_id::text, legacy.piece_technique_id) AS piece_technique_id,
         COALESCE(pt.code_piece, legacy.piece_code) AS piece_code,
-        COALESCE(pt.designation, legacy.piece_designation) AS piece_designation
+        COALESCE(pt.designation, legacy.piece_designation) AS piece_designation,
+        COALESCE(pt.client_id::text, legacy.piece_client_id) AS piece_client_id,
+        COALESCE(pt.code_client, legacy.piece_client_code) AS piece_client_code
       FROM commande_ligne cl
       LEFT JOIN public.articles a ON a.id = cl.article_id
       LEFT JOIN public.pieces_techniques pt ON pt.id = COALESCE(cl.piece_technique_id, a.piece_technique_id)
@@ -5036,7 +5064,9 @@ async function selectCommandeLineRefs(db: PoolClient, commandeId: number): Promi
           a.designation AS article_designation,
           a.piece_technique_id::text AS piece_technique_id,
           apt.code_piece AS piece_code,
-          apt.designation AS piece_designation
+          apt.designation AS piece_designation,
+          apt.client_id::text AS piece_client_id,
+          apt.code_client AS piece_client_code
         FROM public.articles a
         LEFT JOIN public.pieces_techniques apt
           ON apt.id = a.piece_technique_id
@@ -5072,6 +5102,10 @@ async function selectCommandeLineRefs(db: PoolClient, commandeId: number): Promi
       typeof r.piece_designation === "string" && r.piece_designation.trim().length > 0
         ? r.piece_designation.trim()
         : null,
+    piece_client_id:
+      typeof r.piece_client_id === "string" && r.piece_client_id.trim().length > 0 ? r.piece_client_id.trim() : null,
+    piece_client_code:
+      typeof r.piece_client_code === "string" && r.piece_client_code.trim().length > 0 ? r.piece_client_code.trim() : null,
   }));
 }
 
@@ -5128,7 +5162,10 @@ async function loadScopedAvailableQtyByArticle(
     `
       SELECT
         availability.article_id::text AS article_id,
-        COALESCE(lot.source_scope, warehouse.stock_scope, 'NEW') AS stock_scope,
+        CASE
+          WHEN lot.origin_stock_scope = 'OLD' THEN 'OLD'
+          ELSE COALESCE(lot.source_scope, lot.stock_scope, warehouse.stock_scope, 'NEW')
+        END AS stock_scope,
         COALESCE(SUM(availability.qty_available), 0)::float8 AS qty_available
       FROM public.v_stock_availability_225 availability
       JOIN public.warehouses warehouse ON warehouse.id = availability.warehouse_id
@@ -5138,7 +5175,10 @@ async function loadScopedAvailableQtyByArticle(
         AND warehouse.stock_scope IN ('OLD', 'NEW')
       GROUP BY
         availability.article_id,
-        COALESCE(lot.source_scope, warehouse.stock_scope, 'NEW')
+        CASE
+          WHEN lot.origin_stock_scope = 'OLD' THEN 'OLD'
+          ELSE COALESCE(lot.source_scope, lot.stock_scope, warehouse.stock_scope, 'NEW')
+        END
     `,
     [articleIds]
   );
@@ -5275,7 +5315,10 @@ async function loadScopedDeliveryStockCandidates(
     `
       SELECT
         availability.article_id::text AS article_id,
-        COALESCE(lot.source_scope, warehouse.stock_scope, 'NEW') AS stock_scope,
+        CASE
+          WHEN lot.origin_stock_scope = 'OLD' THEN 'OLD'
+          ELSE COALESCE(lot.source_scope, lot.stock_scope, warehouse.stock_scope, 'NEW')
+        END AS stock_scope,
         availability.stock_level_id::text AS stock_level_id,
         availability.stock_batch_id::text AS stock_batch_id,
         availability.location_id::text AS location_id,
@@ -5291,10 +5334,17 @@ async function loadScopedDeliveryStockCandidates(
       WHERE availability.article_id = ANY($1::uuid[])
         AND availability.managed_in_stock = true
         AND availability.qty_available > 0
-        AND COALESCE(lot.source_scope, warehouse.stock_scope, 'NEW') IN ('OLD', 'NEW')
+        AND CASE
+              WHEN lot.origin_stock_scope = 'OLD' THEN 'OLD'
+              ELSE COALESCE(lot.source_scope, lot.stock_scope, warehouse.stock_scope, 'NEW')
+            END IN ('OLD', 'NEW')
         AND COALESCE(lot.lot_status, 'LIBERE') = 'LIBERE'
       ORDER BY
-        CASE COALESCE(lot.source_scope, warehouse.stock_scope, 'NEW') WHEN 'OLD' THEN 0 ELSE 1 END,
+        CASE
+          WHEN lot.origin_stock_scope = 'OLD' THEN 0
+          WHEN COALESCE(lot.source_scope, lot.stock_scope, warehouse.stock_scope, 'NEW') = 'OLD' THEN 0
+          ELSE 1
+        END,
         availability.article_id,
         COALESCE(lot.received_at, lot.manufactured_at, lot.created_at::date),
         lot.created_at,

--- a/src/module/commande-client/validators/commande-client.validators.ts
+++ b/src/module/commande-client/validators/commande-client.validators.ts
@@ -151,14 +151,6 @@ z.object({
     }
 
     if (val.order_type === "INTERNE") {
-      if (!(typeof val.dest_stock_magasin_id === "string" && val.dest_stock_magasin_id.trim().length > 0)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "dest_stock_magasin_id is required for internal orders",
-          path: ["dest_stock_magasin_id"],
-        });
-      }
-
       val.lignes.forEach((l, i) => {
         const articleId = (l.article_id ?? "").toString().trim();
         const codePiece = (l.code_piece ?? "").toString().trim();

--- a/src/module/commande-client/workflow/commande-client-workflow.definition.test.ts
+++ b/src/module/commande-client/workflow/commande-client-workflow.definition.test.ts
@@ -12,4 +12,9 @@ describe("customer stock-only acknowledgement workflow", () => {
   it("keeps the shortage route behind planning", () => {
     expect(canCommandeWorkflowTransition("ATTENTE_OF", "ATTENTE_PLANNING", "customer_order_launch")).toBe(true);
   });
+
+  it("allows the audited repair of the former no-operation planning bypass only", () => {
+    expect(canCommandeWorkflowTransition("AR_PRET", "ATTENTE_PLANNING", "planning_repair")).toBe(true);
+    expect(canCommandeWorkflowTransition("AR_ENVOYE", "ATTENTE_PLANNING", "planning_repair")).toBe(false);
+  });
 });

--- a/src/module/commande-client/workflow/commande-client-workflow.definition.ts
+++ b/src/module/commande-client/workflow/commande-client-workflow.definition.ts
@@ -73,6 +73,7 @@ export const COMMANDE_WORKFLOW_LEGACY_STATUS_ALIASES: Record<string, CommandeWor
 export const COMMANDE_WORKFLOW_TRANSITION_CAUSES = [
   "checkpoint",
   "customer_order_launch",
+  "planning_repair",
   "internal_order_launch",
   "internal_planning_validation",
   "internal_production_launch",
@@ -133,6 +134,10 @@ export const COMMANDE_WORKFLOW_TRANSITIONS: readonly CommandeWorkflowTransitionR
   // A legacy invalid planning state can be recovered by reopening the launch
   // checkpoint while its append-only status history remains ATTENTE_PLANNING.
   { from: "ATTENTE_PLANNING", to: "AR_PRET", cause: "customer_order_launch" },
+  // Before #883, an OF without operations incorrectly skipped planning and
+  // moved the command to AR_PRET. Replaying the launch repairs only that
+  // explicitly-marked legacy path and restores the mandatory planning gate.
+  { from: "AR_PRET", to: "ATTENTE_PLANNING", cause: "planning_repair" },
   { from: "ATTENTE_TECHNIQUE", to: "ATTENTE_PLANNING", cause: "internal_order_launch" },
   // Commands saved by the former guided flow may already have completed one
   // or both customer-only preparation checkpoints. Keep their launch

--- a/src/module/production/repository/production-receipts.repository.ts
+++ b/src/module/production/repository/production-receipts.repository.ts
@@ -28,6 +28,8 @@ export type OfReceiptContext = {
     affaire_id: number | null;
     commande_id: number | null;
     commande_ligne_id: number | null;
+    order_type: string | null;
+    client_code: string | null;
   };
   article_id: string;
   unite: string | null;
@@ -481,6 +483,76 @@ async function resolveEmplacementByLocationId(
   };
 }
 
+async function ensureInternalOrderReceiptDestination(
+  client: Pick<PoolClient, "query">,
+  params: { client_code: string; actor_user_id: number }
+): Promise<{ magasin_id: string; emplacement_id: number; location_id: string; warehouse_id: string }> {
+  const clientCode = params.client_code.trim();
+  if (!clientCode) {
+    throw new HttpError(422, "INTERNAL_ORDER_CLIENT_CODE_REQUIRED", "La pièce technique doit porter un numéro client pour définir son emplacement NEW-PF.");
+  }
+
+  await client.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [`internal-stock-destination:${clientCode}`]);
+  const magasinRes = await client.query<{ id: string; warehouse_id: string; code: string }>(
+    `
+      SELECT id::text AS id, warehouse_id::text AS warehouse_id, COALESCE(code, code_magasin)::text AS code
+      FROM public.magasins
+      WHERE COALESCE(code, code_magasin) = 'NEW-PF'
+        AND is_active = true
+      LIMIT 1
+      FOR UPDATE
+    `
+  );
+  const magasin = magasinRes.rows[0] ?? null;
+  if (!magasin?.warehouse_id) {
+    throw new HttpError(503, "NEW_PF_MAGASIN_REQUIRED", "Le magasin actif NEW-PF doit être configuré et lié à un entrepôt.");
+  }
+
+  const locationCode = `NEW-PF-${clientCode}`;
+  const locationRes = await client.query<{ id: string }>(
+    `
+      INSERT INTO public.locations (warehouse_id, code, description)
+      VALUES ($1::uuid,$2::citext,$3)
+      ON CONFLICT (warehouse_id, code)
+      DO UPDATE SET description = COALESCE(public.locations.description, EXCLUDED.description)
+      RETURNING id::text AS id
+    `,
+    [magasin.warehouse_id, locationCode, `Stock produit fini client ${clientCode}`]
+  );
+  const locationId = locationRes.rows[0]?.id;
+  if (!locationId) throw new Error("Failed to ensure internal order stock location");
+
+  const emplacementRes = await client.query<{ id: number; location_id: string | null }>(
+    `
+      INSERT INTO public.emplacements (
+        magasin_id, code, name, is_scrap, is_active, location_id,
+        location_type, allow_inbound, allow_outbound, restrictions, created_by, updated_by
+      )
+      VALUES ($1::uuid,$2,$3,false,true,$4::uuid,'STORAGE',true,true,'{}'::jsonb,$5,$5)
+      ON CONFLICT (magasin_id, code)
+      DO UPDATE SET
+        location_id = COALESCE(public.emplacements.location_id, EXCLUDED.location_id),
+        is_active = true,
+        allow_inbound = true,
+        updated_at = now(),
+        updated_by = EXCLUDED.updated_by
+      RETURNING id::int AS id, location_id::text AS location_id
+    `,
+    [magasin.id, clientCode, `Client ${clientCode}`, locationId, params.actor_user_id]
+  );
+  const emplacement = emplacementRes.rows[0] ?? null;
+  if (!emplacement || emplacement.location_id !== locationId) {
+    throw new HttpError(409, "INTERNAL_ORDER_DESTINATION_CONFLICT", `L'emplacement NEW-PF ${clientCode} est lié à un autre lieu de stock.`);
+  }
+
+  return {
+    magasin_id: magasin.id,
+    emplacement_id: Number(emplacement.id),
+    location_id: locationId,
+    warehouse_id: magasin.warehouse_id,
+  };
+}
+
 async function ensureStockLevel(
   client: Pick<PoolClient, "query">,
   args: {
@@ -603,6 +675,8 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
     affaire_id: number | null;
     commande_id: number | null;
     commande_ligne_id: number | null;
+    order_type: string | null;
+    client_code: string | null;
   };
 
   const ofRes = await pool.query<OfRow>(
@@ -620,9 +694,12 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
         o.updated_at::text AS updated_at,
         o.affaire_id::bigint::int AS affaire_id,
         o.commande_id::bigint::int AS commande_id,
-        o.commande_ligne_id::bigint::int AS commande_ligne_id
+        o.commande_ligne_id::bigint::int AS commande_ligne_id,
+        commande.order_type::text AS order_type,
+        pt.code_client::text AS client_code
       FROM public.ordres_fabrication o
       JOIN public.pieces_techniques pt ON pt.id = o.piece_technique_id
+      LEFT JOIN public.commande_client commande ON commande.id = o.commande_id
       WHERE o.id = $1::bigint
       LIMIT 1
     `,
@@ -697,7 +774,25 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
   const defaultSetting = await pool.query<{ value_text: string | null }>(
     `SELECT value_text FROM public.erp_settings WHERE key = 'stock.default_receipt_location' LIMIT 1`
   );
-  const defaultLocationId = defaultSetting.rows[0]?.value_text ?? null;
+  const configuredDefaultLocationId = defaultSetting.rows[0]?.value_text ?? null;
+  const internalLocationId = ofRow.order_type === "INTERNE" && ofRow.client_code
+    ? (
+        await pool.query<{ location_id: string }>(
+          `
+            SELECT emplacement.location_id::text AS location_id
+            FROM public.emplacements emplacement
+            JOIN public.magasins magasin ON magasin.id = emplacement.magasin_id
+            WHERE COALESCE(magasin.code, magasin.code_magasin) = 'NEW-PF'
+              AND emplacement.code = $1
+              AND emplacement.is_active = true
+              AND emplacement.location_id IS NOT NULL
+            LIMIT 1
+          `,
+          [ofRow.client_code]
+        )
+      ).rows[0]?.location_id ?? null
+    : null;
+  const defaultLocationId = internalLocationId ?? configuredDefaultLocationId;
 
   const magasinsRes = await pool.query<{ id: string; code: string; name: string; is_active: boolean }>(
     `
@@ -743,6 +838,8 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
       affaire_id: ofRow.affaire_id === null ? null : Number(ofRow.affaire_id),
       commande_id: ofRow.commande_id === null ? null : Number(ofRow.commande_id),
       commande_ligne_id: ofRow.commande_ligne_id === null ? null : Number(ofRow.commande_ligne_id),
+      order_type: ofRow.order_type,
+      client_code: ofRow.client_code,
     },
     article_id: article.id,
     unite: article.unite,
@@ -818,24 +915,32 @@ export async function repoCreateOfReceipt(params: {
       piece_technique_id: string;
       article_id: string | null;
       affaire_id: number | null;
+      commande_id: number | null;
       commande_ligne_id: number | null;
+      order_type: string | null;
+      client_code: string | null;
       quantite_bonne: number;
       statut: string;
       updated_at: string;
     }>(
       `
         SELECT
-          numero,
-          piece_technique_id::text AS piece_technique_id,
-          article_id::text AS article_id,
-          affaire_id::bigint::int AS affaire_id,
-          commande_ligne_id::bigint::int AS commande_ligne_id,
-          quantite_bonne::float8 AS quantite_bonne,
-          statut::text AS statut,
-          updated_at::text AS updated_at
-        FROM public.ordres_fabrication
-        WHERE id = $1::bigint
-        FOR UPDATE
+          fabrication.numero,
+          fabrication.piece_technique_id::text AS piece_technique_id,
+          fabrication.article_id::text AS article_id,
+          fabrication.affaire_id::bigint::int AS affaire_id,
+          fabrication.commande_id::bigint::int AS commande_id,
+          fabrication.commande_ligne_id::bigint::int AS commande_ligne_id,
+          commande.order_type::text AS order_type,
+          piece.code_client::text AS client_code,
+          fabrication.quantite_bonne::float8 AS quantite_bonne,
+          fabrication.statut::text AS statut,
+          fabrication.updated_at::text AS updated_at
+        FROM public.ordres_fabrication fabrication
+        JOIN public.pieces_techniques piece ON piece.id = fabrication.piece_technique_id
+        LEFT JOIN public.commande_client commande ON commande.id = fabrication.commande_id
+        WHERE fabrication.id = $1::bigint
+        FOR UPDATE OF fabrication
       `,
       [params.of_id]
     );
@@ -893,7 +998,17 @@ export async function repoCreateOfReceipt(params: {
     }
 
     const unit = await resolveUnitIdForArticle(client, article.id, params.body.unite ?? null);
-    const map = await resolveEmplacementByLocationId(client, params.body.location_id);
+    const isInternalOrder = ofRow.order_type === "INTERNE";
+    const map = isInternalOrder
+      ? await ensureInternalOrderReceiptDestination(client, {
+          client_code: ofRow.client_code ?? "",
+          actor_user_id: params.audit.user_id,
+        })
+      : params.body.location_id
+        ? await resolveEmplacementByLocationId(client, params.body.location_id)
+        : (() => {
+            throw new HttpError(422, "RECEIPT_LOCATION_REQUIRED", "Sélectionnez l'emplacement de mise en stock.");
+          })();
     const stockLevelId = await ensureStockLevel(client, {
       article_id: article.id,
       unit_id: unit.unit_id,
@@ -1182,7 +1297,7 @@ export async function repoCreateOfReceipt(params: {
     }
 
     const autoReservation =
-      params.body.quality_status === "LIBERE" && typeof ofRow.commande_ligne_id === "number"
+      !isInternalOrder && params.body.quality_status === "LIBERE" && typeof ofRow.commande_ligne_id === "number"
         ? await reserveProducedQtyForCommandeLine(client, {
             commande_ligne_id: ofRow.commande_ligne_id,
             article_id: article.id,

--- a/src/module/production/validators/production.validators.ts
+++ b/src/module/production/validators/production.validators.ts
@@ -288,7 +288,7 @@ export const ofReceiptBodySchema = z
     qty_scrap: z.coerce.number().min(0).optional().default(0),
     qty_rework: z.coerce.number().min(0).optional().default(0),
     unite: z.string().trim().min(1).max(30).optional().nullable(),
-    location_id: uuid,
+    location_id: uuid.optional().nullable(),
     lot_mode: z.enum(["NEW", "EXISTING"]),
     lot_id: uuid.optional().nullable(),
     lot_number: z.string().trim().min(1).max(80).optional().nullable(),

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -3299,7 +3299,10 @@ export async function repoListAvailableArticleLots(
   const count = await db.query<{ total: number }>(`SELECT COUNT(*)::int AS total ${base}`, [articleId]);
   const data = await db.query<StockAvailableLotItem>(`
     SELECT l.id::text AS lot_id,
-           COALESCE(l.source_scope, l.stock_scope, 'NEW')::text AS source_scope,
+           CASE
+             WHEN l.origin_stock_scope = 'OLD' THEN 'OLD'
+             ELSE COALESCE(l.source_scope, l.stock_scope, 'NEW')
+           END::text AS source_scope,
            l.lot_code,
            v.qty_total::float8 AS qty_total,
            v.qty_reserved::float8 AS qty_reserved,
@@ -3310,7 +3313,11 @@ export async function repoListAvailableArticleLots(
            COALESCE(l.received_at, l.manufactured_at, l.created_at::date)::text AS fifo_received_at,
            l.created_at::text AS created_at
     ${base}
-    ORDER BY CASE COALESCE(l.source_scope, l.stock_scope, 'NEW') WHEN 'OLD' THEN 0 ELSE 1 END,
+    ORDER BY CASE
+               WHEN l.origin_stock_scope = 'OLD' THEN 0
+               WHEN COALESCE(l.source_scope, l.stock_scope, 'NEW') = 'OLD' THEN 0
+               ELSE 1
+             END,
              COALESCE(l.received_at, l.manufactured_at, l.created_at::date) ASC,
              l.created_at ASC, l.id ASC
     LIMIT $2 OFFSET $3
@@ -5565,7 +5572,11 @@ export async function repoListConsolidatedInventory(
   const where: string[] = [];
   const push = (value: unknown) => { values.push(value); return `$${values.length}`; };
 
-  if (filters.scope) where.push(`COALESCE(m.stock_scope, w.stock_scope, 'NEW') = ${push(filters.scope)}`);
+  const effectiveScopeSql = `CASE
+    WHEN l.origin_stock_scope = 'OLD' THEN 'OLD'
+    ELSE COALESCE(l.source_scope, l.stock_scope, m.stock_scope, w.stock_scope, 'NEW')
+  END`;
+  if (filters.scope) where.push(`${effectiveScopeSql} = ${push(filters.scope)}`);
   if (filters.magasin_id) where.push(`e.magasin_id = ${push(filters.magasin_id)}::uuid`);
   if (filters.rayon) where.push(`e.code ILIKE ${push(normalizeLikeQuery(filters.rayon))}`);
   if (filters.lot) where.push(`COALESCE(l.lot_code, '') ILIKE ${push(normalizeLikeQuery(filters.lot))}`);
@@ -5576,7 +5587,7 @@ export async function repoListConsolidatedInventory(
   const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
   const sort = {
     article_code: "a.code",
-    scope: "COALESCE(m.stock_scope, w.stock_scope, 'NEW')",
+    scope: effectiveScopeSql,
     magasin_code: "COALESCE(m.code, m.code_magasin, w.code)",
     rayon_code: "COALESCE(e.code, loc.code)",
     lot_code: "l.lot_code",
@@ -5591,6 +5602,14 @@ export async function repoListConsolidatedInventory(
     LEFT JOIN public.emplacements e ON e.location_id = b.location_id
     LEFT JOIN public.magasins m ON m.id = e.magasin_id
     LEFT JOIN public.lots l ON l.id = b.lot_id
+    LEFT JOIN LATERAL (
+      SELECT COALESCE(SUM(movement_line.qty), 0)::float8 AS qty_initial
+      FROM public.stock_movement_lines movement_line
+      JOIN public.stock_movements movement ON movement.id = movement_line.movement_id
+      WHERE movement_line.lot_id = b.lot_id
+        AND movement.status = 'POSTED'
+        AND movement.source_document_type = 'CERP_HISTORICAL_OPENING'
+    ) opening ON TRUE
     LEFT JOIN public.articles_matiere article_material ON article_material.article_id = a.id
     LEFT JOIN public.stock_nuances material_nuance ON material_nuance.id = article_material.nuance_id
     LEFT JOIN public.stock_etats material_etat ON material_etat.id = article_material.etat_id
@@ -5617,11 +5636,12 @@ export async function repoListConsolidatedInventory(
        article_material.hauteur_mm::float8 AS material_hauteur_mm,
        article_material.epaisseur_mm::float8 AS material_epaisseur_mm,
        article_material.diametre_mm::float8 AS material_diametre_mm,
-       COALESCE(m.stock_scope, w.stock_scope, 'NEW')::text AS scope,
+       ${effectiveScopeSql}::text AS scope,
        COALESCE(m.id, '00000000-0000-0000-0000-000000000000')::text AS magasin_id,
        COALESCE(m.code, m.code_magasin, w.code)::text AS magasin_code,
        COALESCE(e.code, loc.code)::text AS rayon_code,
        b.lot_id::text AS lot_id, l.lot_code, l.stock_trace_code::text AS stock_trace_code, l.qr_payload,
+       CASE WHEN ${effectiveScopeSql} = 'OLD' THEN opening.qty_initial ELSE NULL END::float8 AS qty_initial,
        b.qty_total::float8 AS qty_total, b.qty_reserved::float8 AS qty_reserved,
        b.qty_available::float8 AS qty_available, b.updated_at::text AS updated_at
      ${fromSql} ${whereSql}
@@ -5784,7 +5804,7 @@ export async function repoCreateHistoricalImport(body: HistoricalImportBodyDTO, 
     const lotCode = await generateTransactionalBusinessCode(client, { prefix: "LOT" });
     const traceSequence = await client.query<{ value: string }>(`SELECT nextval('public.stock_trace_code_446_seq')::text AS value`);
     const trace = (traceSequence.rows[0]?.value ?? "0").padStart(6, "0");
-    const lot = await client.query<{ id: string }>(`INSERT INTO public.lots (article_id, lot_code, supplier_lot_code, notes, stock_trace_code, qr_payload, origin_stock_scope, created_by, updated_by) VALUES ($1::uuid,$2,$3,$4,$5,$6,'OLD',$7,$7) RETURNING id::text AS id`, [articleId, lotCode, body.kind === "MP" ? body.lot_number : null, body.notes ?? null, trace, `CERP-STOCK:${trace}`, audit.user_id]);
+    const lot = await client.query<{ id: string }>(`INSERT INTO public.lots (article_id, lot_code, supplier_lot_code, notes, stock_trace_code, qr_payload, origin_stock_scope, source_scope, stock_scope, created_by, updated_by) VALUES ($1::uuid,$2,$3,$4,$5,$6,'OLD','OLD','OLD',$7,$7) RETURNING id::text AS id`, [articleId, lotCode, body.kind === "MP" ? body.lot_number : null, body.notes ?? null, trace, `CERP-STOCK:${trace}`, audit.user_id]);
     const lotId = lot.rows[0]?.id;
     if (!lotId) throw new Error("Unable to create historical lot");
     const refs: Array<["OF" | "MP_LOT" | "TRAITEMENT_LOT", string[]]> = body.kind === "PF"

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -10,7 +10,7 @@ export type HistoricalStockImport = { article_id: string; lot_id: string; moveme
 export type ConsolidatedInventoryRow = {
   article_id: string; article_code: string; article_designation: string; old_material_definition: string | null; scope: "OLD" | "NEW";
   magasin_id: string; magasin_code: string; rayon_code: string; lot_id: string | null; lot_code: string | null;
-  stock_trace_code: string | null; qr_payload: string | null; qty_total: number; qty_reserved: number; qty_available: number;
+  stock_trace_code: string | null; qr_payload: string | null; qty_initial: number | null; qty_total: number; qty_reserved: number; qty_available: number;
   updated_at: string;
 };
 

--- a/src/shared/email/resend.service.ts
+++ b/src/shared/email/resend.service.ts
@@ -1,3 +1,5 @@
+import { resolveOutboundEmailRecipients, testSafeEmailSubject } from "./test-email-routing";
+
 type ResendConfig = {
   apiKey: string;
   from: string;
@@ -103,14 +105,15 @@ export async function sendTransactionalEmail(params: {
 }): Promise<ResendSendResult> {
   const cfg = readResendConfig();
   if (!cfg) return { ok: false, skipped: true };
+  const delivery = resolveOutboundEmailRecipients(params.to);
 
   return postResendEmail({
     cfg,
     idempotencyKey: params.idempotencyKey ?? null,
     payload: {
       from: cfg.from,
-      to: params.to,
-      subject: params.subject,
+      to: delivery.recipients,
+      subject: testSafeEmailSubject(params.subject, delivery.rerouted),
       text: params.text,
       html: params.html,
       attachments: (params.attachments ?? []).map((attachment) => ({

--- a/src/shared/email/test-email-routing.test.ts
+++ b/src/shared/email/test-email-routing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TEST_EMAIL_RECIPIENTS,
+  isTestEmailEnvironment,
+  resolveOutboundEmailRecipients,
+  testSafeEmailSubject,
+} from "./test-email-routing";
+
+describe("test email routing safety boundary", () => {
+  it("detects the deployed test database without exposing its credentials", () => {
+    expect(isTestEmailEnvironment({ DATABASE_URL: "postgresql://user:secret@db/cerp_test" } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isTestEmailEnvironment({ CERP_ENVIRONMENT: "test" } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isTestEmailEnvironment({ CERP_ENVIRONMENT: "production", DATABASE_URL: "postgresql://db/cerp" } as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it("replaces every intended test recipient with the two internal mailboxes", () => {
+    const delivery = resolveOutboundEmailRecipients(
+      ["client@example.com", "another-client@example.com"],
+      { CERP_ENVIRONMENT: "test" } as NodeJS.ProcessEnv
+    );
+
+    expect(delivery).toEqual({ recipients: [...TEST_EMAIL_RECIPIENTS], rerouted: true });
+    expect(delivery.recipients).not.toContain("client@example.com");
+    expect(testSafeEmailSubject("Accuse de reception", delivery.rerouted)).toMatch(/^\[TEST/);
+  });
+
+  it("keeps deduplicated intended recipients in production", () => {
+    expect(resolveOutboundEmailRecipients(
+      ["client@example.com", "client@example.com"],
+      { CERP_ENVIRONMENT: "production", DATABASE_URL: "postgresql://db/cerp" } as NodeJS.ProcessEnv
+    )).toEqual({ recipients: ["client@example.com"], rerouted: false });
+  });
+});

--- a/src/shared/email/test-email-routing.ts
+++ b/src/shared/email/test-email-routing.ts
@@ -1,0 +1,49 @@
+export const TEST_EMAIL_RECIPIENTS = Object.freeze([
+  "clement@croix-rousse-precision.fr",
+  "kesmartin2004@croix-rousse-precision.fr",
+] as const);
+
+function databaseNameFromUrl(value: string | undefined): string | null {
+  const raw = value?.trim();
+  if (!raw) return null;
+  try {
+    const pathname = new URL(raw).pathname;
+    const databaseName = decodeURIComponent(pathname.split("/").filter(Boolean).at(-1) ?? "").trim();
+    return databaseName || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The deployed API deliberately runs with NODE_ENV=development in some environments,
+ * so the email safety boundary must use the explicit CERP environment or database name.
+ */
+export function isTestEmailEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  const explicitMode = (env.CERP_EMAIL_TEST_MODE ?? "").trim().toLowerCase();
+  if (["1", "true", "test"].includes(explicitMode)) return true;
+
+  const cerpEnvironment = (env.CERP_ENVIRONMENT ?? "").trim().toLowerCase();
+  if (/^(test|testing|sandbox|staging|recette|development|dev)$/.test(cerpEnvironment)) return true;
+  if ((env.NODE_ENV ?? "").trim().toLowerCase() === "test") return true;
+
+  const databaseName = databaseNameFromUrl(env.DATABASE_URL)?.toLowerCase() ?? "";
+  return /(^|[_-])(test|testing|sandbox|staging|recette|dev|local)($|[_-])/.test(databaseName);
+}
+
+export function resolveOutboundEmailRecipients(
+  intendedRecipients: readonly string[],
+  env: NodeJS.ProcessEnv = process.env
+): { recipients: string[]; rerouted: boolean } {
+  if (isTestEmailEnvironment(env)) {
+    return { recipients: [...TEST_EMAIL_RECIPIENTS], rerouted: true };
+  }
+  return {
+    recipients: [...new Set(intendedRecipients.map((recipient) => recipient.trim()).filter(Boolean))],
+    rerouted: false,
+  };
+}
+
+export function testSafeEmailSubject(subject: string, rerouted: boolean): string {
+  return rerouted ? `[TEST - destinataires rediriges] ${subject}` : subject;
+}


### PR DESCRIPTION
## Promotion validee sur cerp_test\n\n- origine OLD/NEW autoritaire et quantite initiale de lot\n- commande interne sans reservation ni affaire de livraison\n- reception automatique NEW-PF / numero client\n- planning requis des qu'un OF existe\n- versions AR et idempotence fiabilisees\n- routage email des environnements de test\n- migration supprimant la contrainte destination obsolete\n\nTests, typecheck, build et migration test valides.\n\nCloses #883

## Summary by Sourcery

Fiabilisez les flux de stock, de commandes internes, de planning et d’AR en automatisant les destinations, en renforçant l’idempotence et en sécurisant les environnements de test.

New Features:
- Automatisez la destination de réception des commandes internes vers NEW-PF et l’emplacement associé au numéro client.
- Ajoutez la prise en charge des commandes internes sans affaire de livraison, réservation ni destination de stock prédéfinie.
- Exposez la quantité initiale des lots historiques et fiabilisez leur classification OLD/NEW ainsi que leur priorité FIFO.
- Sécurisez le routage des emails sortants vers des boîtes internes dans les environnements de test.

Bug Fixes:
- Restaurez l’obligation de validation du planning pour tout OF, y compris ceux sans opération, avec réparation auditée des anciens contournements.
- Améliorez l’idempotence et la compatibilité des rejoués de génération des commandes internes et des versions AR.
- Supprimez la contrainte de base de données devenue incompatible avec la résolution automatique des destinations internes.

Enhancements:
- Renforcez la cohérence des origines de stock en donnant priorité aux lots explicitement issus de l’ancien stock.
- Centralisez l’envoi transactionnel d’emails et rendez la destination de réception facultative uniquement pour les OF internes.

Deployment:
- Ajoutez une migration contrôlée, avec préflight, vérification et rollback gardé, pour retirer la contrainte de destination obsolète.

Documentation:
- Mettez à jour le contrat des commandes internes pour documenter le flux fabrication, planning, réception et mise en stock.

Tests:
- Actualisez les contrats et tests couvrant les commandes internes, le planning obligatoire, les réceptions automatiques, les origines de stock, la migration et le routage des emails.