### PR TITLE
feat: centraliser la préparation des BL dans l'Atelier

### DIFF
--- a/docs/http/livraisons-226.md
+++ b/docs/http/livraisons-226.md
@@ -4,6 +4,12 @@ Le module `src/module/livraisons` est monté sous `/api/v1/livraisons`.
 
 ## Écritures critiques
 
+- `GET /preparation-cart` liste les réservations actives disponibles pour
+  l'Atelier BL. Les filtres serveur acceptent notamment `q`, `client_id`,
+  `commande_id`, `affaire_id` et `source_scope` (`OLD` ou `NEW`).
+- `POST /from-reservations` est le point d'entrée autoritaire pour constituer
+  un BL depuis les lignes cochées dans l'Atelier. Il consomme une clé
+  d'idempotence et refuse les réservations incompatibles ou périmées.
 - `POST /:id/status` prépare `READY`, annule avec motif ou déclare livré après
   preuve. Il refuse `SHIPPED`.
 - `GET /:id/shipment-preview` calcule l'aperçu sans écriture.
@@ -24,6 +30,17 @@ d'idempotence. Le résultat contient obligatoirement :
 ```
 
 Il n'existe aucun import ou appel Facture dans ce flux.
+
+## Frontière avec la commande client
+
+Le lancement d'une commande client réserve le stock disponible et expose les
+lignes dans le panier de préparation. Il ne crée et ne prépare plus de BL.
+Toute création interactive passe par `POST /from-reservations` dans l'Atelier
+BL.
+
+`POST /from-commande` reste temporairement monté pour compatibilité avec les
+anciens clients API. Le frontend CERP ne l'utilise plus et ce point d'entrée ne
+fait pas partie du nouveau parcours opérateur.
 
 ## Patch
 

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -1387,7 +1387,7 @@ describe("/api/v1/commandes", () => {
     expect(res.body).toMatchObject({ id: 456 });
   });
 
-  it("POST /api/v1/commandes/:id/generate-affaires prepares a reserved BL from OLD stock without OF", async () => {
+  it("POST /api/v1/commandes/:id/generate-affaires reserves OLD stock for Atelier BL without creating a BL or OF", async () => {
     process.env.JWT_SECRET = "test-secret";
     const token = jwt.sign(
       { id: 1, username: "test", email: "test@example.com", role: "admin" },
@@ -1399,6 +1399,7 @@ describe("/api/v1/commandes", () => {
     const LOCATION_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
     const ARTICLE_ID = "11111111-1111-1111-1111-111111111111";
     const PIECE_ID = "22222222-2222-2222-2222-222222222222";
+    const LOT_ID = "99999999-9999-4999-8999-999999999998";
 
     let fullStockReplay = false;
     mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
@@ -1508,7 +1509,7 @@ describe("/api/v1/commandes", () => {
             stock_level_id: "33333333-3333-4333-8333-333333333333",
             stock_batch_id: null,
             location_id: LOCATION_ID,
-            lot_id: null,
+            lot_id: LOT_ID,
             magasin_id: MAGASIN_ID,
             emplacement_id: 1,
             qty_available: 1,
@@ -1551,6 +1552,12 @@ describe("/api/v1/commandes", () => {
       if (q.includes("INSERT INTO affaire")) return { rows: [] };
       if (q.includes("INSERT INTO commande_to_affaire")) return { rows: [] };
       if (q.includes("INSERT INTO public.commande_ligne_affaire_allocation")) return { rows: [] };
+      if (q.includes("FROM public.commande_ligne_affaire_allocation") && q.includes("FOR UPDATE")) {
+        return { rows: [{ id: 42, commande_ligne_id: 1 }] };
+      }
+      if (q.includes("SELECT lot_status, source_scope FROM public.lots")) {
+        return { rows: [{ lot_status: "LIBERE", source_scope: "OLD" }] };
+      }
       if (q.includes("SELECT delivery_address_id::text AS delivery_address_id FROM clients")) return { rows: [{ delivery_address_id: null }] };
       if (q.includes("nextval('public.bon_livraison_no_seq')")) return { rows: [{ n: "1" }] };
       if (q.includes("INSERT INTO bon_livraison (") && q.includes("RETURNING id::text AS id")) {
@@ -1655,7 +1662,7 @@ describe("/api/v1/commandes", () => {
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
       affaire_ids: [7],
-      bon_livraison_id: "44444444-4444-4444-8444-444444444444",
+      bon_livraison_id: null,
       reservations_created: [expect.any(String)],
       of_ids: [],
       workflow_status: "AR_PRET",
@@ -1668,10 +1675,20 @@ describe("/api/v1/commandes", () => {
       String(c[0]).includes("INSERT INTO commande_to_affaire")
     );
     expect(linkCall).toBeTruthy();
-    const allocationCall = mocks.clientQuery.mock.calls.find((call) =>
-      String(call[0]).includes("INSERT INTO public.bon_livraison_ligne_allocations")
+    const reservationCall = mocks.clientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO public.stock_reservations")
     );
-    expect(allocationCall?.[1]).toEqual(expect.arrayContaining(["33333333-3333-4333-8333-333333333333"]));
+    expect(reservationCall?.[1]).toEqual(
+      expect.arrayContaining([LOT_ID, "33333333-3333-4333-8333-333333333333"])
+    );
+    expect(
+      mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO bon_livraison ("))
+    ).toBe(false);
+    expect(
+      mocks.clientQuery.mock.calls.some((call) =>
+        String(call[0]).includes("INSERT INTO public.bon_livraison_ligne_allocations")
+      )
+    ).toBe(false);
     const workflowAdvanceCall = mocks.clientQuery.mock.calls.find((call) =>
       String(call[0]).includes("checkpoint_code IN (") && String(call[0]).includes("'delivery'")
     );

--- a/src/module/access-control/domain/module-catalog.ts
+++ b/src/module/access-control/domain/module-catalog.ts
@@ -53,7 +53,7 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
     description: "Préparation, expédition et bons de livraison.",
     category: "Commerce",
     api_prefixes: ["/livraisons"],
-    nav_page_keys: ["livraisons"],
+    nav_page_keys: ["livraisons", "livraisons-preparation"],
     is_protected: false,
     sort_order: 40,
   },

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -23,8 +23,6 @@ import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repos
 import { assertOperationalLotQualityEligibility } from "../../qualite/repository/quality-operational-gate.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import { repoCreateAppNotifications, repoListUsersForCommandePlanningNotification } from "../../notifications/repository/notifications.repository";
-import { repoCreateLivraisonFromCommande } from "../../livraisons/repository/livraisons.repository";
-import { prepareLivraisonInTransaction } from "../../livraisons/repository/livraisons-shipment.repository";
 import type { AppNotification } from "../../notifications/types/notifications.types";
 import type {
   CreateCommandeInput,
@@ -1601,7 +1599,6 @@ async function advanceCustomerOrderWorkflowAfterLaunch(params: {
   commande_id: number;
   user_id: number;
   needs_production: boolean;
-  bon_livraison_id: string | null;
   of_ids: number[];
 }) {
   const launchMode = resolveCustomerOrderLaunchMode({
@@ -1635,14 +1632,6 @@ async function advanceCustomerOrderWorkflowAfterLaunch(params: {
     });
   }
 
-  if (!params.bon_livraison_id) {
-    throw new HttpError(
-      409,
-      "PREPARED_DELIVERY_REQUIRED",
-      "La commande couverte par le stock doit posséder un bon de livraison préparé."
-    );
-  }
-
   await params.tx.query(
     `
       UPDATE public.commande_client_workflow_checkpoint
