### PR TITLE
fix: order e-invoice migration dependencies

### DIFF
--- a/db/patches/20260827_z_accounting_export_supplier_677.sql
+++ b/db/patches/20260827_z_accounting_export_supplier_677.sql
@@ -1,4 +1,4 @@
--- #677 - Extend SOL-27 immutable accounting exports with supplier invoices and credit notes.
+-- #677 - Extend SOL-27 immutable accounting exports after supplier invoice tables exist.
 BEGIN;
 
 DO $guard$

--- a/db/patches/20260827_z_einvoice_credit_reporting_676.sql
+++ b/db/patches/20260827_z_einvoice_credit_reporting_676.sql
@@ -1,4 +1,4 @@
--- #676 - Electronic credit notes and foreign/payment e-reporting foundations.
+-- #676 - Electronic credit notes and foreign/payment e-reporting foundations; ordered after supplier invoices.
 -- Additive and deliberately inactive in production until explicit feature flags are enabled.
 BEGIN;
 

--- a/db/patches/support/20260823_authoritative_pdf_ged_compatibility_bridge.verify.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_compatibility_bridge.verify.sql
@@ -1,7 +1,38 @@
 BEGIN TRANSACTION READ ONLY;
 
 DO $verify$
+DECLARE
+  cleanup_recorded boolean := false;
 BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.cerp_schema_migrations
+      WHERE filename = '20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql'
+    ) INTO cleanup_recorded;
+  END IF;
+
+  -- The bridge is transitional. Once the immutable cleanup is recorded, the
+  -- legacy SOL-20 profile is valid only with the canonical guard restored and
+  -- every temporary bridge object removed. Closed-registry databases continue
+  -- through the original verification below because cleanup is a no-op there.
+  IF cleanup_recorded AND to_regclass('public.ged_entity_types') IS NULL THEN
+    IF to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL
+       OR to_regprocedure('public.fn_ged_link_guard()') IS NOT NULL
+       OR to_regclass('public.ged_document_links') IS NULL
+       OR to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()') IS NULL
+       OR NOT EXISTS (
+         SELECT 1 FROM pg_trigger
+          WHERE tgname = 'trg_ged_validate_canonical_entity_link_20'
+            AND tgrelid = to_regclass('public.ged_document_links')
+            AND tgfoid = to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()')
+            AND NOT tgisinternal
+       ) THEN
+      RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_COMPATIBILITY_VERIFY_CLEANUP_DRIFT';
+    END IF;
+    RETURN;
+  END IF;
+
   IF to_regclass('public.ged_entity_types') IS NULL
      OR to_regprocedure('public.fn_ged_link_guard()') IS NULL
      OR to_regclass('public.ged_document_links') IS NULL THEN
@@ -19,6 +50,7 @@ $verify$;
 
 SELECT
   to_regclass('public.cerp_authoritative_pdf_ged_bridge_20260823') IS NOT NULL AS temporary_legacy_bridge,
-  to_regprocedure('public.fn_ged_link_guard()') IS NOT NULL AS closed_guard_present;
+  to_regprocedure('public.fn_ged_link_guard()') IS NOT NULL AS closed_guard_present,
+  to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()') IS NOT NULL AS canonical_guard_present;
 
 COMMIT;

--- a/db/patches/support/20260823_authoritative_pdf_ged_entity_contract.verify.sql
+++ b/db/patches/support/20260823_authoritative_pdf_ged_entity_contract.verify.sql
@@ -2,7 +2,33 @@
 BEGIN TRANSACTION READ ONLY;
 
 DO $verify$
+DECLARE
+  cleanup_recorded boolean := false;
 BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.cerp_schema_migrations
+      WHERE filename = '20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql'
+    ) INTO cleanup_recorded;
+  END IF;
+
+  IF cleanup_recorded AND to_regclass('public.ged_entity_types') IS NULL THEN
+    IF to_regclass('public.ged_document_links') IS NULL
+       OR to_regprocedure('public.fn_ged_link_guard()') IS NOT NULL
+       OR to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()') IS NULL
+       OR NOT EXISTS (
+         SELECT 1 FROM pg_trigger
+          WHERE tgname = 'trg_ged_validate_canonical_entity_link_20'
+            AND tgrelid = to_regclass('public.ged_document_links')
+            AND tgfoid = to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()')
+            AND NOT tgisinternal
+       ) THEN
+      RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_VERIFY_CLEANUP_DRIFT';
+    END IF;
+    RETURN;
+  END IF;
+
   IF to_regclass('public.ged_entity_types') IS NULL
      OR to_regclass('public.ged_document_links') IS NULL
      OR to_regprocedure('public.fn_ged_link_guard()') IS NULL THEN
