### PR TITLE
fix(stock): libérer les réservations épuisées sans quantité zéro

### DIFF
--- a/src/__tests__/stock-delivery-reservation.contract.test.ts
+++ b/src/__tests__/stock-delivery-reservation.contract.test.ts
@@ -129,6 +129,10 @@ describe("Commande → stock → OF receipt → delivery contracts", () => {
     expect(deliveryRepository).not.toMatch(/ACTUAL_QTY_BELOW_RESERVED/);
     expect(deliveryRepository).toMatch(/PHYSICAL_QTY_BELOW_PREPARED/);
     expect(deliveryRepository).toMatch(/reallocateCorrectedBatchReservations/);
+    expect(deliveryRepository).toMatch(/remainingReservedQty <= 1e-9/);
+    expect(deliveryRepository).toMatch(/SET status = 'RELEASED'/);
+    expect(deliveryRepository).toMatch(/released_at = now\(\)/);
+    expect(deliveryRepository).toMatch(/release_reason = \$3/);
     expect(deliveryRepository).toMatch(/prepareOfsForReservationShortages/);
     expect(deliveryRepository).toMatch(/createRecursiveOrdresFabrication/);
     expect(deliveryRepository).toMatch(/CASE COALESCE\(l\.source_scope, l\.stock_scope, w\.stock_scope, 'NEW'\) WHEN 'OLD' THEN 0 ELSE 1 END/);

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -3802,19 +3802,42 @@ async function reallocateCorrectedBatchReservations(params: {
     const releasedQty = Math.max(0, flexibleQty - keptFlexibleQty)
     if (releasedQty <= 1e-9) continue
 
-    await params.db.query(
-      `
-        UPDATE public.stock_reservations
-        SET qty_reserved = qty_reserved - $2,
-            version = version + 1,
-            row_version = row_version + 1,
-            reason = $3,
-            updated_at = now(),
-            updated_by = $4
-        WHERE id = $1::uuid
-      `,
-      [row.reservation_id, releasedQty, params.reason, params.user_id]
-    )
+    const remainingReservedQty = Math.max(0, Number(row.qty_reserved) - releasedQty)
+    const reservationUpdate = remainingReservedQty <= 1e-9
+      ? await params.db.query(
+          `
+            UPDATE public.stock_reservations
+            SET status = 'RELEASED',
+                released_at = now(),
+                released_by = $2,
+                release_reason = $3,
+                version = version + 1,
+                row_version = row_version + 1,
+                reason = $3,
+                updated_at = now(),
+                updated_by = $2
+            WHERE id = $1::uuid
+              AND status = 'ACTIVE'
+          `,
+          [row.reservation_id, params.user_id, params.reason]
+        )
+      : await params.db.query(
+          `
+            UPDATE public.stock_reservations
+            SET qty_reserved = $2,
+                version = version + 1,
+                row_version = row_version + 1,
+                reason = $3,
+                updated_at = now(),
+                updated_by = $4
+            WHERE id = $1::uuid
+              AND status = 'ACTIVE'
+          `,
+          [row.reservation_id, remainingReservedQty, params.reason, params.user_id]
+        )
+    if ((reservationUpdate.rowCount ?? 0) !== 1) {
+      throw new HttpError(409, "RESERVATION_REBALANCE_CONFLICT", "La réservation a changé pendant le recomptage.")
+    }
     reallocations.push({
       from_reservation_id: row.reservation_id,
       commande_ligne_affaire_allocation_id: Number(row.commande_ligne_affaire_allocation_id),


### PR DESCRIPTION
Corrige le recomptage physique total d'un lot : une réservation entièrement retirée passe à RELEASED au lieu de violer la contrainte PostgreSQL qty_reserved > 0. Les réservations partielles restent actives avec leur solde positif.\n\nValidation :\n- test contractuel stock/livraison : 5/5\n- build backend complet (OpenAPI 1170 opérations, TypeScript, contrats et frontière production)

## Summary by Sourcery

Handle exhausted reservations safely during batch recount reallocation while preserving valid partial reservations.

Bug Fixes:
- Release fully depleted stock reservations instead of reducing them to an invalid zero quantity during physical recounts.
- Preserve partially depleted reservations with their remaining positive quantity.

Enhancements:
- Detect concurrent reservation changes during reallocation and return a conflict instead of silently proceeding.

Tests:
- Extend the stock/delivery contract test to verify full-release metadata and zero-quantity handling.