### PR TITLE
test(e2e): isolate managed email delivery

### DIFF
--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -239,10 +239,26 @@ async function main() {
     await client.query(
       `UPDATE public.clients SET
          email='client.e2e@invalid.example',phone='0102030405',
+         siren='123456789',
+         electronic_address_scheme='0002',
+         electronic_address_value='123456789',
+         electronic_address_directory_entry_id='E2E-DIRECTORY-BUYER-123456789',
+         electronic_address_verified_at='2026-08-27T00:00:00.000Z'::timestamptz,
          delivery_address_id='91000000-0000-4000-8000-000000000001',
          bill_address_id='92000000-0000-4000-8000-000000000001',
          contact_id='93000000-0000-4000-8000-000000000001'
        WHERE client_id='901'`
+    );
+    await client.query(
+      `UPDATE public.finance_legal_mentions SET
+         electronic_address_scheme='0002',
+         electronic_address_value='380569012',
+         electronic_address_directory_entry_id='E2E-DIRECTORY-SELLER-380569012',
+         electronic_address_verified_at='2026-08-27T00:00:00.000Z'::timestamptz
+       WHERE biller_id=$1::uuid
+         AND effective_from <= $2::date
+         AND (effective_to IS NULL OR effective_to > $2::date)`,
+      [FINANCE_ISSUER_ID, REFERENCE_PERIOD_START]
     );
     await client.query(
       `INSERT INTO public.fournisseurs (id,code,nom,actif,status)

--- a/src/__tests__/e2e-isolated-seed-contract.test.ts
+++ b/src/__tests__/e2e-isolated-seed-contract.test.ts
@@ -18,4 +18,17 @@ describe("isolated deterministic seed contract", () => {
     expect(deleteItems).toBeGreaterThan(guardedReset);
     expect(deleteReviews).toBeGreaterThan(deleteItems);
   });
+
+  it("qualifies the isolated buyer and seller routing data without weakening production guards", () => {
+    const source = readFileSync(path.resolve("scripts/e2e/seed-isolated.js"), "utf8");
+
+    expect(source).toContain("siren='123456789'");
+    expect(source).toContain("electronic_address_value='123456789'");
+    expect(source).toContain("E2E-DIRECTORY-BUYER-123456789");
+    expect(source).toContain("electronic_address_value='380569012'");
+    expect(source).toContain("E2E-DIRECTORY-SELLER-380569012");
+    expect(source.indexOf("assertIsolated();")).toBeLessThan(
+      source.indexOf("E2E-DIRECTORY-BUYER-123456789")
+    );
+  });
 });

--- a/src/__tests__/e2e-isolation.test.ts
+++ b/src/__tests__/e2e-isolation.test.ts
@@ -81,12 +81,16 @@ describe("SOL-05 E2E isolation guard", () => {
     container.CERP_E2E_EMAIL_SINK = "1";
     container.RESEND_API_KEY = "disposable";
     container.RESEND_FROM = "CERP SOL-05 <no-reply@example.local>";
-    container.RESEND_API_BASE_URL = "http://host.docker.internal:55001";
+    container.RESEND_API_BASE_URL = "http://email-sink:55001";
 
     expect(() => assertE2EIsolation(container)).not.toThrow();
     expect(e2eListenHost(container)).toBe("0.0.0.0");
 
     container.DATABASE_URL = managedContainerDatabaseUrl("db.production.example");
+    expect(() => assertE2EIsolation(container)).toThrow(/forbidden/);
+
+    container.DATABASE_URL = managedContainerDatabaseUrl("postgres");
+    container.RESEND_API_BASE_URL = "http://host.docker.internal:55001";
     expect(() => assertE2EIsolation(container)).toThrow(/forbidden/);
   });
 

--- a/src/config/e2e-isolation.ts
+++ b/src/config/e2e-isolation.ts
@@ -54,7 +54,7 @@ export function assertE2EIsolation(env: NodeJS.ProcessEnv = process.env): void {
     assertAllowedUrl(
       "RESEND_API_BASE_URL",
       env.RESEND_API_BASE_URL,
-      managedContainer ? new Set(["host.docker.internal"]) : LOOPBACK_HOSTS
+      managedContainer ? new Set(["email-sink"]) : LOOPBACK_HOSTS
     );
     if (!env.RESEND_FROM.toLowerCase().includes("@example.local")) {
       throw new Error("[SOL-05 isolation] RESEND_FROM must use example.local");

--- a/src/shared/email/test-email-routing.test.ts
+++ b/src/shared/email/test-email-routing.test.ts
@@ -25,6 +25,22 @@ describe("test email routing safety boundary", () => {
     expect(testSafeEmailSubject("Accuse de reception", delivery.rerouted)).toMatch(/^\[TEST/);
   });
 
+  it("keeps only fixture recipients inside the managed SOL-05 email sink", () => {
+    const env = {
+      NODE_ENV: "test",
+      CERP_E2E_ISOLATED: "1",
+      CERP_E2E_MANAGED_STACK: "1",
+      CERP_E2E_EMAIL_SINK: "1",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveOutboundEmailRecipients(["client@example.local", "client@example.local"], env)).toEqual({
+      recipients: ["client@example.local"],
+      rerouted: false,
+    });
+    expect(() => resolveOutboundEmailRecipients(["client@example.com"], env)).toThrow(/example\.local/);
+    expect(() => resolveOutboundEmailRecipients([], env)).toThrow(/example\.local/);
+  });
+
   it("keeps deduplicated intended recipients in production", () => {
     expect(resolveOutboundEmailRecipients(
       ["client@example.com", "client@example.com"],

--- a/src/shared/email/test-email-routing.ts
+++ b/src/shared/email/test-email-routing.ts
@@ -35,6 +35,17 @@ export function resolveOutboundEmailRecipients(
   intendedRecipients: readonly string[],
   env: NodeJS.ProcessEnv = process.env
 ): { recipients: string[]; rerouted: boolean } {
+  if (
+    env.CERP_E2E_ISOLATED === "1" &&
+    env.CERP_E2E_MANAGED_STACK === "1" &&
+    env.CERP_E2E_EMAIL_SINK === "1"
+  ) {
+    const recipients = [...new Set(intendedRecipients.map((recipient) => recipient.trim()).filter(Boolean))];
+    if (recipients.length === 0 || recipients.some((recipient) => !recipient.endsWith("@example.local"))) {
+      throw new Error("[SOL-05 isolation] email sink recipients must use example.local");
+    }
+    return { recipients, rerouted: false };
+  }
   if (isTestEmailEnvironment(env)) {
     return { recipients: [...TEST_EMAIL_RECIPIENTS], rerouted: true };
   }


### PR DESCRIPTION
Closes #684

- runs the SOL-05 email sink as a Docker sidecar on the isolated network
- forbids host.docker.internal and non-example.local recipients
- qualifies deterministic buyer/seller routing fixtures for the regulated invoice path

Validation:
- 5,196 backend tests passed (36 skipped)
- typecheck and production build passed
- isolated browser proof passed with no blocked runtime events

## Summary by Sourcery

Isolate managed E2E email delivery and enforce safe, deterministic routing for regulated invoice fixtures.

New Features:
- Route isolated managed-stack E2E email through a dedicated email-sink service while preserving fixture recipients.

Bug Fixes:
- Prevent isolated E2E email delivery from using host.docker.internal or recipients outside the example.local domain.

Enhancements:
- Qualify deterministic buyer and seller electronic-address data for the regulated invoice E2E path.

Tests:
- Add coverage for isolated seed routing data, managed email-sink restrictions, and forbidden host or recipient configurations.