@@ -16,6 +42,13 @@ BEGIN
        AND NOT tgisinternal
   ) THEN
     RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_VERIFY_LINK_GUARD_MISSING';
+  END IF;
+  IF NOT (
+    SELECT COUNT(*) = 5
+    FROM public.ged_entity_types
+    WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR')
+  ) THEN
+    RAISE EXCEPTION 'AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_VERIFY_ROW_MISMATCH';
   END IF;
   IF EXISTS (
     WITH expected(entity_type, label, module_key, target_table, target_pk_column, sort_order, is_active) AS (
@@ -40,9 +73,7 @@ END
 $verify$;
 
 SELECT
-  COUNT(*) = 5 AS all_required_types_present,
-  bool_and(is_active) AS all_required_types_active
-FROM public.ged_entity_types
-WHERE entity_type IN ('BON_LIVRAISON', 'DEVIS', 'COMMANDE_FOURNISSEUR', 'FACTURE', 'AVOIR');
+  to_regclass('public.ged_entity_types') IS NOT NULL AS closed_registry_profile,
+  to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()') IS NOT NULL AS canonical_legacy_profile;
 
 COMMIT;

--- a/db/patches/support/20260827_z_accounting_export_supplier_677.preflight.sql
+++ b/db/patches/support/20260827_z_accounting_export_supplier_677.preflight.sql
@@ -1,3 +1,4 @@
+-- Ordered with 20260827_z_accounting_export_supplier_677.sql after supplier invoices.
 DO $preflight$
 BEGIN
   IF to_regclass('public.accounting_export_batches') IS NULL

--- a/db/patches/support/20260827_z_accounting_export_supplier_677.rollback.sql
+++ b/db/patches/support/20260827_z_accounting_export_supplier_677.rollback.sql
@@ -1,3 +1,4 @@
+-- Rollback for the dependency-ordered #677 patch.
 DO $rollback$
 BEGIN
   IF current_database() !~* '(test|isolated|scratch)' THEN

--- a/db/patches/support/20260827_z_accounting_export_supplier_677.verify.sql
+++ b/db/patches/support/20260827_z_accounting_export_supplier_677.verify.sql
@@ -1,3 +1,4 @@
+-- Verification for the dependency-ordered #677 patch.
 DO $verify$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='accounting_batch_sources_677_ck')

--- a/db/patches/support/20260827_z_einvoice_credit_reporting_676.preflight.sql
+++ b/db/patches/support/20260827_z_einvoice_credit_reporting_676.preflight.sql
@@ -1,3 +1,4 @@
+-- Ordered with 20260827_z_einvoice_credit_reporting_676.sql after supplier invoices.
 DO $preflight$
 BEGIN
   IF to_regclass('public.avoir') IS NULL

--- a/db/patches/support/20260827_z_einvoice_credit_reporting_676.rollback.sql
+++ b/db/patches/support/20260827_z_einvoice_credit_reporting_676.rollback.sql
@@ -1,3 +1,4 @@
+-- Rollback for the dependency-ordered #676 patch.
 DO $rollback$
 BEGIN
   IF current_database() !~* '(test|isolated|scratch)' THEN

--- a/db/patches/support/20260827_z_einvoice_credit_reporting_676.verify.sql
+++ b/db/patches/support/20260827_z_einvoice_credit_reporting_676.verify.sql
@@ -1,3 +1,4 @@
+-- Verification for the dependency-ordered #676 patch.
 DO $verify$
 BEGIN
   IF to_regclass('public.einvoice_reporting_periods') IS NULL

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-23T15:05:30.619Z",
+  "started_at": "2026-08-27T12:13:28.479Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 17921,
-    "source_seed": 188,
-    "backup": 702,
-    "preflight": 172,
-    "integrity_before": 555,
-    "migration": 904,
-    "verify": 340,
-    "replay": 121,
-    "integrity_after": 1456,
-    "negative_gate": 40,
-    "rollback": 450,
-    "restore": 3847
+    "source_migration": 18879,
+    "source_seed": 192,
+    "backup": 723,
+    "preflight": 155,
+    "integrity_before": 559,
+    "migration": 1311,
+    "verify": 504,
+    "replay": 127,
+    "integrity_after": 1946,
+    "negative_gate": 47,
+    "rollback": 627,
+    "restore": 4821
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-23T15:05:52.071Z",
-    "duration_ms": 114,
+    "checked_at": "2026-08-27T12:13:51.013Z",
+    "duration_ms": 106,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36363287"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-JLVswE\\cerp-test-before-sol06.dump",
-      "bytes": 1968541,
-      "sha256": "a3669cc1ba2253b9a7ce2ed72e636203d7b77bf0d482e1faaf2ee6b5b9473fd7",
-      "free_bytes": 369955233792
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-5GZcVY\\cerp-test-before-sol06.dump",
+      "bytes": 1968535,
+      "sha256": "a6e662427640739f204ef59327995464e6efd6b73e8e8a3fdcda470c499b79ff",
+      "free_bytes": 344260665344
     },
     "ledger": {
       "applied": 140,
@@ -71,8 +71,26 @@
         "20260819_devis_preparation_idempotency_grants_002_003.sql",
         "20260819_mfa_expired_artifact_cleanup_delete_grant.sql",
         "20260823_authoritative_pdf_archive_612.sql",
+        "20260823_authoritative_pdf_ged_compatibility_bridge.sql",
+        "20260823_authoritative_pdf_ged_entity_contract.sql",
+        "20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql",
+        "20260823_finance_ged_archive_625.sql",
+        "20260823_ged_authoritative_pdf_access_events_634.sql",
         "20260823_of_readiness_release_617.sql",
-        "20260823_operational_media_access_611.sql"
+        "20260823_operational_media_access_611.sql",
+        "20260823_subcontract_work_packages_626.sql",
+        "20260824_ged_entity_attachments_203.sql",
+        "20260826_commande_ar_versioning_and_send_guard.sql",
+        "20260826_commandes_stock_reservations_livraisons_atomic.sql",
+        "20260826_pt_article_lot_reference_enrichment.sql",
+        "20260826_z_lots_scope_canonicalization.sql",
+        "20260826_zz_historical_stock_imports.sql",
+        "20260826_zzz_internal_order_auto_destination_883.sql",
+        "20260827_article_sale_price_financial_analysis_672.sql",
+        "20260827_einvoice_regulatory_data_599.sql",
+        "20260827_supplier_invoices_675.sql",
+        "20260827_z_accounting_export_supplier_677.sql",
+        "20260827_z_einvoice_credit_reporting_676.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
@@ -485,14 +503,32 @@
         "20260819_devis_preparation_idempotency_grants_002_003.sql",
         "20260819_mfa_expired_artifact_cleanup_delete_grant.sql",
         "20260823_authoritative_pdf_archive_612.sql",
+        "20260823_authoritative_pdf_ged_compatibility_bridge.sql",
+        "20260823_authoritative_pdf_ged_entity_contract.sql",
+        "20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql",
+        "20260823_finance_ged_archive_625.sql",
+        "20260823_ged_authoritative_pdf_access_events_634.sql",
         "20260823_of_readiness_release_617.sql",
-        "20260823_operational_media_access_611.sql"
+        "20260823_operational_media_access_611.sql",
+        "20260823_subcontract_work_packages_626.sql",
+        "20260824_ged_entity_attachments_203.sql",
+        "20260826_commande_ar_versioning_and_send_guard.sql",
+        "20260826_commandes_stock_reservations_livraisons_atomic.sql",
+        "20260826_pt_article_lot_reference_enrichment.sql",
+        "20260826_z_lots_scope_canonicalization.sql",
+        "20260826_zz_historical_stock_imports.sql",
+        "20260826_zzz_internal_order_auto_destination_883.sql",
+        "20260827_article_sale_price_financial_analysis_672.sql",
+        "20260827_einvoice_regulatory_data_599.sql",
+        "20260827_supplier_invoices_675.sql",
+        "20260827_z_accounting_export_supplier_677.sql",
+        "20260827_z_einvoice_credit_reporting_676.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "e34dff916e151737929bb43238ab161a15aac4b83cde4777ae2ab727dd1a4cf0"
+    "fingerprint": "20ae4eb2a8729e85e2d1959aff14249be55f085332177cd7785a1cb65676042f"
   },
   "replay": {
     "applied_zero": true,
@@ -500,8 +536,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-23T15:05:55.452Z",
-    "duration_ms": 1443,
+    "checked_at": "2026-08-27T12:13:55.464Z",
+    "duration_ms": 1931,
     "table_counts": {
       "accounting_export_batch_sources": "0",
       "accounting_export_batches": "0",
@@ -547,14 +583,16 @@
       "ar_recalage_dossiers": "0",
       "article_category_link": "0",
       "article_category_ref": "6",
+      "article_category_referential": "6",
       "article_create_idempotence": "0",
       "article_devis": "0",
       "article_devis_promotion": "0",
       "article_documents": "0",
       "article_procurement_profile": "0",
+      "article_sale_price_history": "0",
       "articles": "2",
       "articles_achat": "0",
-      "articles_achat_families": "0",
+      "articles_achat_families": "1",
       "articles_fabrique": "1",
       "articles_fabrique_families": "2",
       "articles_matiere": "0",
@@ -579,11 +617,13 @@
       "bon_livraison_ligne_allocations": "0",
       "bon_livraison_pack_quality_documents": "0",
       "bon_livraison_pack_versions": "0",
+      "bon_livraison_prepare_receipts": "0",
+      "bon_livraison_ship_receipts": "0",
       "centres_frais": "1",
       "cerp_migration_supersessions": "5",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "172",
+      "cerp_schema_migrations": "190",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -604,6 +644,7 @@
       "codification_141_quality_control_baseline": "0",
       "codification_141_sequence_baseline": "1",
       "commande_ar_log": "0",
+      "commande_ar_series": "0",
       "commande_cadre_release": "0",
       "commande_cadre_release_ligne": "0",
       "commande_client": "0",
@@ -631,6 +672,7 @@
       "data_import_confirm_idempotency": "0",
       "data_import_crosswalk": "0",
       "data_import_rows": "0",
+      "delivery_outbox": "0",
       "devis": "0",
       "devis_documents": "0",
       "devis_idempotence": "0",
@@ -638,10 +680,17 @@
       "documents_clients": "0",
       "dossier_technique_piece_devis": "0",
       "dossier_technique_piece_devis_promotion": "0",
+      "einvoice_billing_frame_catalog": "13",
       "einvoice_command_receipts": "0",
+      "einvoice_directory_verification_commands": "0",
       "einvoice_documents": "0",
       "einvoice_provider_connections": "0",
       "einvoice_provider_events": "0",
+      "einvoice_reporting_command_receipts": "0",
+      "einvoice_reporting_payments": "0",
+      "einvoice_reporting_periods": "0",
+      "einvoice_reporting_receipts": "0",
+      "einvoice_reporting_transactions": "0",
       "einvoice_submission_attempts": "0",
       "emplacements": "1",
       "entity_locks": "0",
@@ -678,7 +727,7 @@
       "ged_approvals": "0",
       "ged_blobs": "0",
       "ged_checkouts": "0",
-      "ged_document_classes": "23",
+      "ged_document_classes": "25",
       "ged_document_links": "0",
       "ged_document_relations": "0",
       "ged_document_versions": "0",
@@ -704,6 +753,7 @@
       "gestion_outils_revetement": "0",
       "gestion_outils_stock": "0",
       "gestion_outils_valeur_arete_coupe": "0",
+      "historical_stock_import_receipts": "0",
       "hr_absence_records": "0",
       "hr_badge_credentials": "0",
       "hr_employees": "0",
@@ -930,9 +980,22 @@
       "stock_movements": "0",
       "stock_nuance_etats": "0",
       "stock_nuances": "0",
+      "stock_reservation_corrections": "0",
       "stock_reservation_event_log": "0",
+      "stock_reservation_verifications": "0",
       "stock_reservations": "0",
       "stock_sous_etats": "0",
+      "subcontract_work_package_ledger": "0",
+      "subcontract_work_packages": "0",
+      "super_pdp_sync_cursors": "0",
+      "supplier_invoice_artifacts": "0",
+      "supplier_invoice_command_receipts": "0",
+      "supplier_invoice_decisions": "0",
+      "supplier_invoice_line_matches": "0",
+      "supplier_invoice_lines": "0",
+      "supplier_invoice_match_versions": "0",
+      "supplier_invoice_provider_status_outbox": "0",
+      "supplier_invoices": "0",
       "surface_finish_command_receipts": "0",
       "surface_finish_families": "13",
       "surface_finish_favorites": "0",
@@ -948,7 +1011,7 @@
       "users": "8",
       "warehouses": "4"
     },
-    "table_count": 444,
+    "table_count": 471,
     "unvalidated_constraints": [
       {
         "table_name": "avoir",
@@ -1004,6 +1067,11 @@
         "table_name": "stock_reservations",
         "conname": "stock_reservations_status_225_ck",
         "contype": "c"
+      },
+      {
+        "table_name": "stock_reservations",
+        "conname": "stock_reservations_status_v2_chk",
+        "contype": "c"
       }
     ],
     "invalid_foreign_keys": [],
@@ -1025,7 +1093,7 @@
         "groups": 0
       }
     ],