@@ -1674,7 +1663,8 @@ async function advanceCustomerOrderWorkflowAfterLaunch(params: {
       JSON.stringify({
         skip_reason: "commande_fully_reserved_from_stock_awaiting_ar",
         stock_only_flow: true,
-        bon_livraison_id: params.bon_livraison_id,
+        delivery_preparation: "ATELIER_BL",
+        bon_livraison_id: null,
       }),
     ]
   );
@@ -4673,21 +4663,19 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
 
     const holdsStockForGroupedDelivery =
       orderType !== "INTERNE" && needsProduction && decision === "SHIP_ALL_TOGETHER";
-    const preparedDelivery =
-      orderType !== "INTERNE" && livraisonAffaireId !== null && !holdsStockForGroupedDelivery
-        ? await createPreparedLivraisonForStock(client, {
-            commande_id: commandeId,
-            user_id: audit.user_id,
-            analysis_lines: stockAnalysis.lines,
-            quantities_by_line: immediateDeliveryByLine,
-          })
-        : null;
-    const reservationsCreated = holdsStockForGroupedDelivery
+    // A command launch reserves traceable stock but never creates a BL.  The
+    // operator deliberately groups and verifies the ready lines in Atelier BL;
+    // this prevents an order page or an automated launch from becoming a
+    // second, competing delivery-preparation workflow.
+    const quantitiesToReserve = holdsStockForGroupedDelivery
+      ? stockCoveredByLine
+      : immediateDeliveryByLine;
+    const reservationsCreated = orderType !== "INTERNE" && livraisonAffaireId !== null
       ? (
           (recoveredInvalidPlanningState
             ? await reuseRecoveredCommandeStockReservations(client, {
                 commande_id: commandeId,
-                quantities_by_line: stockCoveredByLine,
+                quantities_by_line: quantitiesToReserve,
               })
             : null) ??
           await reserveCommandeStockForLaterDelivery(client, {
@@ -4695,11 +4683,11 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
             livraison_affaire_id: livraisonAffaireId as number,
             user_id: audit.user_id,
             analysis_lines: stockAnalysis.lines,
-            quantities_by_line: stockCoveredByLine,
+            quantities_by_line: quantitiesToReserve,
           })
         )
