### PR TITLE
test: align release gate contracts

### DIFF
--- a/docs/contracts/formal-document-writers.json
+++ b/docs/contracts/formal-document-writers.json
@@ -9,7 +9,6 @@
   "writers": [
     { "id": "delivery.direct-create", "kind": "mounted_post", "source": "src/module/livraisons/routes/livraisons.routes.ts", "entry": "router.post(\"/\"", "transactional_queue": "buildDeliveryCreationSnapshotInput" },
     { "id": "delivery.from-order", "kind": "mounted_post", "source": "src/module/livraisons/routes/livraisons.routes.ts", "entry": "\"/from-commande/:commandeId\"", "transactional_queue": "buildDeliveryCreationSnapshotInput" },
-    { "id": "delivery.repository-create", "kind": "direct_writer", "source": "src/module/livraisons/repository/livraisons.repository.ts", "entry": "INSERT INTO bon_livraison (", "transactional_queue": "buildDeliveryCreationSnapshotInput" },
-    { "id": "delivery.stock-preparation", "kind": "direct_writer", "source": "src/module/commande-client/repository/commande-client.repository.ts", "entry": "repoCreateLivraisonFromCommande(", "transactional_queue": "delegates:repoCreateLivraisonFromCommande" }
+    { "id": "delivery.repository-create", "kind": "direct_writer", "source": "src/module/livraisons/repository/livraisons.repository.ts", "entry": "INSERT INTO bon_livraison (", "transactional_queue": "buildDeliveryCreationSnapshotInput" }
   ]
 }