-    "foreign_key_count": 1232,
+    "foreign_key_count": 1307,
     "orphans": [],
     "readiness": [
       {
@@ -1034,10 +1102,10 @@
         "ready": true,
         "definition": "Calendrier de capacité actif avec jours et horaires explicites.",
         "unit": "calendriers",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1051,10 +1119,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1069,10 +1137,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1095,10 +1163,10 @@
         "ready": true,
         "definition": "Calendrier de capacité actif avec jours et horaires explicites.",
         "unit": "calendriers",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1112,10 +1180,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1130,10 +1198,10 @@
         "ready": true,
         "definition": "Unités canoniques utilisables sans conversion implicite.",
         "unit": "unités",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1150,10 +1218,10 @@
         "ready": true,
         "definition": "Chaque centre de frais actif possède un taux horaire versionné applicable et sourcé.",
         "unit": "EUR/heure",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1168,10 +1236,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1194,10 +1262,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1212,10 +1280,10 @@
         "ready": true,
         "definition": "Au moins un magasin et un emplacement actifs sont reliés au référentiel warehouse/location.",
         "unit": "emplacements",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1231,10 +1299,10 @@
         "ready": true,
         "definition": "Unités canoniques utilisables sans conversion implicite.",
         "unit": "unités",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1269,10 +1337,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-22T22:00:00.000Z",
+        "period_start": "2026-08-26T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-23T15:05:54.008Z",
+        "freshness_at": "2026-08-27T12:13:53.535Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1291,13 +1359,13 @@
       }
     ],
     "ledger": {
-      "applied": 172,
+      "applied": 190,
       "pending": [],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     },
