### PR TITLE
release: corriger les relances AR en environnement test

### DIFF
--- a/src/__tests__/commande-ar.send.service.test.ts
+++ b/src/__tests__/commande-ar.send.service.test.ts
@@ -150,8 +150,39 @@ describe("svcSendCommandeAr", () => {
       status: 503,
     });
 
-    expect(mocks.markFailed).toHaveBeenCalledWith(expect.objectContaining({ ar_id: AR_ID }));
+    expect(mocks.markFailed).toHaveBeenCalledWith(expect.objectContaining({
+      ar_id: AR_ID,
+      release_idempotency: true,
+    }));
     expect(mocks.finalize).not.toHaveBeenCalled();
+  });
+
+  it("keeps the retry guard after an ambiguous provider failure", async () => {
+    mocks.sendEmail.mockResolvedValue({ ok: false, error: "network response lost" });
+
+    await expect(svcSendCommandeAr({ commande_id: 42, user_id: 7, body: sendBody })).rejects.toMatchObject({
+      code: "COMMANDE_AR_SEND_FAILED",
+      status: 502,
+    });
+
+    expect(mocks.markFailed).toHaveBeenCalledWith(expect.objectContaining({
+      ar_id: AR_ID,
+      release_idempotency: false,
+    }));
+  });
+
+  it("releases the retry guard when preparation fails before the provider call", async () => {
+    mocks.readOfficialPdf.mockRejectedValue(new Error("official archive unavailable"));
+
+    await expect(svcSendCommandeAr({ commande_id: 42, user_id: 7, body: sendBody })).rejects.toThrow(
+      "official archive unavailable"
+    );
+
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+    expect(mocks.markFailed).toHaveBeenCalledWith(expect.objectContaining({
+      ar_id: AR_ID,
+      release_idempotency: true,
+    }));
   });
 
   it("returns an already-sent version without calling the provider a second time", async () => {

--- a/src/module/commande-client/repository/commande-ar.repository.ts
+++ b/src/module/commande-client/repository/commande-ar.repository.ts
@@ -1469,6 +1469,7 @@ export async function repoMarkCommandeArFailed(params: {
   error_message: string;
   user_id: number;
   provider_name?: string | null;
+  release_idempotency?: boolean;
 }): Promise<void> {
   const client = await pool.connect();
   await withRealtimeOutboxTransaction(client, async (tx) => {
@@ -1476,18 +1477,32 @@ export async function repoMarkCommandeArFailed(params: {
       `
         UPDATE public.commande_ar_log
         SET status = 'FAILED', error_message = left($4, 2000),
-            provider_name = COALESCE($5, provider_name), send_lock_token = NULL
+            provider_name = COALESCE($5, provider_name), send_lock_token = NULL,
+            send_idempotency_key = CASE WHEN $6::boolean THEN NULL ELSE send_idempotency_key END,
+            send_payload_fingerprint = CASE WHEN $6::boolean THEN NULL ELSE send_payload_fingerprint END
         WHERE id = $1::uuid AND commande_id = $2::bigint
           AND status = 'SENDING' AND send_lock_token = $3::uuid
         RETURNING id::text AS id
       `,
-      [params.ar_id, params.commande_id, params.send_lock_token, params.error_message, params.provider_name ?? "resend"]
+      [
+        params.ar_id,
+        params.commande_id,
+        params.send_lock_token,
+        params.error_message,
+        params.provider_name ?? "resend",
+        params.release_idempotency === true,
+      ]
     );
     if (update.rows[0]) {
       await insertCommandeEvent(tx, {
         commande_id: params.commande_id,
         event_type: "AR_SEND_FAILED",
-        new_values: { ar_id: params.ar_id, provider: params.provider_name ?? "resend", error_message: params.error_message.slice(0, 2000) },
+        new_values: {
+          ar_id: params.ar_id,
+          provider: params.provider_name ?? "resend",
+          error_message: params.error_message.slice(0, 2000),
+          retry_payload_released: params.release_idempotency === true,
+        },
         user_id: params.user_id,
       });
     }

--- a/src/module/commande-client/services/commande-ar.service.ts
+++ b/src/module/commande-client/services/commande-ar.service.ts
@@ -501,6 +501,8 @@ export async function svcSendCommandeAr(params: {
 
   const claim = claimResult;
   const draft = claim.draft;
+  let providerCallStarted = false;
+  let providerDefinitelyNotCalled = false;
   try {
     // The supplier/customer-facing email must attach the exact archived GED
     // bytes, never a mutable legacy working-file copy.
@@ -543,6 +545,7 @@ export async function svcSendCommandeAr(params: {
     const sentText = emailBodyOverride ?? generatedContent.text;
     const sentHtml = emailBodyOverride ? renderCommandeArEmailHtml(emailBodyOverride) : generatedContent.html;
 
+    providerCallStarted = true;
     const emailResult = await sendTransactionalEmail({
       to: recipientEmails,
       subject: generatedContent.subject,
@@ -562,6 +565,7 @@ export async function svcSendCommandeAr(params: {
       let statusCode = 502;
       let message = "Erreur d'envoi de l'email";
       if ("skipped" in emailResult && emailResult.skipped === true) {
+        providerDefinitelyNotCalled = true;
         statusCode = 503;
         message = "Email non configuré sur le serveur";
       } else if (isResendSendError(emailResult)) {
@@ -595,6 +599,12 @@ export async function svcSendCommandeAr(params: {
       error_message: errorMessage,
       user_id: params.user_id,
       provider_name: "resend",
+      // Before the provider call (official archive still pending, integrity
+      // guard, invalid snapshot) or when email is not configured, no external
+      // side effect is possible. Release the payload guard so the operator can
+      // correct recipients/message and retry. Ambiguous provider failures keep
+      // the guard and the deterministic idempotency key.
+      release_idempotency: !providerCallStarted || providerDefinitelyNotCalled,
     })).catch(() => undefined);
     throw err;
   }


### PR DESCRIPTION
## Correctif

- libère l’empreinte de relance AR uniquement quand aucun appel au fournisseur email n’a pu avoir lieu ;
- conserve l’idempotence stricte après une erreur fournisseur ambiguë ;
- journalise explicitement si le payload de relance a été libéré.

## Cause vérifiée

La tentative de la commande 37 échouait avant Resend car `RESEND_API_KEY` était vide sur HYPERBOX2. Le backend conservait malgré tout l’empreinte du payload et rejetait ensuite les corrections opérateur avec `COMMANDE_AR_RETRY_PAYLOAD_MISMATCH`.

## Vérifications

- `pnpm test:run src/__tests__/commande-ar.send.service.test.ts src/module/commande-client/services/commande-ar.service.test.ts`
- `pnpm test:run src/shared/email/test-email-routing.test.ts`
- `pnpm typecheck`
- `pnpm build`

Refs #883

## Summary by Sourcery

Correct AR retry handling so payload idempotency is released only when no external email side effect could have occurred.

Bug Fixes:
- Release the AR retry payload guard when sending fails before any email-provider call or when email delivery is definitively skipped, allowing operator corrections and retries.
- Preserve strict idempotency protection after ambiguous email-provider failures to prevent duplicate sends.
- Record explicitly whether the retry payload guard was released in AR failure events.

Tests:
- Add coverage for ambiguous provider failures and pre-provider preparation failures, including their retry-guard behavior.