-      : preparedDelivery?.reservation_ids ?? [];
-    const bonLivraisonId = preparedDelivery?.bon_livraison_id ?? null;
+      : [];
+    const bonLivraisonId = null;
 
     const generatedOfs: GeneratedOfRef[] = [];
     const generationWarnings: string[] = [];
@@ -4770,7 +4758,6 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         commande_id: commandeId,
         user_id: audit.user_id,
         needs_production: needsProduction,
-        bon_livraison_id: bonLivraisonId,
         of_ids: ofIds,
       });
       workflowStatus = transition.nouveau_statut;
@@ -5399,108 +5386,6 @@ function planDeliveryAllocations(
   }
 
   return planned;
-}
-
-async function createPreparedLivraisonForStock(
-  db: PoolClient,
-  params: {
-    commande_id: number;
-    user_id: number;
-    analysis_lines: CommandeStockAnalysisLine[];
-    quantities_by_line: ReadonlyMap<number, number>;
-  }
-): Promise<{ bon_livraison_id: string; reservation_ids: string[] } | null> {
-  const positiveQuantities = new Map(
-    [...params.quantities_by_line.entries()].filter(([, quantity]) => Number(quantity) > 1e-9)
-  );
-  if (positiveQuantities.size === 0) return null;
-
-  const articleIds = Array.from(
-    new Set(
-      params.analysis_lines
-        .filter((line) => positiveQuantities.has(line.commande_ligne_id))
-        .map((line) => line.article_id)
-        .filter((articleId): articleId is string => Boolean(articleId))
-    )
-  );
-  const candidates = await loadScopedDeliveryStockCandidates(db, articleIds);
-  const allocations = planDeliveryAllocations(params.analysis_lines, positiveQuantities, candidates);
-  const livraison = await repoCreateLivraisonFromCommande(
-    params.commande_id,
-    params.user_id,
-    db,
-    positiveQuantities
-  );
-
-  const lineRows = await db.query<{ id: string; commande_ligne_id: number }>(
-    `
-      SELECT id::text AS id, commande_ligne_id::bigint::int AS commande_ligne_id
-      FROM public.bon_livraison_ligne
-      WHERE bon_livraison_id = $1::uuid
-        AND commande_ligne_id IS NOT NULL
-    `,
-    [livraison.id]
-  );
-  const deliveryLineByCommandeLine = new Map(
-    lineRows.rows.map((line) => [line.commande_ligne_id, line.id] as const)
-  );
-
-  for (const allocation of allocations) {
-    const deliveryLineId = deliveryLineByCommandeLine.get(allocation.commande_ligne_id);
-    if (!deliveryLineId) throw new Error("Prepared delivery line mapping is missing");
-    await db.query(
-      `
-        INSERT INTO public.bon_livraison_ligne_allocations (
-          bon_livraison_ligne_id,
-          article_id,
-          lot_id,
-          magasin_id,
-          emplacement_id,
-          location_id,
-          stock_level_id,
-          stock_batch_id,
-          reservation_id,
-          stock_movement_line_id,
-          quantite,
-          unite,
-          created_by,
-          updated_by
-        ) VALUES (
-          $1::uuid,$2::uuid,$3::uuid,$4::uuid,$5::bigint,$6::uuid,$7::uuid,$8::uuid,
-          NULL,NULL,$9,NULL,$10,$10
-        )
-      `,
-      [
-        deliveryLineId,
-        allocation.article_id,
-        allocation.lot_id,
-        allocation.magasin_id,
-        allocation.emplacement_id,
-        allocation.location_id,
-        allocation.stock_level_id,
-        allocation.stock_batch_id,
-        allocation.quantity,
-        params.user_id,
-      ]
-    );
-  }
-
-  await prepareLivraisonInTransaction(db, livraison.id, params.user_id);
-  const reservations = await db.query<{ id: string }>(
-    `
-      SELECT reservation.id::text AS id
-      FROM public.bon_livraison_ligne_allocations allocation
-      JOIN public.bon_livraison_ligne line ON line.id = allocation.bon_livraison_ligne_id
-      JOIN public.stock_reservations reservation ON reservation.id = allocation.reservation_id
-      WHERE line.bon_livraison_id = $1::uuid
-      ORDER BY reservation.id
-    `,
-    [livraison.id]
-  );
-  return {
-    bon_livraison_id: livraison.id,
-    reservation_ids: reservations.rows.map((reservation) => reservation.id),
-  };
 }
 
 export async function reserveCommandeStockForLaterDelivery(

--- a/src/module/commande-client/repository/commande-delivery-preparation.contract.test.ts
+++ b/src/module/commande-client/repository/commande-delivery-preparation.contract.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+import { repoRoot } from "../../../__tests__/helpers/repo-paths"
+
+const source = readFileSync(
+  resolve(repoRoot, "src/module/commande-client/repository/commande-client.repository.ts"),
+  "utf8"
+)
+
+describe("customer-order delivery preparation boundary", () => {
+  it("reserves stock for Atelier BL without creating a BL during order launch", () => {
+    const start = source.indexOf("export async function repoGenerateAffairesFromOrder")
+    const end = source.indexOf("\ntype AffaireCreationInput", start)
+    const lifecycle = source.slice(start, end)
+
+    expect(lifecycle).toContain("reserveCommandeStockForLaterDelivery")
+    expect(lifecycle).toContain("const bonLivraisonId = null")
+    expect(lifecycle).not.toContain("createPreparedLivraisonForStock(")
+  })
+})

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -3316,6 +3316,21 @@ export async function repoListPreparationCart(filters: PreparationCartQueryDTO):
   }
   if (filters.commande_id) where.push(`a.commande_id = ${push(filters.commande_id)}::bigint`)
   if (filters.affaire_id) where.push(`r.livraison_affaire_id = ${push(filters.affaire_id)}::bigint`)