-    "fingerprint": "5be01aef72126314e94456da1bf659aa7f2e15aba3bbf793faa159d4d1ca0370"
+    "fingerprint": "e9d185122ac2d7f4a4fd379ede4eb2b87cfc419592c9dca6d7324168032c26c6"
   },
   "negative_gate": {
     "status": "passed",
@@ -1341,7 +1409,7 @@
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "e34dff916e151737929bb43238ab161a15aac4b83cde4777ae2ab727dd1a4cf0",
+    "fingerprint": "20ae4eb2a8729e85e2d1959aff14249be55f085332177cd7785a1cb65676042f",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1376,13 +1444,31 @@
         "20260819_devis_preparation_idempotency_grants_002_003.sql",
         "20260819_mfa_expired_artifact_cleanup_delete_grant.sql",
         "20260823_authoritative_pdf_archive_612.sql",
+        "20260823_authoritative_pdf_ged_compatibility_bridge.sql",
+        "20260823_authoritative_pdf_ged_entity_contract.sql",
+        "20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql",
+        "20260823_finance_ged_archive_625.sql",
+        "20260823_ged_authoritative_pdf_access_events_634.sql",
         "20260823_of_readiness_release_617.sql",
-        "20260823_operational_media_access_611.sql"
+        "20260823_operational_media_access_611.sql",
+        "20260823_subcontract_work_packages_626.sql",
+        "20260824_ged_entity_attachments_203.sql",
+        "20260826_commande_ar_versioning_and_send_guard.sql",
+        "20260826_commandes_stock_reservations_livraisons_atomic.sql",
+        "20260826_pt_article_lot_reference_enrichment.sql",
+        "20260826_z_lots_scope_canonicalization.sql",
+        "20260826_zz_historical_stock_imports.sql",
+        "20260826_zzz_internal_order_auto_destination_883.sql",
+        "20260827_article_sale_price_financial_analysis_672.sql",
+        "20260827_einvoice_regulatory_data_599.sql",
+        "20260827_supplier_invoices_675.sql",
+        "20260827_z_accounting_export_supplier_677.sql",
+        "20260827_z_einvoice_credit_reporting_676.sql"
       ],
       "checksum_mismatches": [],
       "known_external_applied": [],
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-23T15:05:59.944Z"
+  "completed_at": "2026-08-27T12:14:01.126Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-23T15:05:59.944Z
+- Exécutée : 2026-08-27T12:14:01.126Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36363287 octets
-- Sauvegarde : 1968541 octets, SHA-256 `a3669cc1ba2253b9a7ce2ed72e636203d7b77bf0d482e1faaf2ee6b5b9473fd7`
-- Patches avant/après : 140 / 172
+- Sauvegarde : 1968535 octets, SHA-256 `a6e662427640739f204ef59327995464e6efd6b73e8e8a3fdcda470c499b79ff`
+- Patches avant/après : 140 / 190
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `e34dff916e151737929bb43238ab161a15aac4b83cde4777ae2ab727dd1a4cf0` / `e34dff916e151737929bb43238ab161a15aac4b83cde4777ae2ab727dd1a4cf0`
+- Empreinte source/restaurée : `20ae4eb2a8729e85e2d1959aff14249be55f085332177cd7785a1cb65676042f` / `20ae4eb2a8729e85e2d1959aff14249be55f085332177cd7785a1cb65676042f`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 17921 |
-| source_seed | 188 |
-| backup | 702 |
-| preflight | 172 |
-| integrity_before | 555 |
-| migration | 904 |
-| verify | 340 |
-| replay | 121 |
-| integrity_after | 1456 |
-| negative_gate | 40 |
-| rollback | 450 |
-| restore | 3847 |
+| source_migration | 18879 |
+| source_seed | 192 |
+| backup | 723 |
+| preflight | 155 |
+| integrity_before | 559 |
+| migration | 1311 |
+| verify | 504 |
+| replay | 127 |
+| integrity_after | 1946 |
+| negative_gate | 47 |
+| rollback | 627 |
+| restore | 4821 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -81,14 +81,14 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "133e0b49689d94f2b507a9bb32de19ace74b492c75ed999a3a8128fbaf1630fe",
   "20260819_mfa_expired_artifact_cleanup_delete_grant.sql":
     "4e7dc39721970b14cd515d12658f79bf9e95d46d684d1e06204f78f60c2dbb0b",
