### PR TITLE
fix(livraisons): autoriser les BL multi-commandes

### DIFF
--- a/src/__tests__/stock-delivery-repositories.pg.integration.test.ts
+++ b/src/__tests__/stock-delivery-repositories.pg.integration.test.ts
@@ -32,6 +32,10 @@ const ids = {
   lot: "10000000-0000-4000-8000-000000000009",
   stockBatch: "10000000-0000-4000-8000-000000000010",
   reservation: "10000000-0000-4000-8000-000000000011",
+  deliveryAddress: "10000000-0000-4000-8000-000000000012",
+  otherClient: "10000000-0000-4000-8000-000000000013",
+  otherDeliveryAddress: "10000000-0000-4000-8000-000000000014",
+  secondReservation: "10000000-0000-4000-8000-000000000015",
 } as const;
 
 let harnessPool: Pool | null = null;
@@ -248,9 +252,16 @@ async function installMinimalSchema(db: Pool) {
     AFTER INSERT OR UPDATE OF status ON public.stock_movements
     FOR EACH ROW EXECUTE FUNCTION public.fn_apply_stock_movement();
 
+    CREATE TABLE public.clients (
+      client_id UUID PRIMARY KEY,
+      company_name TEXT NOT NULL,
+      delivery_address_id UUID NULL
+    );
     CREATE TABLE public.commande_client (
       id BIGINT PRIMARY KEY,
-      client_id UUID NOT NULL
+      numero TEXT NOT NULL,
+      client_id UUID NOT NULL,
+      destinataire_id UUID NULL
     );
     CREATE TABLE public.commande_ligne (
       id BIGINT PRIMARY KEY,
@@ -379,6 +390,7 @@ async function installMinimalSchema(db: Pool) {
       client_id UUID NOT NULL,
       commande_id BIGINT NULL,
       affaire_id BIGINT NULL,
+      adresse_livraison_id UUID NULL,
       statut TEXT NOT NULL,
       date_creation DATE NOT NULL DEFAULT CURRENT_DATE,
       date_expedition DATE NULL,
@@ -495,12 +507,32 @@ async function installMinimalSchema(db: Pool) {
       details JSONB NULL,
       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     );
+    CREATE TABLE public.realtime_stream_enqueue_state (
+      stream_id TEXT PRIMARY KEY,
+      next_ordinal BIGINT NOT NULL,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE TABLE public.erp_outbox_events (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      event_key TEXT NOT NULL UNIQUE,
+      aggregate_type TEXT NOT NULL,
+      aggregate_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      payload JSONB NOT NULL,
+      correlation_id UUID NOT NULL,
+      status TEXT NOT NULL,
+      available_at TIMESTAMPTZ NOT NULL,
+      realtime_stream_id TEXT NULL,
+      realtime_stream_ordinal BIGINT NULL
+    );
   `);
 }
 
 async function clearScenario(db: Pool) {
   await db.query(`
     TRUNCATE TABLE
+      public.erp_outbox_events,
+      public.realtime_stream_enqueue_state,
       public.erp_audit_logs,
       public.delivery_outbox,
       public.bon_livraison_ship_receipts,
@@ -519,6 +551,7 @@ async function clearScenario(db: Pool) {
       public.commande_ligne_affaire_allocation,
       public.commande_ligne,
       public.commande_client,
+      public.clients,
       public.stock_movement_event_log,
       public.stock_movement_lines,
       public.stock_movements,
@@ -586,7 +619,16 @@ async function seedDeliveryScenario(db: Pool) {
      VALUES ($1::uuid, $2::uuid, 'PIECE_TECHNIQUE', true, 'u')`,
     [ids.article, ids.pieceTechnique]
   );
-  await db.query(`INSERT INTO public.commande_client (id, client_id) VALUES (42, $1::uuid)`, [ids.client]);
+  await db.query(
+    `INSERT INTO public.clients (client_id, company_name, delivery_address_id)
+     VALUES ($1::uuid, 'Client intégration', $2::uuid), ($3::uuid, 'Autre client', $4::uuid)`,
+    [ids.client, ids.deliveryAddress, ids.otherClient, ids.otherDeliveryAddress]
+  );
+  await db.query(
+    `INSERT INTO public.commande_client (id, numero, client_id, destinataire_id)
+     VALUES (42, 'CMD-INT-0042', $1::uuid, $2::uuid)`,
+    [ids.client, ids.deliveryAddress]
+  );
   await db.query(
     `INSERT INTO public.commande_ligne (id, designation, code_piece, unite, delai_client)
      VALUES (43, 'Pièce intégration', 'PT-INT', 'u', '2026-09-01')`
@@ -630,6 +672,47 @@ async function seedDeliveryScenario(db: Pool) {
        reservation_id, verified_qty, scanned_lot_code, snapshot, verified_by
      ) VALUES ($1::uuid, 5, 'LOT-INT-001', $2::jsonb, 7)`,
     [ids.reservation, JSON.stringify({ verified_qty: 5, lot_code: "LOT-INT-001", source_scope: "NEW" })]
+  );
+}
+
+async function seedAdditionalDeliveryReservation(
+  db: Pool,
+  params: { clientId?: string; deliveryAddressId?: string | null } = {}
+) {
+  const clientId = params.clientId ?? ids.client;
+  const deliveryAddressId = params.deliveryAddressId === undefined ? ids.deliveryAddress : params.deliveryAddressId;
+  await db.query(
+    `INSERT INTO public.commande_client (id, numero, client_id, destinataire_id)
+     VALUES (44, 'CMD-INT-0044', $1::uuid, $2::uuid)`,
+    [clientId, deliveryAddressId]
+  );
+  await db.query(
+    `INSERT INTO public.commande_ligne (id, designation, code_piece, unite, delai_client)
+     VALUES (45, 'Seconde pièce intégration', 'PT-INT-2', 'u', '2026-09-02')`
+  );
+  await db.query(
+    `INSERT INTO public.commande_ligne_affaire_allocation (
+       id, commande_id, commande_ligne_id, livraison_affaire_id, article_ref_id,
+       qty_ordered, qty_reserved, qty_delivered, qty_remaining, delivery_status
+     ) VALUES (901, 44, 45, 701, $1::uuid, 4, 4, 0, 4, 'A_PREPARER')`,
+    [ids.article]
+  );
+  await db.query(
+    `INSERT INTO public.stock_reservations (
+       id, article_id, location_id, qty_reserved, source_type, source_id, status,
+       commande_ligne_affaire_allocation_id, livraison_affaire_id, lot_id,
+       stock_level_id, stock_batch_id, source_scope, created_by, updated_by
+     ) VALUES (
+       $1::uuid, $2::uuid, $3::uuid, 4, 'COMMANDE_LIGNE', '45', 'ACTIVE',
+       901, 701, $4::uuid, $5::uuid, $6::uuid, 'NEW', 7, 7
+     )`,
+    [ids.secondReservation, ids.article, ids.location, ids.lot, ids.stockLevel, ids.stockBatch]
+  );
+  await db.query(
+    `INSERT INTO public.stock_reservation_verifications (
+       reservation_id, verified_qty, scanned_lot_code, snapshot, verified_by
+     ) VALUES ($1::uuid, 4, 'LOT-INT-001', $2::jsonb, 7)`,
+    [ids.secondReservation, JSON.stringify({ verified_qty: 4, lot_code: "LOT-INT-001", source_scope: "NEW" })]
   );
 }
 
@@ -906,6 +989,89 @@ describePg("stock/delivery repositories — isolated PostgreSQL invariants", () 
       status: 409,
       code: "OF_SCAN_MISMATCH",
     });
+  });
+
+  it("creates one BL from several lines and commands of the same client and destination", async () => {
+    if (!harnessPool) throw new Error("Integration pool was not initialized");
+    await seedDeliveryScenario(harnessPool);
+    await seedAdditionalDeliveryReservation(harnessPool);
+
+    const result = await deliveryRepository.repoCreateLivraisonFromReservations({
+      body: {
+        items: [
+          { reservation_id: ids.reservation, qty: 3 },
+          { reservation_id: ids.secondReservation, qty: 2 },
+        ],
+      },
+      user_id: 7,
+      idempotency_key: "delivery-prepare-multi-command-001",
+    });
+
+    const header = await harnessPool.query<{
+      client_id: string;
+      commande_id: number | null;
+      affaire_id: number | null;
+      adresse_livraison_id: string | null;
+    }>(
+      `SELECT client_id::text, commande_id::bigint::int, affaire_id::bigint::int,
+              adresse_livraison_id::text
+       FROM public.bon_livraison
+       WHERE id = $1::uuid`,
+      [result.id]
+    );
+    const lines = await harnessPool.query<{ commande_ligne_id: number }>(
+      `SELECT commande_ligne_id::bigint::int
+       FROM public.bon_livraison_ligne
+       WHERE bon_livraison_id = $1::uuid
+       ORDER BY commande_ligne_id`,
+      [result.id]
+    );
+
+    expect(header.rows).toEqual([
+      {
+        client_id: ids.client,
+        commande_id: null,
+        affaire_id: null,
+        adresse_livraison_id: ids.deliveryAddress,
+      },
+    ]);
+    expect(lines.rows).toEqual([{ commande_ligne_id: 43 }, { commande_ligne_id: 45 }]);
+  });
+
+  it("rejects carts that mix clients or delivery destinations", async () => {
+    if (!harnessPool) throw new Error("Integration pool was not initialized");
+    await seedDeliveryScenario(harnessPool);
+    await seedAdditionalDeliveryReservation(harnessPool, { clientId: ids.otherClient, deliveryAddressId: ids.otherDeliveryAddress });
+
+    await expect(
+      deliveryRepository.repoCreateLivraisonFromReservations({
+        body: {
+          items: [
+            { reservation_id: ids.reservation, qty: 1 },
+            { reservation_id: ids.secondReservation, qty: 1 },
+          ],
+        },
+        user_id: 7,
+        idempotency_key: "delivery-prepare-mixed-client-001",
+      })
+    ).rejects.toMatchObject({ status: 409, code: "MIXED_DELIVERY_CLIENT" });
+
+    await clearScenario(harnessPool);
+    await seedDeliveryScenario(harnessPool);
+    await seedAdditionalDeliveryReservation(harnessPool, { deliveryAddressId: ids.otherDeliveryAddress });
+
+    await expect(
+      deliveryRepository.repoCreateLivraisonFromReservations({
+        body: {
+          items: [
+            { reservation_id: ids.reservation, qty: 1 },
+            { reservation_id: ids.secondReservation, qty: 1 },
+          ],
+        },
+        user_id: 7,
+        idempotency_key: "delivery-prepare-mixed-address-001",
+      })
+    ).rejects.toMatchObject({ status: 409, code: "MIXED_DELIVERY_DESTINATION" });
   });
 
   it("permits only one concurrent preparation and ships its reservation exactly once on idempotent retry", async () => {

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -464,6 +464,18 @@ function buildListWhere(filters: ListLivraisonsQueryDTO): ListWhere {
       bl.numero ILIKE ${p}
       OR c.company_name ILIKE ${p}
       OR (cc.numero IS NOT NULL AND cc.numero ILIKE ${p})
+      OR EXISTS (
+        SELECT 1
+        FROM public.bon_livraison_ligne scope_line
+        JOIN public.bon_livraison_ligne_allocations scope_bla
+          ON scope_bla.bon_livraison_ligne_id = scope_line.id
+        JOIN public.commande_ligne_affaire_allocation scope_allocation
+          ON scope_allocation.id = scope_bla.commande_ligne_affaire_allocation_id
+        JOIN public.commande_client scope_commande
+          ON scope_commande.id = scope_allocation.commande_id
+        WHERE scope_line.bon_livraison_id = bl.id
+          AND scope_commande.numero ILIKE ${p}
+      )
     )`)
   }
 
@@ -474,7 +486,19 @@ function buildListWhere(filters: ListLivraisonsQueryDTO): ListWhere {
 
   if (filters.commande_id) {
     const p = push(filters.commande_id)
-    where.push(`bl.commande_id = ${p}::bigint`)
+    where.push(`(
+      bl.commande_id = ${p}::bigint
+      OR EXISTS (
+        SELECT 1
+        FROM public.bon_livraison_ligne scope_line
+        JOIN public.bon_livraison_ligne_allocations scope_bla
+          ON scope_bla.bon_livraison_ligne_id = scope_line.id
+        JOIN public.commande_ligne_affaire_allocation scope_allocation
+          ON scope_allocation.id = scope_bla.commande_ligne_affaire_allocation_id
+        WHERE scope_line.bon_livraison_id = bl.id
+          AND scope_allocation.commande_id = ${p}::bigint
+      )
+    )`)
   }
 
   if (filters.statut) {
@@ -551,8 +575,10 @@ export async function repoListLivraisons(
     client_company_name: string
     commande_id: string | null
     commande_numero: string | null
+    commande_numeros: string[]
     affaire_id: string | null
     affaire_reference: string | null
+    affaire_references: string[]
     date_creation: string
     date_expedition: string | null
     date_livraison: string | null
@@ -570,8 +596,42 @@ export async function repoListLivraisons(
       c.company_name AS client_company_name,
       bl.commande_id::text AS commande_id,
       cc.numero AS commande_numero,
+      ARRAY(
+        SELECT reference
+        FROM (
+          SELECT DISTINCT scope_commande.numero AS reference
+          FROM public.bon_livraison_ligne scope_line
+          JOIN public.bon_livraison_ligne_allocations scope_bla
+            ON scope_bla.bon_livraison_ligne_id = scope_line.id
+          JOIN public.commande_ligne_affaire_allocation scope_allocation
+            ON scope_allocation.id = scope_bla.commande_ligne_affaire_allocation_id
+          JOIN public.commande_client scope_commande
+            ON scope_commande.id = scope_allocation.commande_id
+          WHERE scope_line.bon_livraison_id = bl.id
+          UNION
+          SELECT cc.numero WHERE cc.numero IS NOT NULL
+        ) commande_scope
+        ORDER BY reference
+      ) AS commande_numeros,
       bl.affaire_id::text AS affaire_id,
       a.reference AS affaire_reference,
+      ARRAY(
+        SELECT reference
+        FROM (
+          SELECT DISTINCT scope_affaire.reference
+          FROM public.bon_livraison_ligne scope_line
+          JOIN public.bon_livraison_ligne_allocations scope_bla
+            ON scope_bla.bon_livraison_ligne_id = scope_line.id
+          JOIN public.commande_ligne_affaire_allocation scope_allocation
+            ON scope_allocation.id = scope_bla.commande_ligne_affaire_allocation_id
+          JOIN public.affaire scope_affaire
+            ON scope_affaire.id = scope_allocation.livraison_affaire_id
+          WHERE scope_line.bon_livraison_id = bl.id
+          UNION
+          SELECT a.reference WHERE a.reference IS NOT NULL
+        ) affaire_scope
+        ORDER BY reference
+      ) AS affaire_references,
       bl.date_creation::text AS date_creation,
       bl.date_expedition::text AS date_expedition,
       bl.date_livraison::text AS date_livraison,
@@ -595,7 +655,9 @@ export async function repoListLivraisons(
     statut: r.statut,
     client: { client_id: r.client_id, company_name: r.client_company_name },
     commande: r.commande_id && r.commande_numero ? { id: toInt(r.commande_id, "bon_livraison.commande_id"), numero: r.commande_numero } : null,
+    commande_numeros: r.commande_numeros,
     affaire: r.affaire_id && r.affaire_reference ? { id: toInt(r.affaire_id, "bon_livraison.affaire_id"), reference: r.affaire_reference } : null,
+    affaire_references: r.affaire_references,
     date_creation: r.date_creation,
     date_expedition: r.date_expedition,
     date_livraison: r.date_livraison,
@@ -615,8 +677,10 @@ type HeaderRow = {
   client_company_name: string
   commande_id: string | null
   commande_numero: string | null
+  commande_numeros: string[]
   affaire_id: string | null
   affaire_reference: string | null
+  affaire_references: string[]
   adresse_livraison_id: string | null
   al_name: string | null
   al_street: string | null
@@ -657,8 +721,42 @@ async function getHeader(client: PoolClient, id: string, opts?: { forUpdate?: bo
       c.company_name AS client_company_name,
       bl.commande_id::text AS commande_id,
       cc.numero AS commande_numero,
+      ARRAY(
+        SELECT reference
+        FROM (
+          SELECT DISTINCT scope_commande.numero AS reference
+          FROM public.bon_livraison_ligne scope_line
+          JOIN public.bon_livraison_ligne_allocations scope_bla
+            ON scope_bla.bon_livraison_ligne_id = scope_line.id
+          JOIN public.commande_ligne_affaire_allocation scope_allocation
+            ON scope_allocation.id = scope_bla.commande_ligne_affaire_allocation_id
+          JOIN public.commande_client scope_commande
+            ON scope_commande.id = scope_allocation.commande_id
+          WHERE scope_line.bon_livraison_id = bl.id
+          UNION
+          SELECT cc.numero WHERE cc.numero IS NOT NULL
+        ) commande_scope
+        ORDER BY reference
+      ) AS commande_numeros,
       bl.affaire_id::text AS affaire_id,
       a.reference AS affaire_reference,
+      ARRAY(
+        SELECT reference
+        FROM (
+          SELECT DISTINCT scope_affaire.reference
+          FROM public.bon_livraison_ligne scope_line
+          JOIN public.bon_livraison_ligne_allocations scope_bla
+            ON scope_bla.bon_livraison_ligne_id = scope_line.id
+          JOIN public.commande_ligne_affaire_allocation scope_allocation
+            ON scope_allocation.id = scope_bla.commande_ligne_affaire_allocation_id
+          JOIN public.affaire scope_affaire
+            ON scope_affaire.id = scope_allocation.livraison_affaire_id
+          WHERE scope_line.bon_livraison_id = bl.id
+          UNION
+          SELECT a.reference WHERE a.reference IS NOT NULL
+        ) affaire_scope
+        ORDER BY reference
+      ) AS affaire_references,
       bl.adresse_livraison_id::text AS adresse_livraison_id,
       al.name AS al_name,
       al.street AS al_street,
@@ -749,7 +847,9 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
       statut: headerRow.statut,
       client: { client_id: headerRow.client_id, company_name: headerRow.client_company_name },
       commande: headerRow.commande_id && headerRow.commande_numero ? { id: toInt(headerRow.commande_id, "bon_livraison.commande_id"), numero: headerRow.commande_numero } : null,
+      commande_numeros: headerRow.commande_numeros,
       affaire: headerRow.affaire_id && headerRow.affaire_reference ? { id: toInt(headerRow.affaire_id, "bon_livraison.affaire_id"), reference: headerRow.affaire_reference } : null,
+      affaire_references: headerRow.affaire_references,
       adresse_livraison,
       date_creation: headerRow.date_creation,
       date_expedition: headerRow.date_expedition,
@@ -3251,7 +3351,9 @@ export type PreparationCartItem = {
   affaire_reference: string | null
   commande_ligne_id: number
   allocation_id: number | null
+  client_id: string
   client_name: string | null
+  delivery_address_id: string | null
   article_id: string
   article_code: string | null
   // Kept nullable rather than inventing a display fallback: the source of
@@ -3363,7 +3465,9 @@ export async function repoListPreparationCart(filters: PreparationCartQueryDTO):
     affaire_reference: string | null
     commande_ligne_id: number
     allocation_id: number | null
+    client_id: string
     client_name: string | null
+    delivery_address_id: string | null
     article_id: string
     article_code: string | null
     plan_reference: string | null
@@ -3395,7 +3499,9 @@ export async function repoListPreparationCart(filters: PreparationCartQueryDTO):
         af.reference AS affaire_reference,
         a.commande_ligne_id::bigint::int AS commande_ligne_id,
         a.id::bigint::int AS allocation_id,
+        cc.client_id::text AS client_id,
         c.company_name AS client_name,
+        COALESCE(cc.destinataire_id, c.delivery_address_id)::text AS delivery_address_id,
         r.article_id::text AS article_id,
         art.code AS article_code,
         applicable_version.plan_reference,
@@ -3481,7 +3587,9 @@ export async function repoListPreparationCart(filters: PreparationCartQueryDTO):
         affaire_reference: row.affaire_reference,
         commande_ligne_id: Number(row.commande_ligne_id),
         allocation_id: row.allocation_id === null ? null : Number(row.allocation_id),
+        client_id: row.client_id,
         client_name: row.client_name,
+        delivery_address_id: row.delivery_address_id,
         article_id: row.article_id,
         article_code: row.article_code,
         plan_reference: row.plan_reference,
@@ -4091,6 +4199,7 @@ type LockedReservationForDelivery = {
   qty_available: number
   commande_id: number
   client_id: string
+  delivery_address_id: string | null
   livraison_affaire_id: number
   allocation_id: number
   commande_ligne_id: number
@@ -4191,6 +4300,7 @@ export async function repoCreateLivraisonFromReservations(params: {
           (r.qty_reserved - r.qty_consumed - r.qty_prepared)::float8 AS qty_available,
           a.commande_id::bigint::int AS commande_id,
           cc.client_id::text AS client_id,
+          COALESCE(cc.destinataire_id, c.delivery_address_id)::text AS delivery_address_id,
           r.livraison_affaire_id::bigint::int AS livraison_affaire_id,
           a.id::bigint::int AS allocation_id,
           a.commande_ligne_id::bigint::int AS commande_ligne_id,
@@ -4210,6 +4320,7 @@ export async function repoCreateLivraisonFromReservations(params: {
         FROM public.stock_reservations r
         JOIN public.commande_ligne_affaire_allocation a ON a.id = r.commande_ligne_affaire_allocation_id
         JOIN public.commande_client cc ON cc.id = a.commande_id
+        LEFT JOIN public.clients c ON c.client_id = cc.client_id
         JOIN public.commande_ligne cl ON cl.id = a.commande_ligne_id
         LEFT JOIN public.emplacements e ON e.location_id = r.location_id
         LEFT JOIN LATERAL (
@@ -4241,12 +4352,11 @@ export async function repoCreateLivraisonFromReservations(params: {
     const first = locked.rows[0]
     if (!first) throw new HttpError(400, "EMPTY_CART", "No reservation selected")
     for (const row of locked.rows) {
-      if (
-        row.commande_id !== first.commande_id ||
-        row.client_id !== first.client_id ||
-        row.livraison_affaire_id !== first.livraison_affaire_id
-      ) {
-        throw new HttpError(409, "MIXED_DELIVERY_SCOPE", "A delivery cart must target one commande and one delivery affaire")
+      if (row.client_id !== first.client_id) {
+        throw new HttpError(409, "MIXED_DELIVERY_CLIENT", "A delivery cart must target one client")
+      }
+      if (row.delivery_address_id !== first.delivery_address_id) {
+        throw new HttpError(409, "MIXED_DELIVERY_DESTINATION", "A delivery cart must target one delivery address")
       }
       if (!row.lot_id || !row.stock_level_id || !row.stock_batch_id || !row.magasin_id || row.emplacement_id === null) {
         throw new HttpError(409, "RESERVATION_TRACEABILITY_INCOMPLETE", "Reservation cannot be prepared without lot, level, batch and location")
@@ -4312,15 +4422,27 @@ export async function repoCreateLivraisonFromReservations(params: {
     const n = Number(seq.rows[0]?.n)
     if (!Number.isFinite(n)) throw new Error("Failed to reserve bon_livraison number")
     const numero = `BL-${String(n).padStart(8, "0")}`
+    const commandeIds = new Set(locked.rows.map((row) => row.commande_id))
+    const affaireIds = new Set(locked.rows.map((row) => row.livraison_affaire_id))
+    const headerCommandeId = commandeIds.size === 1 ? first.commande_id : null
+    const headerAffaireId = affaireIds.size === 1 ? first.livraison_affaire_id : null
     const headerIns = await db.query<{ id: string }>(
       `
         INSERT INTO public.bon_livraison (
-          numero, client_id, commande_id, affaire_id, statut,
+          numero, client_id, commande_id, affaire_id, adresse_livraison_id, statut,
           date_creation, commentaire_interne, created_by, updated_by
-        ) VALUES ($1,$2,$3,$4,'DRAFT',CURRENT_DATE,$5,$6,$6)
+        ) VALUES ($1,$2,$3,$4,$5::uuid,'DRAFT',CURRENT_DATE,$6,$7,$7)
         RETURNING id::text AS id
       `,
-      [numero, first.client_id, first.commande_id, first.livraison_affaire_id, body.commentaire_interne ?? null, userId]
+      [
+        numero,
+        first.client_id,
+        headerCommandeId,
+        headerAffaireId,
+        first.delivery_address_id,
+        body.commentaire_interne ?? null,
+        userId,
+      ]
     )
     const bonLivraisonId = headerIns.rows[0]?.id
     if (!bonLivraisonId) throw new Error("Failed to create reservation-backed BL")

--- a/src/module/livraisons/services/bon-livraison-document.ts
+++ b/src/module/livraisons/services/bon-livraison-document.ts
@@ -90,10 +90,16 @@ export function addressLines(label: string | null | undefined): string[] | null 
   return lines.length ? lines : null
 }
 
+function references(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.map((value) => clean(value)).filter((value): value is string => Boolean(value))))
+}
+
 export async function renderBonLivraisonDocument(input: BonLivraisonDocumentInput): Promise<Buffer> {
   const { header: bl, company, version } = input
   const issuer = input.issuer ?? {}
   const clientName = clean(bl.client.company_name) ?? "Client"
+  const commandes = references([...(bl.commande_numeros ?? []), bl.commande?.numero])
+  const affaires = references([...(bl.affaire_references ?? []), bl.affaire?.reference])
 
   // Le referentiel expose l'identifiant technique du client ; il n'a rien a faire sur un
   // document qui part chez lui. Seule la raison sociale est imprimee.
@@ -156,8 +162,8 @@ export async function renderBonLivraisonDocument(input: BonLivraisonDocumentInpu
       // La commande et l'affaire sont ce qui rattache le bon au contrat : elles etaient
       // absentes du bon de livraison alors que le certificat les portait deja.
       const rattachement = [
-        { label: "Commande", value: clean(bl.commande?.numero) },
-        { label: "Affaire", value: clean(bl.affaire?.reference) },
+        { label: commandes.length > 1 ? "Commandes" : "Commande", value: commandes.join(" · ") || null },
+        { label: affaires.length > 1 ? "Affaires" : "Affaire", value: affaires.join(" · ") || null },
       ].filter((cell) => cell.value)
       if (rattachement.length) ctx.legalStrip(rattachement)
 

--- a/src/module/livraisons/services/delivery-authoritative-document.ts
+++ b/src/module/livraisons/services/delivery-authoritative-document.ts
@@ -10,6 +10,7 @@ type Queryable = Pick<PoolClient, "query">;
 
 type DeliverySnapshot = {
   numero: string; statut: string; client_name: string; commande_numero: string | null; affaire_reference: string | null;
+  commande_numeros: string[]; affaire_references: string[];
   address_label: string | null; date_creation: string; date_expedition: string | null; transporteur: string | null;
   tracking_number: string | null; commentaire_client: string | null; updated_at: string;
   /** Issuer terms are source data too: a later legal-profile edit must not alter an issued BL. */
@@ -60,6 +61,40 @@ export async function loadDeliveryAuthoritativeSnapshot(tx: Queryable, deliveryI
   const header = await tx.query<Omit<DeliverySnapshot, "lines" | "issuer">>(`
     SELECT bl.numero, bl.statut::text, c.company_name AS client_name, cc.numero AS commande_numero,
       a.reference AS affaire_reference,
+      ARRAY(
+        SELECT reference
+        FROM (
+          SELECT DISTINCT scope_commande.numero AS reference
+          FROM public.bon_livraison_ligne scope_line
+          JOIN public.bon_livraison_ligne_allocations scope_bla
+            ON scope_bla.bon_livraison_ligne_id = scope_line.id
+          JOIN public.commande_ligne_affaire_allocation scope_allocation
+            ON scope_allocation.id = scope_bla.commande_ligne_affaire_allocation_id
+          JOIN public.commande_client scope_commande
+            ON scope_commande.id = scope_allocation.commande_id
+          WHERE scope_line.bon_livraison_id = bl.id
+          UNION
+          SELECT cc.numero WHERE cc.numero IS NOT NULL
+        ) commande_scope
+        ORDER BY reference
+      ) AS commande_numeros,
+      ARRAY(
+        SELECT reference
+        FROM (
+          SELECT DISTINCT scope_affaire.reference
+          FROM public.bon_livraison_ligne scope_line
+          JOIN public.bon_livraison_ligne_allocations scope_bla
+            ON scope_bla.bon_livraison_ligne_id = scope_line.id
+          JOIN public.commande_ligne_affaire_allocation scope_allocation
+            ON scope_allocation.id = scope_bla.commande_ligne_affaire_allocation_id
+          JOIN public.affaire scope_affaire
+            ON scope_affaire.id = scope_allocation.livraison_affaire_id
+          WHERE scope_line.bon_livraison_id = bl.id
+          UNION
+          SELECT a.reference WHERE a.reference IS NOT NULL
+        ) affaire_scope
+        ORDER BY reference
+      ) AS affaire_references,
       concat_ws(E'\\n', al.name, concat_ws(' ', al.street, al.house_number), concat_ws(' ', al.postal_code, al.city), al.country) AS address_label,
       bl.date_creation::text, bl.date_expedition::text, bl.transporteur, bl.tracking_number, bl.commentaire_client, bl.updated_at::text
     FROM public.bon_livraison bl
@@ -89,6 +124,8 @@ export async function loadDeliveryAuthoritativeSnapshot(tx: Queryable, deliveryI
 
 export async function buildDeliveryCreationSnapshotInput(tx: Queryable, input: { deliveryId: string; actorUserId: number | null }): Promise<AuthoritativePdfCreationInput> {
   const snapshot = await loadDeliveryAuthoritativeSnapshot(tx, input.deliveryId);
+  const commandeNumeros = Array.isArray(snapshot.commande_numeros) ? snapshot.commande_numeros : [];
+  const affaireReferences = Array.isArray(snapshot.affaire_references) ? snapshot.affaire_references : [];
   return {
     entityType: "bon-livraison", entityId: input.deliveryId, documentKind: "DELIVERY_NOTE_CREATION_SNAPSHOT", documentVersion: 1,
     renderVersion: "internal-creation-snapshot-v1", idempotencyKey: `delivery:${input.deliveryId}:creation:v1`,
@@ -98,7 +135,8 @@ export async function buildDeliveryCreationSnapshotInput(tx: Queryable, input: {
       entityLabel: "Bon de livraison", reference: snapshot.numero,
       summary: [{ label: "Numéro", value: snapshot.numero }, { label: "Client", value: snapshot.client_name }, { label: "Statut initial", value: snapshot.statut }],
       sections: [{ title: "Création", rows: [
-        { label: "Commande", value: snapshot.commande_numero }, { label: "Affaire", value: snapshot.affaire_reference },
+        { label: commandeNumeros.length > 1 ? "Commandes" : "Commande", value: commandeNumeros.join(" · ") || snapshot.commande_numero },
+        { label: affaireReferences.length > 1 ? "Affaires" : "Affaire", value: affaireReferences.join(" · ") || snapshot.affaire_reference },
         { label: "Date", value: snapshot.date_creation }, { label: "Nombre de lignes", value: snapshot.lines.length },
       ] }],
     }), actorUserId: input.actorUserId,
@@ -129,7 +167,9 @@ export async function renderShippedDeliveryOfficialPdf({ archive }: { archive: A
     header: {
       id: archive.entityId, numero: source.numero, statut: "SHIPPED", client: { client_id: "", company_name: source.client_name },
       commande: source.commande_numero ? { id: 0, numero: source.commande_numero } : null,
+      commande_numeros: Array.isArray(source.commande_numeros) ? source.commande_numeros : source.commande_numero ? [source.commande_numero] : [],
       affaire: source.affaire_reference ? { id: 0, reference: source.affaire_reference } : null,
+      affaire_references: Array.isArray(source.affaire_references) ? source.affaire_references : source.affaire_reference ? [source.affaire_reference] : [],
       adresse_livraison: source.address_label ? { id: "", label: source.address_label, name: null, street: null, house_number: null, postal_code: null, city: null, country: null } : null,
       date_creation: source.date_creation ?? "", date_expedition: source.date_expedition ?? null, date_livraison: null,
       transporteur: source.transporteur ?? null, tracking_number: source.tracking_number ?? null,

--- a/src/module/livraisons/services/pack-pdf.service.test.ts
+++ b/src/module/livraisons/services/pack-pdf.service.test.ts
@@ -289,6 +289,31 @@ describe("bon de livraison PDF — rendu reel", () => {
     expect(text).toContain("ABB FRANCE")
   }, 60_000)
 
+  it("imprime toutes les commandes et affaires d'un BL groupé", async () => {
+    const p = preview()
+    const bytes = await svcRenderPackBonLivraisonPdf({
+      preview: {
+        ...p,
+        bon_livraison: {
+          ...p.bon_livraison,
+          commande: null,
+          commande_numeros: ["CMD-2026-0142", "CMD-2026-0149"],
+          affaire: null,
+          affaire_references: ["AFF-2026-0031", "AFF-2026-0038"],
+        },
+      },
+      version: 1,
+    })
+    const text = drawnText(bytes)
+
+    expect(text).toContain("COMMANDES")
+    expect(text).toContain("CMD-2026-0142")
+    expect(text).toContain("CMD-2026-0149")
+    expect(text).toContain("AFFAIRES")
+    expect(text).toContain("AFF-2026-0031")
+    expect(text).toContain("AFF-2026-0038")
+  }, 60_000)
+
   it("conserve les donnees metier de l'ancienne version : delai client et lots", async () => {
     const bytes = await svcRenderPackBonLivraisonPdf({ preview: preview(), version: 1 })
     const text = drawnText(bytes)

--- a/src/module/livraisons/types/livraisons.types.ts
+++ b/src/module/livraisons/types/livraisons.types.ts
@@ -61,7 +61,9 @@ export type BonLivraisonListItem = {
   statut: BonLivraisonStatut
   client: ClientLite
   commande: CommandeLite
+  commande_numeros?: string[]
   affaire: AffaireLite
+  affaire_references?: string[]
   date_creation: string
   date_expedition: string | null
   date_livraison: string | null
@@ -76,7 +78,9 @@ export type BonLivraisonHeader = {
   statut: BonLivraisonStatut
   client: ClientLite
   commande: CommandeLite
+  commande_numeros?: string[]
   affaire: AffaireLite
+  affaire_references?: string[]
   adresse_livraison: AdresseLivraisonLite
   date_creation: string
   date_expedition: string | null


### PR DESCRIPTION
## Résultat
- autorise plusieurs lignes et plusieurs commandes dans un même BL
- conserve l’invariant même client et même adresse de livraison
- conserve la traçabilité ligne par ligne vers chaque commande et affaire
- affiche toutes les références dans le détail et les PDF

## Validation
- TypeScript build OK
- tests PostgreSQL multi-commandes / client / destination OK
- tests PDF 19/19 OK
- contrat OpenAPI et frontière production OK

Closes #664

## Summary by Sourcery

Support multi-order delivery notes while retaining client, destination, traceability, and document reference integrity.

New Features:
- Allow a single delivery note to consolidate lines from multiple orders while preserving the shared client and delivery destination constraints.
- Expose all associated order and project references in delivery lists, details, authoritative snapshots, and PDFs.

Bug Fixes:
- Reject delivery carts that combine different clients or delivery destinations with specific conflict errors.

Enhancements:
- Preserve line-level traceability from grouped delivery notes to each originating order and project.

Tests:
- Add PostgreSQL integration coverage for multi-order delivery creation and client or destination validation.
- Add PDF coverage for rendering multiple order and project references.