### PR TITLE
release: réservation, affaires de livraison et AR client

### DIFF
--- a/src/__tests__/commande-ar.service.test.ts
+++ b/src/__tests__/commande-ar.service.test.ts
@@ -11,7 +11,6 @@ import { sendCommandeArSchema } from "../module/commande-client/validators/comma
 describe("commande AR email content", () => {
   it("uses the required French subject and keeps the custom message before the signature in text and HTML", () => {
     const email = buildCommandeArEmailContent({
-      numero: "CMD-2026-42",
       customer_reference: "PO-CLIENT-9",
       reference: "AR-00000001-v2",
       contact: {
@@ -24,9 +23,11 @@ describe("commande AR email content", () => {
       custom_message: "Merci de vérifier <ce délai> & de nous répondre.",
     });
 
-    expect(email.subject).toBe("Accusé de réception de votre commande CMD-2026-42 — AR-00000001-v2");
+    expect(email.subject).toBe("Accusé de réception de votre commande PO-CLIENT-9 — AR-00000001-v2");
     expect(email.text).toContain("Bonjour Mme Élodie Dœ,");
-    expect(email.text).toContain("commande PO-CLIENT-9, enregistrée dans CERP sous le numéro CMD-2026-42.");
+    expect(email.text).toContain("commande PO-CLIENT-9.");
+    expect(email.text).not.toContain("CMD-2026-42");
+    expect(email.text).not.toContain("enregistrée dans CERP");
     expect(email.text.indexOf("Merci de vérifier")).toBeLessThan(email.text.indexOf("Cordialement,"));
     expect(email.html).toContain("Merci de vérifier &lt;ce délai&gt; &amp; de nous répondre.");
     expect(email.html.indexOf("Merci de vérifier")).toBeLessThan(email.html.indexOf("Cordialement,"));
@@ -34,13 +35,13 @@ describe("commande AR email content", () => {
 
   it("uses Madame, Monsieur when the send does not select exactly one contact", () => {
     const email = buildCommandeArEmailContent({
-      numero: "CMD-1",
       customer_reference: null,
       reference: "AR-00000001-v1",
       contact: null,
     });
     expect(email.text).toContain("Bonjour Madame, Monsieur,");
-    expect(email.text).toContain("commande CMD-1, enregistrée dans CERP sous le numéro CMD-1.");
+    expect(email.text).toContain("prise en compte de votre commande.");
+    expect(email.text).not.toContain("CMD-");
   });
 
   it("escapes arbitrary HTML while preserving French accents", () => {
@@ -55,7 +56,7 @@ describe("commande AR PDF", () => {
     const pdf = await buildCommandeArPdfBuffer({
       reference: "AR-00000001-v2",
       issuer: { company_name: "CROIX ROUSSE PRÉCISION", legal_form: "SARL", siret: "38056901200020" },
-      draftNumber: "CMD-2026-42",
+      orderNumber: "PO-CLIENT-9",
       companyName: "Client Démonstration",
       dateCommande: "2026-08-26",
       statut: "AR_PRET",

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -4501,6 +4501,9 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
     }
 
     const stockAnalysis = analysis;
+    const deliveryAffairPlan = resolveDeliveryAffairPlan(stockAnalysis.lines, requestedLivraisonCount);
+    const effectiveLivraisonCount =
+      orderType === "INTERNE" ? 0 : deliveryAffairPlan.affaire_count;
 
     const hasPartial = stockAnalysis.lines.some((l) => l.status === "PARTIAL");
     const needsConfirmation = orderType !== "INTERNE" && hasPartial;
@@ -4605,13 +4608,15 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         commande_id: commandeId,
         affaire_id: createdId,
         role: "LIVRAISON",
-        commentaire: "Generated from commande",
+        commentaire: deliveryAffairPlan.automatic_stock_production_split
+          ? "Livraison partielle — quantité réservée en stock"
+          : "Generated from commande",
       });
       await queueAffaireCreationPdf(client, { affaireId: createdId, actorUserId: audit.user_id });
       livraisonAffaireIds.push(createdId);
     }
 
-    for (let i = livraisonAffaireIds.length; orderType !== "INTERNE" && i < requestedLivraisonCount; i += 1) {
+    for (let i = livraisonAffaireIds.length; orderType !== "INTERNE" && i < effectiveLivraisonCount; i += 1) {
       const extraId = await createAffaire(client, {
         commande_id: commandeId,
         devis_id: commande.devis_id ? toNullableInt(commande.devis_id, "commande.devis_id") : null,
@@ -4621,15 +4626,24 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         commande_id: commandeId,
         affaire_id: extraId,
         role: "LIVRAISON",
-        commentaire: `Split delivery (${i + 1}/${requestedLivraisonCount})`,
+        commentaire:
+          deliveryAffairPlan.automatic_stock_production_split && i === 1
+            ? "Livraison partielle — reliquat à fabriquer"
+            : `Split delivery (${i + 1}/${effectiveLivraisonCount})`,
       });
       await queueAffaireCreationPdf(client, { affaireId: extraId, actorUserId: audit.user_id });
       livraisonAffaireIds.push(extraId);
     }
 
     const livraisonAffaireId = livraisonAffaireIds[0] ?? null;
+    const productionLivraisonAffaireId = deliveryAffairPlan.automatic_stock_production_split
+      ? livraisonAffaireIds[1] ?? null
+      : livraisonAffaireId;
     if (orderType !== "INTERNE" && !livraisonAffaireId) {
       throw new HttpError(500, "LIVRAISON_AFFAIRE_REQUIRED", "Aucune affaire de livraison n'a pu être préparée.");
+    }
+    if (orderType !== "INTERNE" && needsProduction && !productionLivraisonAffaireId) {
+      throw new HttpError(500, "PRODUCTION_LIVRAISON_AFFAIRE_REQUIRED", "Aucune affaire de livraison n'a pu porter le reliquat à fabriquer.");
     }
 
     const planLines: CommandeAllocationPlanLine[] = analysis.lines.map((l) => ({
@@ -4651,14 +4665,57 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           : "AUTO_STOCK";
 
     if (orderType !== "INTERNE" && livraisonAffaireId !== null) {
-      await upsertCommandeAllocations(client, {
-        commande_id: commandeId,
-        livraison_affaire_id: livraisonAffaireId,
-        allocation_mode: allocationMode,
-        reserve_stock: false,
-        reserved_qty_by_line: stockCoveredByLine,
-        lines: planLines,
-      });
+      if (deliveryAffairPlan.automatic_stock_production_split && productionLivraisonAffaireId !== null) {
+        const stockLines = planLines
+          .map((line) => {
+            const quantity = Number(stockCoveredByLine.get(line.commande_ligne_id) ?? 0);
+            return {
+              ...line,
+              qty_ordered: quantity,
+              qty_from_stock: quantity,
+              qty_to_produce: 0,
+            };
+          })
+          .filter((line) => line.qty_ordered > 1e-9);
+        const productionLines = planLines
+          .map((line) => {
+            const quantityToProduce = Number(productionByLine.get(line.commande_ligne_id) ?? 0);
+            const quantityFromStock = Number(stockCoveredByLine.get(line.commande_ligne_id) ?? 0);
+            return {
+              ...line,
+              qty_ordered: Math.max(0, line.qty_ordered - quantityFromStock),
+              qty_from_stock: 0,
+              qty_to_produce: quantityToProduce,
+            };
+          })
+          .filter((line) => line.qty_ordered > 1e-9 || line.qty_to_produce > 1e-9);
+
+        await upsertCommandeAllocations(client, {
+          commande_id: commandeId,
+          livraison_affaire_id: livraisonAffaireId,
+          allocation_mode: "PARTIAL_STOCK",
+          reserve_stock: false,
+          reserved_qty_by_line: stockCoveredByLine,
+          lines: stockLines,
+        });
+        await upsertCommandeAllocations(client, {
+          commande_id: commandeId,
+          livraison_affaire_id: productionLivraisonAffaireId,
+          allocation_mode: "PARTIAL_PRODUCTION",
+          reserve_stock: false,
+          reserved_qty_by_line: null,
+          lines: productionLines,
+        });
+      } else {
+        await upsertCommandeAllocations(client, {
+          commande_id: commandeId,
+          livraison_affaire_id: livraisonAffaireId,
+          allocation_mode: allocationMode,
+          reserve_stock: false,
+          reserved_qty_by_line: stockCoveredByLine,
+          lines: planLines,
+        });
+      }
     }
 
     const holdsStockForGroupedDelivery =
@@ -4712,7 +4769,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           commande_id: commandeId,
           commande_numero: commande.numero,
           commande_ligne_id: l.commande_ligne_id,
-          livraison_affaire_id: livraisonAffaireId,
+          livraison_affaire_id: productionLivraisonAffaireId,
           client_id: orderType === "INTERNE" ? ref?.piece_client_id ?? clientId : clientId,
           root_article_id: l.article_id,
           root_piece_technique_id: pieceTechniqueId,
@@ -4770,6 +4827,9 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         order_type: orderType,
         decision,
         livraison_affaire_ids: livraisonAffaireIds,
+        stock_livraison_affaire_id: livraisonAffaireId,
+        production_livraison_affaire_id: productionLivraisonAffaireId,
+        automatic_stock_production_split: deliveryAffairPlan.automatic_stock_production_split,
         bon_livraison_id: bonLivraisonId,
         reservations_created: reservationsCreated.length,
         of_created: ofIds.length,
@@ -4788,6 +4848,8 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         decision,
         livraison_affaire_id: livraisonAffaireId,
         livraison_affaire_ids: livraisonAffaireIds,
+        production_livraison_affaire_id: productionLivraisonAffaireId,
+        automatic_stock_production_split: deliveryAffairPlan.automatic_stock_production_split,
         bon_livraison_id: bonLivraisonId,
         reservations_created: reservationsCreated,
         of_ids: ofIds,
@@ -4814,6 +4876,8 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
     return {
       affaire_ids: livraisonAffaireIds,
       livraison_affaire_id: livraisonAffaireId,
+      production_livraison_affaire_id: productionLivraisonAffaireId,
+      automatic_stock_production_split: deliveryAffairPlan.automatic_stock_production_split,
       requires_confirmation: false,
       livraison_affaire_ids: livraisonAffaireIds,
       bon_livraison_id: bonLivraisonId,
@@ -5205,6 +5269,31 @@ type CommandeStockAnalysis = {
   lines: CommandeStockAnalysisLine[];
 };
 
+export type DeliveryAffairPlan = {
+  automatic_stock_production_split: boolean;
+  affaire_count: number;
+};
+
+/**
+ * A customer order that can ship a real stock quantity while another quantity
+ * still has to be manufactured has two distinct delivery commitments.  The
+ * first affair owns the reserved stock and the second owns the manufacturing
+ * remainder; manual cadence counts must not merge those two responsibilities.
+ */
+export function resolveDeliveryAffairPlan(
+  lines: readonly Pick<CommandeStockAnalysisLine, "available_used_qty" | "shortage_qty">[],
+  requestedCount: number
+): DeliveryAffairPlan {
+  const boundedRequestedCount = Math.max(1, Math.min(10, Math.trunc(requestedCount) || 1));
+  const hasStock = lines.some((line) => Number(line.available_used_qty) > 1e-9);
+  const hasProduction = lines.some((line) => Number(line.shortage_qty) > 1e-9);
+  const automaticSplit = hasStock && hasProduction;
+  return {
+    automatic_stock_production_split: automaticSplit,
+    affaire_count: automaticSplit ? 2 : boundedRequestedCount,
+  };
+}
+
 function buildZeroStockAnalysisLines(refs: CommandeLineRef[]): CommandeStockAnalysisLine[] {
   return refs.map((ref) => {
     const requestedQty = Math.max(0, Number(ref.qty_ordered));
@@ -5531,7 +5620,7 @@ export async function reserveCommandeStockForLaterDelivery(
           commande_ligne_affaire_allocation_id, livraison_affaire_id,
           stock_level_id, source_scope, reason, created_by, updated_by
         ) VALUES (
-          $1::uuid,$2::uuid,$3,'COMMANDE_LIGNE',$4,$4::bigint,$5::bigint,
+          $1::uuid,$2::uuid,$3,'COMMANDE_LIGNE',$4::bigint::text,$4::bigint,$5::bigint,
           'ACTIVE',$6::uuid,$7::uuid,$8::bigint,$5::bigint,$9::uuid,$10,$11,$12,$12
         )
         ON CONFLICT (commande_ligne_affaire_allocation_id, stock_batch_id)
@@ -5551,7 +5640,7 @@ export async function reserveCommandeStockForLaterDelivery(
         allocation.article_id,
         allocation.location_id,
         allocation.quantity,
-        String(allocation.commande_ligne_id),
+        allocation.commande_ligne_id,
         params.livraison_affaire_id,
         allocation.lot_id,
         allocation.stock_batch_id,

--- a/src/module/commande-client/repository/commande-stock-reservation.repository.test.ts
+++ b/src/module/commande-client/repository/commande-stock-reservation.repository.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   reserveCommandeStockForLaterDelivery,
+  resolveDeliveryAffairPlan,
   reuseRecoveredCommandeStockReservations,
   type CommandeStockAnalysisLine,
 } from "./commande-client.repository";
@@ -34,6 +35,28 @@ const line: CommandeStockAnalysisLine = {
   proposed_production_qty: 6,
   status: "PARTIAL",
 };
+
+describe("resolveDeliveryAffairPlan", () => {
+  it("creates one stock affair and one production affair for a partial delivery", () => {
+    expect(resolveDeliveryAffairPlan([line], 1)).toEqual({
+      automatic_stock_production_split: true,
+      affaire_count: 2,
+    });
+    expect(resolveDeliveryAffairPlan([line], 4)).toEqual({
+      automatic_stock_production_split: true,
+      affaire_count: 2,
+    });
+  });
+
+  it("keeps the requested cadence count when the order is fully covered or fully missing", () => {
+    expect(
+      resolveDeliveryAffairPlan([{ ...line, available_used_qty: 10, shortage_qty: 0 }], 3)
+    ).toMatchObject({ automatic_stock_production_split: false, affaire_count: 3 });
+    expect(
+      resolveDeliveryAffairPlan([{ ...line, available_used_qty: 0, shortage_qty: 10 }], 2)
+    ).toMatchObject({ automatic_stock_production_split: false, affaire_count: 2 });
+  });
+});
 
 describe("reserveCommandeStockForLaterDelivery", () => {
   it("reserves exactly the four OLD/NEW units for SHIP_ALL_TOGETHER without creating a BL", async () => {
@@ -86,7 +109,9 @@ describe("reserveCommandeStockForLaterDelivery", () => {
     const levelUpdate = query.mock.calls.find(([sql]) => String(sql).includes("UPDATE public.stock_levels"));
     const reservationInsert = query.mock.calls.find(([sql]) => String(sql).includes("INSERT INTO public.stock_reservations"));
     expect(levelUpdate?.[1]).toEqual([ids.level, 4, 9]);
-    expect(reservationInsert?.[1]).toEqual(expect.arrayContaining([ids.article, ids.location, 4, "1", 7, ids.lot]));
+    expect(reservationInsert?.[1]).toEqual(expect.arrayContaining([ids.article, ids.location, 4, 1, 7, ids.lot]));
+    expect(String(reservationInsert?.[0])).toContain("$4::bigint::text,$4::bigint");
+    expect(String(reservationInsert?.[0])).not.toContain("'COMMANDE_LIGNE',$4,$4::bigint");
     expect(query.mock.calls.some(([sql]) => String(sql).includes("FROM public.quality_control qc"))).toBe(false);
     expect(query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO bon_livraison"))).toBe(false);
   });

--- a/src/module/commande-client/services/commande-ar.service.test.ts
+++ b/src/module/commande-client/services/commande-ar.service.test.ts
@@ -256,7 +256,8 @@ describe("envoi AR claimé avant effet externe", () => {
 describe("accusé de réception — mentions légales", () => {
   it("uses the CERP document footer and repeats legal mentions on every page", async () => {
     const bytes = await buildCommandeArPdfBuffer({
-      draftNumber: "CC-2026-0042",
+      reference: "AR-00000042-v1",
+      orderNumber: "ESSAI 1 GA",
       companyName: "ABB FRANCE",
       dateCommande: "2026-07-20",
       generatedAt: new Date("2026-07-29T10:00:00.000Z"),
@@ -296,6 +297,7 @@ describe("accusé de réception — mentions légales", () => {
 
     const pages = drawnPages(bytes);
     expect(pages.length).toBeGreaterThan(1);
+    expect(pages.join("\n")).toContain("ESSAI 1 GA");
     for (const page of pages) {
       expect(page).toContain("SIRET 380 569 012 00020");
       expect(page).toContain("Pénalités de retard : 12,5 % l'an");

--- a/src/module/commande-client/services/commande-ar.service.ts
+++ b/src/module/commande-client/services/commande-ar.service.ts
@@ -113,7 +113,6 @@ type CommandeArEmailContact = {
 };
 
 export function buildCommandeArEmailContent(params: {
-  numero: string;
   customer_reference: string | null;
   reference: string;
   contact: CommandeArEmailContact | null;
@@ -123,11 +122,14 @@ export function buildCommandeArEmailContent(params: {
     ? [params.contact.civility, params.contact.first_name, params.contact.last_name].filter((part) => part?.trim()).join(" ").trim()
     : "";
   const greeting = contactName || "Madame, Monsieur";
-  const customerReference = params.customer_reference?.trim() || params.numero;
+  const customerReference = params.customer_reference?.trim() || null;
+  const orderAcknowledgement = customerReference
+    ? `Nous vous confirmons la prise en compte de votre commande ${customerReference}.`
+    : "Nous vous confirmons la prise en compte de votre commande.";
   const lines = [
     `Bonjour ${greeting},`,
     "",
-    `Nous vous confirmons la prise en compte de votre commande ${customerReference}, enregistrée dans CERP sous le numéro ${params.numero}.`,
+    orderAcknowledgement,
     "",
     `Veuillez trouver en pièce jointe notre accusé de réception ${params.reference}.`,
   ];
@@ -135,7 +137,9 @@ export function buildCommandeArEmailContent(params: {
   lines.push("", "Cordialement,", "Croix Rousse Précision");
   const text = lines.join("\n");
   return {
-    subject: `Accusé de réception de votre commande ${params.numero} — ${params.reference}`,
+    subject: customerReference
+      ? `Accusé de réception de votre commande ${customerReference} — ${params.reference}`
+      : `Accusé de réception de votre commande — ${params.reference}`,
     text,
     html: renderCommandeArEmailHtml(text),
   };
@@ -152,39 +156,6 @@ function addressLines(address: CommandeArAddress): string[] {
     .filter((value) => value.length > 0);
 
   return lines.length ? lines : ["-"];
-}
-
-function subjectForCommande(numero: string): string {
-  return `Accusé de réception ${numero}`;
-}
-
-function bodyTextForCommande(params: { numero: string; companyName: string | null }): string {
-  const company = params.companyName?.trim() || "Madame, Monsieur";
-  return [
-    `Bonjour ${company},`,
-    "",
-    `Nous vous confirmons la bonne réception de votre commande ${params.numero}.`,
-    "Vous trouverez en pièce jointe l’accusé de réception préparé par notre ERP.",
-    "",
-    "Cordialement,",
-    "Croix-Rousse Précision",
-  ].join("\n");
-}
-
-function buildEmailHtml(text: string, customMessage?: string | null): string {
-  const paragraphs = text.split(/\n{2,}/).map((block) => `<p style=\"margin:0 0 12px 0;line-height:1.5;\">${escapeHtml(block).replace(/\n/g, "<br />")}</p>`);
-  const extra = customMessage?.trim()
-    ? `<div style=\"margin-top:16px;padding:12px;border:1px solid #e2e8f0;border-radius:10px;background:#f8fafc;\">${escapeHtml(customMessage.trim()).replace(/\n/g, "<br />")}</div>`
-    : "";
-  return `
-    <div style="background:#f6f7fb;padding:24px 12px;font-family:Arial,Helvetica,sans-serif;color:#0f172a;">
-      <div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e2e8f0;border-radius:14px;padding:24px;">
-        <div style="font-size:18px;font-weight:800;margin-bottom:14px;">Accuse de reception</div>
-        ${paragraphs.join("")}
-        ${extra}
-      </div>
-    </div>
-  `.trim();
 }
 
 function isResendSendError(result: Extract<ResendSendResult, { ok: false }>): result is { ok: false; error: string } {
@@ -208,10 +179,10 @@ async function waitForCommandeArOfficialArchiveId(
 }
 
 export async function buildCommandeArPdfBuffer(params: {
-  reference?: string;
-  draftNumber: string;
-  /** Customer order reference; distinct from the acknowledgement number when configured. */
-  orderNumber?: string;
+  /** Versioned acknowledgement reference, for example AR-00000042-v1. */
+  reference: string;
+  /** Customer order reference; distinct from the acknowledgement number. */
+  orderNumber: string;
   companyName: string | null;
   dateCommande: string;
   generatedAt?: Date;
@@ -244,8 +215,10 @@ export async function buildCommandeArPdfBuffer(params: {
   issuer?: LegalParty;
 }): Promise<Buffer> {
   const clientName = params.companyName?.trim() || "Client";
-  const orderNumber = params.orderNumber?.trim() || params.draftNumber;
-  const reference = params.reference?.trim() || params.draftNumber;
+  const orderNumber = params.orderNumber.trim();
+  if (!orderNumber) throw new Error("COMMANDE_CUSTOMER_REFERENCE_REQUIRED");
+  const reference = params.reference.trim();
+  if (!reference) throw new Error("COMMANDE_AR_REFERENCE_REQUIRED");
   const generatedAt = params.generatedAt ?? new Date();
   const issuer = params.issuer ?? await readIssuerParty({ at: generatedAt.toISOString().slice(0, 10) });
   const draft = params.statut?.trim().toUpperCase() === "BROUILLON";
@@ -267,7 +240,7 @@ export async function buildCommandeArPdfBuffer(params: {
       documentType: "Accusé de réception",
       name: clientName,
       code: reference,
-      subtitle: `Version ${params.documentVersion ?? 1} · Commande ${orderNumber}`,
+      subtitle: `Version ${params.documentVersion ?? 1} · Référence commande client ${orderNumber}`,
       status: params.statut ?? "PLANIFIEE",
       flag: draft ? "INTERNE / BROUILLON" : null,
       watermark: draft ? "INTERNE / BROUILLON" : null,
@@ -282,7 +255,7 @@ export async function buildCommandeArPdfBuffer(params: {
     },
     (ctx) => {
       ctx.legalStrip([
-        { label: "Commande", value: orderNumber },
+        { label: "Référence commande client", value: orderNumber },
         { label: "Date commande", value: formatDateFR(params.dateCommande) },
         { label: "Statut", value: params.statut ?? "PLANIFIEE" },
         { label: "Total TTC", value: formatCurrencyEUR(params.totalTtc) },
@@ -342,13 +315,13 @@ export async function buildCommandeArPdfBuffer(params: {
 /** Renderer registered in the authoritative worker. It consumes the frozen source only. */
 export async function renderCommandeArOfficialPdf({ archive }: { archive: AuthoritativePdfArchiveRecord }): Promise<Buffer> {
   const source = archive.sourceSnapshot as Partial<CommandeArOfficialSnapshot>;
-  if (source.type !== "CUSTOMER_ORDER_ACKNOWLEDGEMENT" || !source.acknowledgement_number || !Array.isArray(source.lines) || !source.issuer) {
+  if (source.type !== "CUSTOMER_ORDER_ACKNOWLEDGEMENT" || !source.acknowledgement_number || !source.order_number || !Array.isArray(source.lines) || !source.issuer) {
     throw new Error("COMMANDE_AR_OFFICIAL_SNAPSHOT_INVALID");
   }
   const archivedAt = new Date(archive.createdAt);
   if (Number.isNaN(archivedAt.getTime())) throw new Error("COMMANDE_AR_ARCHIVE_CREATED_AT_INVALID");
   return buildCommandeArPdfBuffer({
-    issuer: source.issuer, draftNumber: source.acknowledgement_number, orderNumber: source.order_number,
+    issuer: source.issuer, reference: source.acknowledgement_number, orderNumber: source.order_number,
     companyName: source.customer_name ?? null,
     // `generated_at` remains inside the frozen business snapshot; the document
     // artifact's header/footer/PDF metadata are the immutable archive time.
@@ -380,6 +353,14 @@ export async function svcGenerateCommandeAr(params: {
     if (!data) {
       throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable");
     }
+    const customerReference = data.header.customer_reference?.trim() || null;
+    if (!customerReference) {
+      throw new HttpError(
+        409,
+        "COMMANDE_CUSTOMER_REFERENCE_REQUIRED",
+        "Renseignez la référence commande client avant de générer l’accusé de réception."
+      );
+    }
     const recipientSuggestions = buildCommandeArRecipientSuggestions(data);
 
     const generatedAt = new Date();
@@ -388,7 +369,7 @@ export async function svcGenerateCommandeAr(params: {
     const issuer = await readIssuerParty({ at: generatedAt.toISOString().slice(0, 10) });
 
     const officialSnapshot: CommandeArOfficialSnapshot = {
-      type: "CUSTOMER_ORDER_ACKNOWLEDGEMENT", acknowledgement_number: data.header.numero, order_number: data.header.numero,
+      type: "CUSTOMER_ORDER_ACKNOWLEDGEMENT", acknowledgement_number: data.header.numero, order_number: customerReference,
       generated_at: generatedAt.toISOString(), status: data.header.statut, customer_name: data.header.client_company_name,
       date_commande: data.header.date_commande, total_ht: String(data.header.total_ht), total_ttc: String(data.header.total_ttc),
       public_comment: data.header.commentaire, bill_address: { name: data.header.bill_name, street: data.header.bill_street, house_number: data.header.bill_house_number, postal_code: data.header.bill_postal_code, city: data.header.bill_city, country: data.header.bill_country },
@@ -404,13 +385,12 @@ export async function svcGenerateCommandeAr(params: {
       commande_id: params.commande_id,
       user_id: params.user_id,
       user_role: params.user_role,
-      document_name: `AR-${data.header.numero}.pdf`,
+      document_name: "AR.pdf",
       pdf_buffer: Buffer.alloc(0),
       pdf_factory: ({ reference, version_number }) => buildCommandeArPdfBuffer({
         reference,
         issuer,
-        draftNumber: data.header.numero,
-        orderNumber: data.header.customer_reference ?? data.header.numero,
+        orderNumber: customerReference,
         companyName: data.header.client_company_name,
         dateCommande: data.header.date_commande,
         generatedAt,
@@ -428,14 +408,12 @@ export async function svcGenerateCommandeAr(params: {
       subject: "",
       body_text: "",
       subject_factory: ({ reference }) => buildCommandeArEmailContent({
-        numero: data.header.numero,
-        customer_reference: data.header.customer_reference,
+        customer_reference: customerReference,
         reference,
         contact: defaultContact,
       }).subject,
       body_text_factory: ({ reference }) => buildCommandeArEmailContent({
-        numero: data.header.numero,
-        customer_reference: data.header.customer_reference,
+        customer_reference: customerReference,
         reference,
         contact: defaultContact,
       }).text,
@@ -522,18 +500,20 @@ export async function svcSendCommandeAr(params: {
       throw new HttpError(409, "COMMANDE_AR_PDF_INTEGRITY_ERROR", "Le PDF officiel archivé ne correspond pas à la version préparée.");
     }
 
-    const snapshot = draft.content_snapshot as { header?: { numero?: unknown; customer_reference?: unknown } } | null;
-    const numero = typeof snapshot?.header?.numero === "string" ? snapshot.header.numero.trim() : "";
-    if (!numero) {
-      throw new HttpError(409, "COMMANDE_AR_SNAPSHOT_INVALID", "Le contenu figé de cet accusé de réception est incomplet.");
-    }
+    const snapshot = draft.content_snapshot as { header?: { customer_reference?: unknown } } | null;
     const customerReference = typeof snapshot?.header?.customer_reference === "string"
-      ? snapshot.header.customer_reference
+      ? snapshot.header.customer_reference.trim()
       : null;
+    if (!customerReference) {
+      throw new HttpError(
+        409,
+        "COMMANDE_CUSTOMER_REFERENCE_REQUIRED",
+        "Renseignez la référence commande client puis générez une nouvelle version de l’accusé de réception."
+      );
+    }
     const selectedContact = claim.contacts.length === 1 ? claim.contacts[0] : null;
     const emailBodyOverride = params.body.email_body?.trim() || null;
     const generatedContent = buildCommandeArEmailContent({
-      numero,
       customer_reference: customerReference,
       reference: draft.reference,
       contact: selectedContact,


### PR DESCRIPTION
Promotion de dev après validation CERP_TEST : correction SQL 42P08, découpage automatique des affaires stock/fabrication et documents AR basés sur la référence commande client. Tests backend ciblés et build validés.

## Summary by Sourcery

Fiabiliser la génération des affaires de livraison et des accusés de réception en distinguant les engagements stock et fabrication et en utilisant la référence de commande client.

New Features:
- Sépare automatiquement les affaires de livraison entre les quantités disponibles en stock et le reliquat à fabriquer.
- Génère les accusés de réception à partir de la référence de commande client, avec validation obligatoire et affichage cohérent dans les emails et PDF.

Bug Fixes:
- Corrige la requête de réservation de stock afin d’éviter l’erreur PostgreSQL 42P08 liée à l’inférence de type.

Enhancements:
- Expose les identifiants des affaires stock et production ainsi que l’état du découpage automatique dans les résultats et journaux de génération.

Tests:
- Ajoute des tests couvrant le découpage stock/production et la correction du typage des réservations.
- Met à jour les tests des emails et PDF d’accusé de réception selon l’usage de la référence client.