-  "20260827_accounting_export_supplier_677.sql":
-    "de1bd03efb37635d655c2536a35fe6c99d7be0b447b3bdbd5ed3727d9d77c94f",
+  "20260827_z_accounting_export_supplier_677.sql":
+    "0344c68426dbf7437e1db7e077df68499e11f7d989cd53e1cb131042755f4f16",
   "20260827_einvoice_regulatory_data_599.sql":
     "76f06374a17e0679e16befde6926068d1d012cf8e83dbb0deba77e2aedb56f0f",
   "20260827_supplier_invoices_675.sql":
     "4e3f6747bab9a649d6dd93a0c62c6314c098254249319f65375aeedd2a58c8d1",
-  "20260827_einvoice_credit_reporting_676.sql":
-    "a8d760a14104a2496e8f6e8c46bf86e219d45e8f4aade66fedee1b4c4acf67de",
+  "20260827_z_einvoice_credit_reporting_676.sql":
+    "1021100ef8b8d912dfaf690b1057d357582b73675e907fd5464d860d61ded5fe",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -21,6 +21,10 @@ const ADV_RELIABILITY_PATCH = "20260814_adv_reliability_sol23.sql";
 const PROJECT_OPERATIONS_PATCH = "20260814_project_operations_sol24.sql";
 const ELECTRONIC_INVOICING_PATCH = "20260814_electronic_invoicing_sol26.sql";
 const ACCOUNTING_EXPORT_PATCH = "20260814_accounting_export_sol27.sql";