+  if (filters.client_id) where.push(`cc.client_id::text = ${push(filters.client_id)}::text`)
+  if (filters.source_scope) {
+    where.push(`COALESCE(r.source_scope, l.source_scope, 'NEW') = ${push(filters.source_scope)}`)
+  }
+  if (filters.q) {
+    const term = push(`%${filters.q}%`)
+    where.push(`(
+      cc.numero ILIKE ${term}
+      OR COALESCE(c.company_name, '') ILIKE ${term}
+      OR COALESCE(af.reference, '') ILIKE ${term}
+      OR COALESCE(art.code, '') ILIKE ${term}
+      OR COALESCE(cl.designation, '') ILIKE ${term}
+      OR COALESCE(l.lot_code, '') ILIKE ${term}
+    )`)
+  }
   if (filters.bon_livraison_id) {
     where.push(`EXISTS (
       SELECT 1 FROM public.bon_livraison_ligne_allocations bla
@@ -3329,7 +3344,13 @@ export async function repoListPreparationCart(filters: PreparationCartQueryDTO):
     `
       SELECT COUNT(*)::int AS total
       FROM public.stock_reservations r
-      LEFT JOIN public.commande_ligne_affaire_allocation a ON a.id = r.commande_ligne_affaire_allocation_id
+      JOIN public.commande_ligne_affaire_allocation a ON a.id = r.commande_ligne_affaire_allocation_id
+      JOIN public.commande_client cc ON cc.id = a.commande_id
+      JOIN public.commande_ligne cl ON cl.id = a.commande_ligne_id
+      LEFT JOIN public.clients c ON c.client_id = cc.client_id
+      LEFT JOIN public.affaire af ON af.id = r.livraison_affaire_id
+      JOIN public.articles art ON art.id = r.article_id
+      LEFT JOIN public.lots l ON l.id = r.lot_id
       ${whereSql}
     `,
     values

--- a/src/module/livraisons/validators/livraisons.validators.test.ts
+++ b/src/module/livraisons/validators/livraisons.validators.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+
+import { preparationCartQuerySchema } from "./livraisons.validators"
+
+describe("preparationCartQuerySchema", () => {
+  it("accepte les filtres de l'atelier BL", () => {
+    expect(
+      preparationCartQuerySchema.parse({
+        q: "CMD-2026",
+        client_id: "CLIENT-999",
+        source_scope: "OLD",
+        page: "2",
+        pageSize: "50",
+      })
+    ).toEqual({
+      q: "CMD-2026",
+      client_id: "CLIENT-999",
+      source_scope: "OLD",
+      page: 2,
+      pageSize: 50,
+    })
+  })
+
+  it("refuse un filtre de base inconnu", () => {
+    expect(() => preparationCartQuerySchema.parse({ source_scope: "LEGACY" })).toThrow()
+  })
+})

--- a/src/module/livraisons/validators/livraisons.validators.ts
+++ b/src/module/livraisons/validators/livraisons.validators.ts
@@ -223,9 +223,12 @@ export type LivraisonProofBodyDTO = z.infer<typeof livraisonProofBodySchema>
 /* -------------------------------------------------------------------------- */
 
 export const preparationCartQuerySchema = z.object({
+  q: z.string().trim().min(1).max(160).optional(),
+  client_id: z.string().trim().min(1).max(120).optional(),
   commande_id: z.coerce.number().int().positive().optional(),
   affaire_id: z.coerce.number().int().positive().optional(),
   bon_livraison_id: z.string().uuid().optional(),
+  source_scope: z.enum(["OLD", "NEW"]).optional(),
   page: z.coerce.number().int().positive().optional().default(1),
   pageSize: z.coerce.number().int().positive().max(200).optional().default(100),
 })


### PR DESCRIPTION
## Résumé
- filtre le panier serveur par client, recherche et source OLD/NEW
- réserve le stock au lancement d'une commande sans générer de BL
- conserve l'Atelier BL comme seul parcours opérateur de constitution
- ajoute les contrats de non-régression et la documentation API

Closes #658

## Vérifications
- typecheck backend vert
- 50 tests ciblés verts
- build production et contrat OpenAPI verts
- suite complète: 5144 tests verts; deux échecs résiduels sont locaux (mot de passe PostgreSQL absent et verrou Windows temporaire d'upload)

## Summary by Sourcery

Centralisez la préparation des bons de livraison dans l’Atelier BL en limitant le lancement des commandes à la réservation du stock.

New Features:
- Étend le panier de préparation Atelier BL avec des filtres serveur par client, recherche, commande, affaire et source OLD/NEW.

Bug Fixes:
- Empêche le lancement d’une commande client de créer ou préparer automatiquement un bon de livraison.

Enhancements:
- Centralise la constitution interactive des bons de livraison dans l’Atelier BL via un point d’entrée autoritaire et idempotent.
- Expose l’état réservé des commandes pour une préparation ultérieure par l’Atelier BL.

Documentation:
- Documente les nouveaux filtres du panier de préparation, le point d’entrée de constitution des BL et la séparation avec le parcours de commande client.

Tests:
- Ajoute des contrats de non-régression vérifiant la réservation sans création de BL et la validation des filtres de l’Atelier BL.