--- a/src/__tests__/article-categories-commande-selectable-395.test.ts
+++ b/src/__tests__/article-categories-commande-selectable-395.test.ts
@@ -1,7 +1,13 @@
 // #395 / BUG-CERP-0015 - referentiel des categories commandables.
 // Le filtre de recherche et la creation depuis une commande doivent rester fermes sur le
 // perimetre que le repository Commande sait valider et convertir sans ambiguite.
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({ query: vi.fn() }));
+
+vi.mock("../config/database", () => ({
+  default: { query: dbMocks.query },
+}));
 
 import {
   commandeClientSelectableCategoryCodes,
@@ -13,6 +19,25 @@ describe("#395 / BUG-CERP-0015 - categories commandables", () => {
   let options: StockArticleCategoryOption[] = [];
 
   beforeAll(async () => {
+    dbMocks.query.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query.includes("to_regclass('public.article_category_referential')")) {
+        return { rows: [{ ok: true }] };
+      }
+      if (query.includes("FROM public.article_category_referential")) {
+        return {
+          rows: [
+            { code: "piece_finie_fabriquee", label: "Pièce finie fabriquée", code_segment: "PLAN", stock_managed_default: true, piece_technique_required: true, commande_client_selectable: true, is_active: true, sort_order: 10 },
+            { code: "matiere_premiere", label: "Matière première", code_segment: "MP", stock_managed_default: true, piece_technique_required: false, commande_client_selectable: false, is_active: true, sort_order: 20 },
+            { code: "traitement_surface", label: "Traitement de surface", code_segment: "TRT", stock_managed_default: false, piece_technique_required: false, commande_client_selectable: false, is_active: true, sort_order: 30 },
+            { code: "achat_revente", label: "Achat-revente", code_segment: "ACH", stock_managed_default: true, piece_technique_required: false, commande_client_selectable: false, is_active: true, sort_order: 40 },
+            { code: "sous_traitance", label: "Sous-traitance", code_segment: "STA", stock_managed_default: false, piece_technique_required: false, commande_client_selectable: false, is_active: true, sort_order: 50 },
+            { code: "achat_transforme", label: "Achat transformé", code_segment: "AHT", stock_managed_default: true, piece_technique_required: false, commande_client_selectable: false, is_active: true, sort_order: 60 },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
     options = await repoListArticleCategories();
   });
 

--- a/src/__tests__/authoritative-pdf-renderers.test.ts
+++ b/src/__tests__/authoritative-pdf-renderers.test.ts
@@ -255,7 +255,7 @@ describe("Wave-1 official PDF renderers", () => {
     expect(text).toContain("INTERNE/BROUILLON");
     expect(text).toContain("VERSION7");
     expect(text).toContain("AR-CC-2026-0042");
-    expect(text).toContain("COMMANDECC-2026-0042");
+    expect(text).toContain("RÉFÉRENCECOMMANDECLIENTCC-2026-0042");
     expect(text).not.toContain("ORIGINALGED");
     expect(text).not.toContain("QARENDERV1");
   });

--- a/src/__tests__/commande-ar.send.service.test.ts
+++ b/src/__tests__/commande-ar.send.service.test.ts
@@ -49,7 +49,7 @@ function claimedDraft() {
     reference: "AR-00000001-v1",
     series_number: 1,
     version_number: 1,
-    subject: "Accusé de réception de votre commande CMD-42 — AR-00000001-v1",
+    subject: "Accusé de réception de votre commande PO-42 — AR-00000001-v1",
     body_text: null,
     generated_at: "2026-08-26T10:00:00.000Z",
     generated_by: 7,
@@ -130,7 +130,7 @@ describe("svcSendCommandeAr", () => {
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         idempotencyKey: "commande-ar:test",
-        subject: "Accusé de réception de votre commande CMD-42 — AR-00000001-v1",
+        subject: "Accusé de réception de votre commande PO-42 — AR-00000001-v1",
         attachments: [expect.objectContaining({ filename: "AR-00000001-v1.pdf", content: PDF })],
       })
     );

--- a/src/__tests__/commande-article-eligibility.routes.test.ts
+++ b/src/__tests__/commande-article-eligibility.routes.test.ts
@@ -371,6 +371,9 @@ describe("BUG-CERP-0015 - validation serveur POST/PATCH commandes", () => {
       if (query.includes("FROM public.article_devis_promotion")) {
         return { rows: [{ promoted_article_id: ARTICLE_ID }] };
       }
+      if (query.includes("sale_price_reference::float8 AS sale_price_reference")) {
+        return { rows: [{ sale_price_reference: 19.5, sale_price_currency: "EUR", sale_price_source: "CUSTOMER_ORDER" }] };
+      }
       if (
         query.includes("FROM public.articles a") &&
         (query.includes("WHERE a.id = $1::uuid") || query.includes("AS commande_client_eligible"))

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -319,6 +319,9 @@ describe("/api/v1/commandes", () => {
           is_active: true,
         }],
       }) // resolve article
+      .mockResolvedValueOnce({
+        rows: [{ sale_price_reference: 100, sale_price_currency: "EUR", sale_price_source: "CUSTOMER_ORDER" }],
+      }) // lock reference sale price
       .mockResolvedValueOnce({ rows: [] }) // INSERT commande_ligne
       .mockResolvedValueOnce({ rows: [] }) // INSERT documents_clients
       .mockResolvedValueOnce({ rows: [] }) // INSERT commande_documents
@@ -480,6 +483,9 @@ describe("/api/v1/commandes", () => {
         articlePromoted = true;
         return { rows: [] };
       }
+      if (q.includes("SELECT sale_price_reference::float8 AS sale_price_reference")) {
+        return { rows: [{ sale_price_reference: 100, sale_price_currency: "EUR", sale_price_source: "CUSTOMER_ORDER" }] };
+      }
       if (q.includes("SELECT") && q.includes("FROM public.articles a")) {
         return {
           rows: [
@@ -591,6 +597,9 @@ describe("/api/v1/commandes", () => {
           is_active: true,
         }],
       }) // resolve article
+      .mockResolvedValueOnce({
+        rows: [{ sale_price_reference: 100, sale_price_currency: "EUR", sale_price_source: "CUSTOMER_ORDER" }],
+      }) // lock reference sale price
       .mockResolvedValueOnce({ rows: [] }) // INSERT commande_ligne
       .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
@@ -1373,6 +1382,9 @@ describe("/api/v1/commandes", () => {
           is_active: true,
         }],
       }) // resolve article
+      .mockResolvedValueOnce({
+        rows: [{ sale_price_reference: 100, sale_price_currency: "EUR", sale_price_source: "CUSTOMER_ORDER" }],
+      }) // lock reference sale price
       .mockResolvedValueOnce({ rows: [] }) // insert lignes
       .mockResolvedValueOnce({ rows: [] }) // insert historique
       .mockResolvedValueOnce({ rows: [] }); // COMMIT
@@ -1711,7 +1723,7 @@ describe("/api/v1/commandes", () => {
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
   });
 
-  it("POST /api/v1/commandes/:id/generate-affaires recovers planning and reuses its existing delivery affair", async () => {
+  it("POST /api/v1/commandes/:id/generate-affaires reuses the stock affair and creates the production-remainder affair", async () => {
     process.env.JWT_SECRET = "test-secret";
     const token = jwt.sign(
       { id: 1, username: "test", email: "test@example.com", role: "admin" },
@@ -1772,6 +1784,9 @@ describe("/api/v1/commandes", () => {
         return { rows: [{ ok: 1 }] };
       }
 
+      if (q.includes("FROM commande_to_affaire") && q.includes("AND affaire_id = $2")) {
+        return { rows: Number(Array.isArray(params) ? params[1] : null) === 7 ? [{ id: "1" }] : [] };
+      }
       if (q.includes("FROM commande_to_affaire") && q.includes("WHERE commande_id")) {
         return { rows: [{ affaire_id: 7, role: "LIVRAISON" }] };
       }
@@ -1808,7 +1823,7 @@ describe("/api/v1/commandes", () => {
       }
 
       if (q.includes("nextval('public.affaire_id_seq')")) {
-        return { rows: [{ id: "7" }] };
+        return { rows: [{ id: "8" }] };
       }
 
       if (q.includes("SELECT client_code FROM public.clients")) {
@@ -1825,6 +1840,24 @@ describe("/api/v1/commandes", () => {
 
       if (q.includes("jsonb_build_object") && q.includes("'piece'")) {
         return { rows: [{ snapshot: { piece: { id: PIECE_ID, code: "PT-001" }, version: { version_interne: 1 } } }] };
+      }
+
+      if (q.includes("FROM public.affaire a") && q.includes("FOR UPDATE OF a")) {
+        return {
+          rows: [{
+            id: "8",
+            reference: "AFF-CLI-001-000001",
+            statut: "OUVERTE",
+            type_affaire: "livraison",
+            date_ouverture: "2026-08-27",
+            updated_at: "2026-08-27T12:00:00.000000Z",
+            client_id: "001",
+            client_name: "ACME",
+            commande_id: "123",
+            commande_numero: "CC-123",
+            devis_id: null,
+          }],
+        };
       }
 
       if (q.includes("WITH RECURSIVE tree") && q.includes("public.pieces_techniques_nomenclature")) {
@@ -1885,12 +1918,14 @@ describe("/api/v1/commandes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
-      affaire_ids: [7],
+      affaire_ids: [7, 8],
       livraison_affaire_id: 7,
+      production_livraison_affaire_id: 8,
+      automatic_stock_production_split: true,
       warnings: ["RECOVERED_PLANNING_WITHOUT_OF_OR_DELIVERY"],
     });
     expect(ofInsertCalls.some((params) => params.includes(3))).toBe(true);
-    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(true);
     expect(
       mocks.clientQuery.mock.calls.some(
         (call) =>

--- a/src/__tests__/delivery-formal-document-coverage.contract.test.ts
+++ b/src/__tests__/delivery-formal-document-coverage.contract.test.ts
@@ -18,15 +18,13 @@ describe("#624 delivery formal-document writer coverage", () => {
 
   it("classifies every mounted POST and direct delivery writer", () => {
     const routes = read("src/module/livraisons/routes/livraisons.routes.ts");
-    const direct = read("src/module/commande-client/repository/commande-client.repository.ts");
-    expect(manifest.writers).toHaveLength(4);
+    expect(manifest.writers).toHaveLength(3);
     for (const writer of manifest.writers) {
       expect(read(writer.source)).toContain(writer.entry);
       expect(writer.transactional_queue).toBeTruthy();
     }
     expect(routes).toContain('router.post("/", requireLivraisonCapability("prepare"), createLivraison)');
     expect(routes).toContain('"/from-commande/:commandeId"');
-    expect(direct).toContain("repoCreateLivraisonFromCommande(");
   });
 
   it("fails closed when a new production direct INSERT writer is not classified", () => {


### PR DESCRIPTION
## Résumé
- isole le référentiel des catégories article de la base ambiante
- aligne les contrats AR/PDF et prix de référence sur le comportement courant
- retire l'ancien writer de livraison supprimé du manifeste
- couvre la séparation stock / reliquat à fabriquer

## Vérifications
- 66 scénarios ciblés verts
- typecheck backend vert
- build backend vert

Closes #679

## Summary by Sourcery

Align release-gate contracts and tests with current order, pricing, document-writer, and fulfillment behavior.

Bug Fixes:
- Align order acknowledgment and reference-sale-price contract tests with current customer-order behavior.
- Cover automatic separation of stock fulfillment from the production remainder when generating affairs.

Enhancements:
- Isolate article-category repository tests from the ambient database by using a dedicated referential mock.
- Update authoritative PDF expectations to the current order-reference labels.

Tests:
- Update release-gate contract coverage for article-category eligibility, reference pricing, PDF renderers, order flows, and stock/production-affair splitting.
- Remove the deleted delivery writer from the formal-document writer manifest coverage.