+const EINVOICE_REGULATORY_PATCH = "20260827_einvoice_regulatory_data_599.sql";
+const SUPPLIER_INVOICES_PATCH = "20260827_supplier_invoices_675.sql";
+const EINVOICE_CREDIT_REPORTING_PATCH = "20260827_z_einvoice_credit_reporting_676.sql";
+const ACCOUNTING_EXPORT_SUPPLIER_PATCH = "20260827_z_accounting_export_supplier_677.sql";
 const API_WEBHOOKS_PATCH = "20260814_api_contract_webhooks_sol28.sql";
 const MFA_POLICY_PATCH = "20260816_mfa_policy_and_device_labels.sql";
 const DEVIS_AUDIT_GRANTS_PATCH = "20260819_devis_preparation_idempotency_grants_002_003.sql";
@@ -530,6 +534,34 @@ async function proveRollback(databaseUrl) {
       "SELECT to_regclass('public.accounting_export_batches') IS NOT NULL AS present"
     );
     if (accountingExportRollback && accountingExportObject.rows[0].present) {
+      const einvoiceCreditReportingRollback = patchSupportSql(EINVOICE_CREDIT_REPORTING_PATCH, "rollback");
+      const einvoiceCreditReportingObject = await client.query(
+        "SELECT to_regclass('public.einvoice_reporting_periods') IS NOT NULL AS present"
+      );
+      if (einvoiceCreditReportingRollback && einvoiceCreditReportingObject.rows[0].present) {
+        await runSqlFile(client, einvoiceCreditReportingRollback);
+      }
+      const accountingExportSupplierRollback = patchSupportSql(ACCOUNTING_EXPORT_SUPPLIER_PATCH, "rollback");
+      const accountingExportSupplierObject = await client.query(
+        "SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='accounting_batch_sources_677_ck') AS present"
+      );
+      if (accountingExportSupplierRollback && accountingExportSupplierObject.rows[0].present) {
+        await runSqlFile(client, accountingExportSupplierRollback);
+      }
+      const supplierInvoicesRollback = patchSupportSql(SUPPLIER_INVOICES_PATCH, "rollback");
+      const supplierInvoicesObject = await client.query(
+        "SELECT to_regclass('public.supplier_invoices') IS NOT NULL AS present"
+      );
+      if (supplierInvoicesRollback && supplierInvoicesObject.rows[0].present) {
+        await runSqlFile(client, supplierInvoicesRollback);
+      }
+      const einvoiceRegulatoryRollback = patchSupportSql(EINVOICE_REGULATORY_PATCH, "rollback");
+      const einvoiceRegulatoryObject = await client.query(
+        "SELECT to_regclass('public.einvoice_billing_frame_catalog') IS NOT NULL AS present"
+      );
+      if (einvoiceRegulatoryRollback && einvoiceRegulatoryObject.rows[0].present) {
+        await runSqlFile(client, einvoiceRegulatoryRollback);
+      }
       await runSqlFile(client, accountingExportRollback);
     }
     const electronicInvoicingRollback = patchSupportSql(ELECTRONIC_INVOICING_PATCH, "rollback");

--- a/src/__tests__/accounting-export-supplier-677.migration-guards.test.ts
+++ b/src/__tests__/accounting-export-supplier-677.migration-guards.test.ts
@@ -5,17 +5,17 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const root = path.resolve(__dirname, "../..");
-const filename = "20260827_accounting_export_supplier_677.sql";
+const filename = "20260827_z_accounting_export_supplier_677.sql";
 const patch = fs.readFileSync(path.join(root, "db/patches", filename), "utf8");
-const preflight = fs.readFileSync(path.join(root, "db/patches/support/20260827_accounting_export_supplier_677.preflight.sql"), "utf8");
-const verify = fs.readFileSync(path.join(root, "db/patches/support/20260827_accounting_export_supplier_677.verify.sql"), "utf8");
-const rollback = fs.readFileSync(path.join(root, "db/patches/support/20260827_accounting_export_supplier_677.rollback.sql"), "utf8");
+const preflight = fs.readFileSync(path.join(root, "db/patches/support/20260827_z_accounting_export_supplier_677.preflight.sql"), "utf8");
+const verify = fs.readFileSync(path.join(root, "db/patches/support/20260827_z_accounting_export_supplier_677.verify.sql"), "utf8");
+const rollback = fs.readFileSync(path.join(root, "db/patches/support/20260827_z_accounting_export_supplier_677.rollback.sql"), "utf8");
 const runner = fs.readFileSync(path.join(root, "scripts/db-patches.js"), "utf8");
 const sha256 = crypto.createHash("sha256").update(patch.replace(/\r\n?/g, "\n")).digest("hex");
 
 describe("ACCOUNTING-EXPORT-677 migration guards", () => {
   it("pins the exact additive migration in the immutable production runner", () => {
-    expect(sha256).toBe("de1bd03efb37635d655c2536a35fe6c99d7be0b447b3bdbd5ed3727d9d77c94f");
+    expect(sha256).toBe("0344c68426dbf7437e1db7e077df68499e11f7d989cd53e1cb131042755f4f16");
     expect(runner).toContain(`"${filename}"`);
     expect(runner).toContain(sha256);
   });

--- a/src/__tests__/authoritative-pdf-ged-entity-contract.migration.test.ts
+++ b/src/__tests__/authoritative-pdf-ged-entity-contract.migration.test.ts
@@ -70,6 +70,11 @@ describe("authoritative PDF/GED entity-contract migration", () => {
     }
     expect(cleanupVerify).toContain("LEGACY_SOL20");
     expect(cleanupVerify).toContain("CLOSED_REGISTRY");
+    expect(verify).toContain("20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql");
+    expect(verify).toContain("AUTHORITATIVE_PDF_GED_ENTITY_CONTRACT_VERIFY_CLEANUP_DRIFT");
+    expect(bridgeVerify).toContain("20260823_authoritative_pdf_ged_legacy_profile_cleanup.sql");
+    expect(bridgeVerify).toContain("trg_ged_validate_canonical_entity_link_20");
+    expect(bridgeVerify).toContain("AUTHORITATIVE_PDF_GED_COMPATIBILITY_VERIFY_CLEANUP_DRIFT");
     expect(bridgeRollback).toContain("immutable entity contract has consumed");
     expect(cleanupRollback).toContain("production legacy cleanup is not automatically reversible");
   });

--- a/src/__tests__/einvoice-credit-reporting-676.migration-guards.test.ts
+++ b/src/__tests__/einvoice-credit-reporting-676.migration-guards.test.ts
@@ -5,11 +5,11 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const root = path.resolve(__dirname, "../..");
-const filename = "20260827_einvoice_credit_reporting_676.sql";
+const filename = "20260827_z_einvoice_credit_reporting_676.sql";
 const patch = fs.readFileSync(path.join(root, "db/patches", filename), "utf8");
-const preflight = fs.readFileSync(path.join(root, "db/patches/support/20260827_einvoice_credit_reporting_676.preflight.sql"), "utf8");
-const verify = fs.readFileSync(path.join(root, "db/patches/support/20260827_einvoice_credit_reporting_676.verify.sql"), "utf8");
-const rollback = fs.readFileSync(path.join(root, "db/patches/support/20260827_einvoice_credit_reporting_676.rollback.sql"), "utf8");
+const preflight = fs.readFileSync(path.join(root, "db/patches/support/20260827_z_einvoice_credit_reporting_676.preflight.sql"), "utf8");
+const verify = fs.readFileSync(path.join(root, "db/patches/support/20260827_z_einvoice_credit_reporting_676.verify.sql"), "utf8");
+const rollback = fs.readFileSync(path.join(root, "db/patches/support/20260827_z_einvoice_credit_reporting_676.rollback.sql"), "utf8");
 const runner = fs.readFileSync(path.join(root, "scripts/db-patches.js"), "utf8");
 const reportingRepository = fs.readFileSync(
   path.join(root, "src/module/facturation/electronic-invoicing/electronic-invoice-reporting.repository.ts"),
@@ -19,7 +19,7 @@ const sha256 = crypto.createHash("sha256").update(patch.replace(/\r\n?/g, "\n"))
 
 describe("EINVOICE-676 migration guards", () => {
   it("pins the exact additive migration in the immutable production runner", () => {
-    expect(sha256).toBe("a8d760a14104a2496e8f6e8c46bf86e219d45e8f4aade66fedee1b4c4acf67de");
+    expect(sha256).toBe("1021100ef8b8d912dfaf690b1057d357582b73675e907fd5464d860d61ded5fe");
     expect(runner).toContain(`"${filename}"`);
     expect(runner).toContain(sha256);
   });

--- a/src/__tests__/migration-release-gate-sol06.test.ts
+++ b/src/__tests__/migration-release-gate-sol06.test.ts
@@ -119,6 +119,21 @@ describe("SOL-06 migration release gate", () => {
     expect(source).toContain('path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.md")');
   });
 
+  it("retire les extensions e-invoicing dépendantes avant les socles SOL-26/SOL-27 pendant la preuve de rollback", () => {
+    const source = fs.readFileSync(path.join(ROOT, "scripts", "migrations", "release-gate.js"), "utf8");
+    const dependentRollback = source.indexOf('patchSupportSql(EINVOICE_CREDIT_REPORTING_PATCH, "rollback")');
+    const supplierRollback = source.indexOf('patchSupportSql(SUPPLIER_INVOICES_PATCH, "rollback")');
+    const regulatoryRollback = source.indexOf('patchSupportSql(EINVOICE_REGULATORY_PATCH, "rollback")');
+    const sol27Rollback = source.indexOf('await runSqlFile(client, accountingExportRollback)');
+    const sol26Rollback = source.indexOf('await runSqlFile(client, electronicInvoicingRollback)');
+
+    expect(dependentRollback).toBeGreaterThanOrEqual(0);
+    expect(supplierRollback).toBeGreaterThan(dependentRollback);
+    expect(regulatoryRollback).toBeGreaterThan(supplierRollback);
+    expect(sol27Rollback).toBeGreaterThan(regulatoryRollback);
+    expect(sol26Rollback).toBeGreaterThan(sol27Rollback);
+  });
+
   it("attend le serveur PostgreSQL final au lieu du serveur temporaire d'initialisation", () => {
     const source = fs.readFileSync(path.join(ROOT, "scripts", "migrations", "release-gate.js"), "utf8");
 


### PR DESCRIPTION
Corrige l ordre immutable des migrations de facturation electronique, rend les verifications GED transitoires compatibles avec l etat final et execute les rollbacks dependants avant les socles SOL-26 et SOL-27. Validation: 42 tests cibles, typecheck, build et repetition complete des migrations avec restauration. Closes #681. Closes #682.

## Summary by Sourcery

Correct the ordering and rollback handling of e-invoicing migrations while keeping GED verification valid across transitional and final schema states.

Bug Fixes:
- Order electronic-invoicing migrations after their supplier-invoice dependencies and execute dependent rollbacks before the SOL-26 and SOL-27 base migrations.
- Make transitional GED verification compatible with both legacy bridge and final canonical profiles while detecting cleanup drift.

Enhancements:
- Update immutable migration registrations, support scripts, and release-gate checks to reflect the dependency-safe ordering.

Documentation:
- Refresh the SOL-06 migration rehearsal report with the latest successful migration, rollback, and restoration results.

Tests:
- Extend migration guard tests to cover dependency ordering, GED cleanup compatibility, and rollback sequencing.