### PR TITLE
release: suivi d'indice et inventaire guidé

### DIFF
--- a/db/patches/20260831_stock_article_inventory_revision_ux.sql
+++ b/db/patches/20260831_stock_article_inventory_revision_ux.sql
@@ -1,0 +1,99 @@
+-- Article revision-aware stock and guided inventory scopes.
+-- Additive and idempotent: canonical lot numbers and historical evidence stay immutable.
+BEGIN;
+
+ALTER TABLE public.lots
+  ADD COLUMN IF NOT EXISTS piece_technique_version_id uuid NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'lots_piece_technique_version_fkey'
+      AND conrelid = 'public.lots'::regclass
+  ) THEN
+    ALTER TABLE public.lots
+      ADD CONSTRAINT lots_piece_technique_version_fkey
+      FOREIGN KEY (piece_technique_version_id)
+      REFERENCES public.piece_technique_versions(id)
+      ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS lots_piece_technique_version_idx
+  ON public.lots (piece_technique_version_id, article_id, created_at DESC)
+  WHERE piece_technique_version_id IS NOT NULL;
+
+-- A lot may have several receipt rows for the same OF/version. Backfill only
+-- when every linked OF agrees on one technical version; ambiguous history is
+-- deliberately left NULL instead of being guessed.
+WITH unambiguous_lot_versions AS (
+  SELECT
+    output.lot_id,
+    (array_agg(DISTINCT fabrication.piece_technique_version_id)
+      FILTER (WHERE fabrication.piece_technique_version_id IS NOT NULL))[1] AS version_id
+  FROM public.of_output_lots output
+  JOIN public.ordres_fabrication fabrication ON fabrication.id = output.of_id
+  GROUP BY output.lot_id
+  HAVING COUNT(DISTINCT fabrication.piece_technique_version_id)
+    FILTER (WHERE fabrication.piece_technique_version_id IS NOT NULL) = 1
+)
+UPDATE public.lots lot
+SET piece_technique_version_id = version.version_id
+FROM unambiguous_lot_versions version
+WHERE lot.id = version.lot_id
+  AND lot.piece_technique_version_id IS NULL;
+
+ALTER TABLE public.stock_inventory_sessions
+  ADD COLUMN IF NOT EXISTS scope_article_prefix text NULL;
+
+ALTER TABLE public.stock_inventory_sessions
+  DROP CONSTRAINT IF EXISTS stock_inventory_sessions_article_prefix_ck;
+
+ALTER TABLE public.stock_inventory_sessions
+  ADD CONSTRAINT stock_inventory_sessions_article_prefix_ck
+  CHECK (scope_article_prefix IS NULL OR btrim(scope_article_prefix) <> '');
+
+-- Extend the existing scope freeze with the new article-prefix dimension.
+CREATE OR REPLACE FUNCTION public.fn_protect_stock_inventory_session()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'inventory sessions cannot be deleted'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status IN ('CLOSED', 'CANCELLED') THEN
+    RAISE EXCEPTION 'closed or cancelled inventory sessions are immutable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status <> 'DRAFT' AND (
+    NEW.scope_magasin_id IS DISTINCT FROM OLD.scope_magasin_id
+    OR NEW.scope_emplacement_id IS DISTINCT FROM OLD.scope_emplacement_id
+    OR NEW.scope_article_id IS DISTINCT FROM OLD.scope_article_id
+    OR NEW.scope_article_category IS DISTINCT FROM OLD.scope_article_category
+    OR NEW.scope_article_prefix IS DISTINCT FROM OLD.scope_article_prefix
+    OR NEW.blind_count IS DISTINCT FROM OLD.blind_count
+    OR NEW.requires_second_count IS DISTINCT FROM OLD.requires_second_count
+    OR NEW.snapshot_at IS DISTINCT FROM OLD.snapshot_at
+  ) THEN
+    RAISE EXCEPTION 'inventory scope and snapshot are frozen after start'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- Trace references can be corrected during an inventory. The before/after
+-- image is appended to stock_lot_event_log before the live references change.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT DELETE ON public.stock_lot_trace_references TO cerp_app;
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260831_stock_article_inventory_revision_ux.rollback.sql
+++ b/db/patches/support/20260831_stock_article_inventory_revision_ux.rollback.sql
@@ -1,0 +1,64 @@
+-- Conservative rollback: refuse once revision-aware lots or scoped inventories exist.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.lots WHERE piece_technique_version_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'rollback refused: revision-aware lot data exists';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.stock_inventory_sessions WHERE scope_article_prefix IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'rollback refused: prefix-scoped inventory sessions exist';
+  END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.fn_protect_stock_inventory_session()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'inventory sessions cannot be deleted'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status IN ('CLOSED', 'CANCELLED') THEN
+    RAISE EXCEPTION 'closed or cancelled inventory sessions are immutable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status <> 'DRAFT' AND (
+    NEW.scope_magasin_id IS DISTINCT FROM OLD.scope_magasin_id
+    OR NEW.scope_emplacement_id IS DISTINCT FROM OLD.scope_emplacement_id
+    OR NEW.scope_article_id IS DISTINCT FROM OLD.scope_article_id
+    OR NEW.scope_article_category IS DISTINCT FROM OLD.scope_article_category
+    OR NEW.blind_count IS DISTINCT FROM OLD.blind_count
+    OR NEW.requires_second_count IS DISTINCT FROM OLD.requires_second_count
+    OR NEW.snapshot_at IS DISTINCT FROM OLD.snapshot_at
+  ) THEN
+    RAISE EXCEPTION 'inventory scope and snapshot are frozen after start'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+ALTER TABLE public.stock_inventory_sessions
+  DROP CONSTRAINT IF EXISTS stock_inventory_sessions_article_prefix_ck,
+  DROP COLUMN IF EXISTS scope_article_prefix;
+
+DROP INDEX IF EXISTS public.lots_piece_technique_version_idx;
+
+ALTER TABLE public.lots
+  DROP CONSTRAINT IF EXISTS lots_piece_technique_version_fkey,
+  DROP COLUMN IF EXISTS piece_technique_version_id;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    REVOKE DELETE ON public.stock_lot_trace_references FROM cerp_app;
+  END IF;
+END $$;
+

--- a/db/patches/support/20260831_stock_article_inventory_revision_ux.verify.sql
+++ b/db/patches/support/20260831_stock_article_inventory_revision_ux.verify.sql
@@ -1,0 +1,29 @@
+-- Read-only post-patch checks; do not mutate production data.
+SELECT
+  EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'lots'
+      AND column_name = 'piece_technique_version_id'
+  ) AS lot_revision_exists,
+  EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'stock_inventory_sessions'
+      AND column_name = 'scope_article_prefix'
+  ) AS inventory_prefix_exists,
+  to_regclass('public.lots_piece_technique_version_idx') IS NOT NULL AS lot_revision_index_exists,
+  EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'lots_piece_technique_version_fkey'
+      AND conrelid = 'public.lots'::regclass
+  ) AS lot_revision_fk_exists;
+
+SELECT
+  COUNT(*) FILTER (WHERE piece_technique_version_id IS NOT NULL)::int AS revisioned_lots,
+  COUNT(*) FILTER (WHERE piece_technique_version_id IS NULL)::int AS unscoped_lots
+FROM public.lots;
+

--- a/src/module/livraisons/repository/livraisons-reservation-stock-correction.contract.test.ts
+++ b/src/module/livraisons/repository/livraisons-reservation-stock-correction.contract.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+import { repoRoot } from "../../../__tests__/helpers/repo-paths"
+
+const source = readFileSync(
+  resolve(repoRoot, "src/module/livraisons/repository/livraisons.repository.ts"),
+  "utf8"
+)
+
+describe("Atelier BL reservation stock correction contract (#923)", () => {
+  it("locks the exact batch and all active reservations before changing physical stock", () => {
+    expect(source).toContain("async function reallocateCorrectedBatchReservations")
+    expect(source).toContain("WHERE r.stock_batch_id = $1::uuid")
+    expect(source).toContain("FOR UPDATE OF r")
+    expect(source).toContain("PHYSICAL_QTY_BELOW_PREPARED")
+  })
+
+  it("reallocates released quantities over eligible lots in OLD then NEW FIFO order", () => {
+    expect(source).toContain("CASE COALESCE(l.source_scope, l.stock_scope, w.stock_scope, 'NEW') WHEN 'OLD' THEN 0 ELSE 1 END")
+    expect(source).toContain("COALESCE(l.received_at, l.manufactured_at, l.created_at::date)")
+    expect(source).toContain("RESERVATION_REALLOCATION_CONFLICT")
+  })
+
+  it("prepares idempotent work orders only for the remaining shortage", () => {
+    expect(source).toContain("async function prepareOfsForReservationShortages")
+    expect(source).toContain("createRecursiveOrdresFabrication")
+    expect(source).toContain("STOCK_CORRECTION_OF_PREPARED")
+    expect(source).toContain("stock-correction:${params.correction_id}:${allocationId}")
+    expect(source).toContain("prepared_ofs")
+  })
+
+  it("keeps physical verification separate from controlled correction", () => {
+    expect(source).toContain('"LOT_SCAN_MISMATCH"')
+    expect(source).toContain("stock_reservation_verifications")
+    expect(source).toContain("stock_reservation_corrections")
+    expect(source).toContain("IDEMPOTENCY_KEY_REUSED")
+    expect(source).toContain("CORRECTION_IN_PROGRESS")
+  })
+})

--- a/src/module/production/repository/production-receipts.repository.ts
+++ b/src/module/production/repository/production-receipts.repository.ts
@@ -917,6 +917,7 @@ export async function repoCreateOfReceipt(params: {
       affaire_id: number | null;
       commande_id: number | null;
       commande_ligne_id: number | null;
+      piece_technique_version_id: string | null;
       order_type: string | null;
       client_code: string | null;
       quantite_bonne: number;
@@ -931,6 +932,7 @@ export async function repoCreateOfReceipt(params: {
           fabrication.affaire_id::bigint::int AS affaire_id,
           fabrication.commande_id::bigint::int AS commande_id,
           fabrication.commande_ligne_id::bigint::int AS commande_ligne_id,
+          fabrication.piece_technique_version_id::text AS piece_technique_version_id,
           commande.order_type::text AS order_type,
           piece.code_client::text AS client_code,
           fabrication.quantite_bonne::float8 AS quantite_bonne,
@@ -1023,9 +1025,9 @@ export async function repoCreateOfReceipt(params: {
     if (params.body.lot_mode === "EXISTING") {
       const rawLotId = params.body.lot_id ?? null;
       if (!rawLotId) throw new HttpError(422, "LOT_REQUIRED", "Veuillez selectionner un lot");
-      const lot = await client.query<{ id: string; lot_code: string; lot_status: string | null }>(
+      const lot = await client.query<{ id: string; lot_code: string; lot_status: string | null; piece_technique_version_id: string | null }>(
         `
-          SELECT id::text AS id, lot_code, lot_status
+          SELECT id::text AS id, lot_code, lot_status, piece_technique_version_id::text AS piece_technique_version_id
           FROM public.lots
           WHERE id = $1::uuid AND article_id = $2::uuid
           LIMIT 1
@@ -1034,6 +1036,26 @@ export async function repoCreateOfReceipt(params: {
       );
       const row = lot.rows[0] ?? null;
       if (!row) throw new HttpError(400, "INVALID_LOT", "Lot introuvable pour cet article");
+
+      if (
+        row.piece_technique_version_id
+        && ofRow.piece_technique_version_id
+        && row.piece_technique_version_id !== ofRow.piece_technique_version_id
+      ) {
+        throw new HttpError(
+          409,
+          "LOT_TECHNICAL_VERSION_MISMATCH",
+          "Ce lot appartient à un autre indice technique et ne peut pas recevoir cette production."
+        );
+      }
+      if (!row.piece_technique_version_id && ofRow.piece_technique_version_id) {
+        await client.query(
+          `UPDATE public.lots
+           SET piece_technique_version_id = $2::uuid, updated_at = now(), updated_by = $3
+           WHERE id = $1::uuid AND piece_technique_version_id IS NULL`,
+          [row.id, ofRow.piece_technique_version_id, params.audit.user_id]
+        );
+      }
 
       const lotStatus = row.lot_status ?? "LIBERE";
       if (lotStatus !== params.body.quality_status) {
@@ -1074,9 +1096,10 @@ export async function repoCreateOfReceipt(params: {
         const ins = await client.query<{ id: string }>(
           `
             INSERT INTO public.lots (
-              article_id, lot_code, lot_status, lot_status_note, notes, created_by, updated_by
+              article_id, lot_code, lot_status, lot_status_note, notes,
+              piece_technique_version_id, created_by, updated_by
             )
-            VALUES ($1::uuid,$2,$3,$4,$5,$6,$6)
+            VALUES ($1::uuid,$2,$3,$4,$5,$6::uuid,$7,$7)
             RETURNING id::text AS id
           `,
           [
@@ -1085,6 +1108,7 @@ export async function repoCreateOfReceipt(params: {
             params.body.quality_status,
             params.body.quality_reason ?? null,
             params.body.commentaire ?? null,
+            ofRow.piece_technique_version_id,
             params.audit.user_id,
           ]
         );

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -1986,6 +1986,49 @@ async function reserveInventorySessionNo(client: Pick<PoolClient, "query">): Pro
   return inventorySessionNoFromSeq(n);
 }
 
+function inventoryScopeSegment(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toUpperCase()
+    .replace(/[^A-Z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}
+
+async function reserveInventorySessionNoForScope(
+  client: Pick<PoolClient, "query">,
+  body: CreateInventorySessionBodyDTO
+): Promise<string> {
+  if (!body.scope_magasin_id) return reserveInventorySessionNo(client);
+  const scope = await client.query<{ magasin_code: string; rayon_code: string | null }>(
+    `SELECT
+       COALESCE(magasin.code, magasin.code_magasin)::text AS magasin_code,
+       emplacement.code::text AS rayon_code
+     FROM public.magasins magasin
+     LEFT JOIN public.emplacements emplacement
+       ON emplacement.id = $2::bigint AND emplacement.magasin_id = magasin.id
+     WHERE magasin.id = $1::uuid`,
+    [body.scope_magasin_id, body.scope_emplacement_id ?? null]
+  );
+  const row = scope.rows[0];
+  if (!row) return reserveInventorySessionNo(client);
+  const parts = [row.magasin_code, row.rayon_code, body.scope_article_prefix]
+    .map((part) => inventoryScopeSegment(part ?? ""))
+    .filter(Boolean);
+  if (parts.length < 2) return reserveInventorySessionNo(client);
+  const base = parts.join("/");
+  await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [`inventory-session:${base}`]);
+  const existing = await client.query<{ total: number }>(
+    `SELECT COUNT(*)::int AS total
+     FROM public.stock_inventory_sessions
+     WHERE session_no = $1 OR session_no LIKE $1 || '-%'`,
+    [base]
+  );
+  const total = existing.rows[0]?.total ?? 0;
+  return total === 0 ? base : `${base}-${String(total + 1).padStart(2, "0")}`;
+}
+
 function parseEffectiveAt(raw: string | null | undefined): Date {
   if (!raw) return new Date();
   const dt = new Date(raw);
@@ -5765,6 +5808,15 @@ export async function repoListConsolidatedInventory(
   const fromSql = `
     FROM public.v_stock_availability_225 b
     JOIN public.articles a ON a.id = b.article_id
+    LEFT JOIN public.pieces_techniques piece ON piece.id = a.piece_technique_id
+    LEFT JOIN LATERAL (
+      SELECT version.plan_reference, version.indice
+      FROM public.piece_technique_versions version
+      WHERE version.piece_technique_id = piece.id
+      ORDER BY (version.statut = 'APPLICABLE') DESC, version.is_current DESC,
+               version.version_interne DESC, version.created_at DESC
+      LIMIT 1
+    ) article_version ON true
     JOIN public.warehouses w ON w.id = b.warehouse_id
     JOIN public.locations loc ON loc.id = b.location_id
     LEFT JOIN public.emplacements e ON e.location_id = b.location_id
@@ -5778,6 +5830,36 @@ export async function repoListConsolidatedInventory(
         AND movement.status = 'POSTED'
         AND movement.source_document_type = 'CERP_HISTORICAL_OPENING'
     ) opening ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT
+        ARRAY(
+          SELECT DISTINCT reference_value
+          FROM (
+            SELECT reference.reference_value
+            FROM public.stock_lot_trace_references reference
+            WHERE reference.lot_id = b.lot_id AND reference.reference_type = 'OF'
+            UNION ALL
+            SELECT fabrication.numero
+            FROM public.of_output_lots output
+            JOIN public.ordres_fabrication fabrication ON fabrication.id = output.of_id
+            WHERE output.lot_id = b.lot_id
+          ) values_of(reference_value)
+          WHERE reference_value IS NOT NULL AND btrim(reference_value) <> ''
+          ORDER BY reference_value
+        ) AS of_references,
+        ARRAY(
+          SELECT DISTINCT reference.reference_value
+          FROM public.stock_lot_trace_references reference
+          WHERE reference.lot_id = b.lot_id AND reference.reference_type = 'MP_LOT'
+          ORDER BY reference.reference_value
+        ) AS mp_references,
+        ARRAY(
+          SELECT DISTINCT reference.reference_value
+          FROM public.stock_lot_trace_references reference
+          WHERE reference.lot_id = b.lot_id AND reference.reference_type = 'TRAITEMENT_LOT'
+          ORDER BY reference.reference_value
+        ) AS tr_references
+    ) traceability ON b.lot_id IS NOT NULL
     LEFT JOIN public.articles_matiere article_material ON article_material.article_id = a.id
     LEFT JOIN public.stock_nuances material_nuance ON material_nuance.id = article_material.nuance_id
     LEFT JOIN public.stock_etats material_etat ON material_etat.id = article_material.etat_id
@@ -5788,6 +5870,9 @@ export async function repoListConsolidatedInventory(
   const rows = await db.query<InventoryRow>(
     `SELECT
        b.article_id::text AS article_id, a.code AS article_code, a.designation AS article_designation,
+       article_version.plan_reference AS article_reference,
+       article_version.indice AS piece_indice,
+       piece.code_client AS client_code,
        a.article_category::text AS material_article_category,
        a.designation AS material_designation,
        COALESCE(article_material.family_code, a.family_code)::text AS material_profile_code,
@@ -5808,7 +5893,11 @@ export async function repoListConsolidatedInventory(
        COALESCE(m.id, '00000000-0000-0000-0000-000000000000')::text AS magasin_id,
        COALESCE(m.code, m.code_magasin, w.code)::text AS magasin_code,
        COALESCE(e.code, loc.code)::text AS rayon_code,
-       b.lot_id::text AS lot_id, l.lot_code, l.stock_trace_code::text AS stock_trace_code, l.qr_payload,
+       b.lot_id::text AS lot_id, l.lot_code,
+       COALESCE(traceability.of_references, ARRAY[]::text[]) AS of_references,
+       COALESCE(traceability.mp_references, ARRAY[]::text[]) AS mp_references,
+       COALESCE(traceability.tr_references, ARRAY[]::text[]) AS tr_references,
+       l.stock_trace_code::text AS stock_trace_code, l.qr_payload,
        CASE WHEN ${effectiveScopeSql} = 'OLD' THEN opening.qty_initial ELSE NULL END::float8 AS qty_initial,
        b.qty_total::float8 AS qty_total, b.qty_reserved::float8 AS qty_reserved,
        b.qty_available::float8 AS qty_available, b.updated_at::text AS updated_at
@@ -5968,11 +6057,27 @@ export async function repoCreateHistoricalImport(body: HistoricalImportBodyDTO, 
       shelf = body.client_number.trim();
     }
     await ensureArticleStockManaged(client, articleId);
+    const historicalTechnicalVersionId = body.kind === "PF"
+      ? (await client.query<{ id: string }>(
+          `SELECT version.id::text AS id
+           FROM public.articles article
+           JOIN public.piece_technique_versions version
+             ON version.piece_technique_id = article.piece_technique_id
+           WHERE article.id = $1::uuid
+           ORDER BY
+             (version.statut = 'APPLICABLE') DESC,
+             version.is_current DESC,
+             version.version_interne DESC,
+             version.created_at DESC
+           LIMIT 1`,
+          [articleId]
+        )).rows[0]?.id ?? null
+      : null;
     const position = await ensureHistoricalPositionTx(client, body.kind, shelf, audit);
     const lotCode = await generateTransactionalBusinessCode(client, { prefix: "LOT" });
     const traceSequence = await client.query<{ value: string }>(`SELECT nextval('public.stock_trace_code_446_seq')::text AS value`);
     const trace = (traceSequence.rows[0]?.value ?? "0").padStart(6, "0");
-    const lot = await client.query<{ id: string }>(`INSERT INTO public.lots (article_id, lot_code, supplier_lot_code, notes, stock_trace_code, qr_payload, origin_stock_scope, source_scope, stock_scope, created_by, updated_by) VALUES ($1::uuid,$2,$3,$4,$5,$6,'OLD','OLD','OLD',$7,$7) RETURNING id::text AS id`, [articleId, lotCode, body.kind === "MP" ? body.lot_number : null, body.notes ?? null, trace, `CERP-STOCK:${trace}`, audit.user_id]);
+    const lot = await client.query<{ id: string }>(`INSERT INTO public.lots (article_id, lot_code, supplier_lot_code, notes, stock_trace_code, qr_payload, origin_stock_scope, source_scope, stock_scope, piece_technique_version_id, created_by, updated_by) VALUES ($1::uuid,$2,$3,$4,$5,$6,'OLD','OLD','OLD',$7::uuid,$8,$8) RETURNING id::text AS id`, [articleId, lotCode, body.kind === "MP" ? body.lot_number : null, body.notes ?? null, trace, `CERP-STOCK:${trace}`, historicalTechnicalVersionId, audit.user_id]);
     const lotId = lot.rows[0]?.id;
     if (!lotId) throw new Error("Unable to create historical lot");
     const refs: Array<["OF" | "MP_LOT" | "TRAITEMENT_LOT", string[]]> = body.kind === "PF"
@@ -6014,6 +6119,11 @@ export async function repoListBalances(filters: ListBalancesQueryDTO): Promise<P
   if (filters.lot_id) where.push(`b.lot_id = ${push(filters.lot_id)}::uuid`);
   if (filters.lot_status) where.push(`b.lot_status = ${push(filters.lot_status)}`);
   if (filters.only_available === true) where.push(`b.qty_available > 0`);
+  if (filters.physical_state === "present") where.push(`b.qty_total > 0`);
+  if (filters.physical_state === "archived") where.push(`b.lot_id IS NOT NULL AND b.qty_total <= 0`);
+  if (filters.piece_technique_version_id) {
+    where.push(`lot.piece_technique_version_id = ${push(filters.piece_technique_version_id)}::uuid`);
+  }
   if (filters.warehouse_id) where.push(`b.warehouse_id = ${push(filters.warehouse_id)}::uuid`);
   if (filters.location_id) where.push(`b.location_id = ${push(filters.location_id)}::uuid`);
   if (filters.q && filters.q.trim().length > 0) {
@@ -6034,6 +6144,7 @@ export async function repoListBalances(filters: ListBalancesQueryDTO): Promise<P
       FROM public.v_stock_availability_225 b
       JOIN public.articles a ON a.id = b.article_id
       LEFT JOIN public.emplacements e ON e.location_id = b.location_id
+      LEFT JOIN public.lots lot ON lot.id = b.lot_id
       ${whereSql}
     `,
     values
@@ -6054,6 +6165,9 @@ export async function repoListBalances(filters: ListBalancesQueryDTO): Promise<P
       e.name AS emplacement_name,
       b.lot_id::text AS lot_id,
       b.lot_code,
+      lot.piece_technique_version_id::text AS piece_technique_version_id,
+      technical_version.indice AS piece_technique_indice,
+      technical_version.plan_reference AS piece_plan_reference,
       COALESCE(traceability.of_references, ARRAY[]::text[]) AS of_references,
       COALESCE(traceability.mp_references, ARRAY[]::text[]) AS mp_references,
       COALESCE(traceability.tr_references, ARRAY[]::text[]) AS tr_references,
@@ -6083,6 +6197,8 @@ export async function repoListBalances(filters: ListBalancesQueryDTO): Promise<P
     LEFT JOIN public.emplacements e ON e.location_id = b.location_id
     LEFT JOIN public.magasins m ON m.id = e.magasin_id
     LEFT JOIN public.lots lot ON lot.id = b.lot_id
+    LEFT JOIN public.piece_technique_versions technical_version
+      ON technical_version.id = lot.piece_technique_version_id
     LEFT JOIN LATERAL (
       SELECT
         ARRAY(
@@ -6442,6 +6558,16 @@ export async function repoListMovements(filters: ListMovementsQueryDTO): Promise
   if (filters.movement_type) where.push(`m.movement_type = ${push(filters.movement_type)}::public.movement_type`);
   if (filters.status) where.push(`m.status = ${push(filters.status)}`);
   if (filters.article_id) where.push(`m.article_id = ${push(filters.article_id)}::uuid`);
+  if (filters.piece_technique_version_id) {
+    const versionParam = push(filters.piece_technique_version_id);
+    where.push(`EXISTS (
+      SELECT 1
+      FROM public.stock_movement_lines version_line
+      JOIN public.lots version_lot ON version_lot.id = version_line.lot_id
+      WHERE version_line.movement_id = m.id
+        AND version_lot.piece_technique_version_id = ${versionParam}::uuid
+    )`);
+  }
   if (filters.from) where.push(`m.effective_at >= ${push(filters.from)}::timestamptz`);
   if (filters.to) where.push(`m.effective_at <= ${push(filters.to)}::timestamptz`);
 
@@ -6461,11 +6587,23 @@ export async function repoListMovements(filters: ListMovementsQueryDTO): Promise
       m.article_id::text AS article_id,
       a.code AS article_code,
       a.designation AS article_designation,
+      COALESCE(technical_version.plan_reference, latest_version.plan_reference) AS article_reference,
+      technical_version.id::text AS piece_technique_version_id,
+      technical_version.indice AS piece_technique_indice,
+      CASE
+        WHEN m.movement_type::text = 'IN' THEN 'IN'
+        WHEN m.movement_type::text IN ('OUT','SCRAP','DEPRECIATE') THEN 'OUT'
+        WHEN m.movement_type::text = 'TRANSFER' THEN 'TRANSFER'
+        WHEN m.movement_type::text IN ('ADJUST','ADJUSTMENT') AND m.qty < 0 THEN 'OUT'
+        WHEN m.movement_type::text IN ('ADJUST','ADJUSTMENT') AND m.qty >= 0 THEN 'IN'
+        ELSE NULL
+      END::text AS direction,
       ABS(m.qty)::float8 AS qty_total,
       m.effective_at::text AS effective_at,
       m.posted_at::text AS posted_at,
       m.source_document_type,
       m.source_document_id,
+      COALESCE(inventory_session.session_no, delivery.numero, fabrication.numero, m.source_document_id) AS source_document_no,
       m.reason_code,
       m.correlation_id::text AS correlation_id,
       m.reversal_of_id::text AS reversal_of_id,
@@ -6474,6 +6612,39 @@ export async function repoListMovements(filters: ListMovementsQueryDTO): Promise
       COALESCE(ml.lines_count, 0)::int AS lines_count
     FROM public.stock_movements m
     JOIN public.articles a ON a.id = m.article_id
+    LEFT JOIN LATERAL (
+      SELECT CASE
+        WHEN COUNT(DISTINCT resolved.version_id) = 1
+          THEN (array_agg(DISTINCT resolved.version_id))[1]
+        ELSE NULL
+      END AS version_id
+      FROM (
+        SELECT lot.piece_technique_version_id AS version_id
+        FROM public.stock_movement_lines line
+        JOIN public.lots lot ON lot.id = line.lot_id
+        WHERE line.movement_id = m.id
+          AND lot.piece_technique_version_id IS NOT NULL
+      ) resolved
+    ) movement_version ON true
+    LEFT JOIN public.piece_technique_versions technical_version
+      ON technical_version.id = movement_version.version_id
+    LEFT JOIN LATERAL (
+      SELECT version.plan_reference
+      FROM public.piece_technique_versions version
+      WHERE version.piece_technique_id = a.piece_technique_id
+      ORDER BY (version.statut = 'APPLICABLE') DESC, version.is_current DESC,
+               version.version_interne DESC, version.created_at DESC
+      LIMIT 1
+    ) latest_version ON true
+    LEFT JOIN public.stock_inventory_sessions inventory_session
+      ON m.source_document_type = 'stock_inventory_session'
+     AND inventory_session.id::text = m.source_document_id
+    LEFT JOIN public.bon_livraison delivery
+      ON m.source_document_type = 'BON_LIVRAISON'
+     AND delivery.id::text = m.source_document_id
+    LEFT JOIN public.ordres_fabrication fabrication
+      ON m.source_document_type = 'OF'
+     AND fabrication.id::text = m.source_document_id
     LEFT JOIN (
       SELECT movement_id, COUNT(*)::int AS lines_count
       FROM public.stock_movement_lines
@@ -8695,6 +8866,9 @@ export async function repoListInventorySessions(
       s.scope_emplacement_id::int AS scope_emplacement_id,
       s.scope_article_id::text AS scope_article_id,
       s.scope_article_category,
+      s.scope_article_prefix,
+      COALESCE(scope_magasin.code, scope_magasin.code_magasin)::text AS scope_magasin_code,
+      scope_emplacement.code::text AS scope_rayon_code,
       s.blind_count,
       s.requires_second_count,
       s.snapshot_at::text AS snapshot_at,
@@ -8709,13 +8883,25 @@ export async function repoListInventorySessions(
       s.updated_at::text AS updated_at,
       s.created_at::text AS created_at,
       COALESCE(agg.adjustment_movements_count, 0)::int AS adjustment_movements_count,
-      last.last_adjustment_movement_id
+      last.last_adjustment_movement_id,
+      COALESCE(progress.lines_count, 0)::int AS lines_count,
+      COALESCE(progress.counted_lines_count, 0)::int AS counted_lines_count
     FROM public.stock_inventory_sessions s
+    LEFT JOIN public.magasins scope_magasin ON scope_magasin.id = s.scope_magasin_id
+    LEFT JOIN public.emplacements scope_emplacement ON scope_emplacement.id = s.scope_emplacement_id
     LEFT JOIN (
       SELECT session_id, COUNT(*)::int AS adjustment_movements_count
       FROM public.stock_inventory_session_movements
       GROUP BY session_id
     ) agg ON agg.session_id = s.id
+    LEFT JOIN (
+      SELECT snapshot.session_id,
+             COUNT(*)::int AS lines_count,
+             COUNT(DISTINCT event.snapshot_line_id)::int AS counted_lines_count
+      FROM public.stock_inventory_snapshot_lines snapshot
+      LEFT JOIN public.stock_inventory_count_events event ON event.snapshot_line_id = snapshot.id
+      GROUP BY snapshot.session_id
+    ) progress ON progress.session_id = s.id
     LEFT JOIN LATERAL (
       SELECT sim.stock_movement_id::text AS last_adjustment_movement_id
       FROM public.stock_inventory_session_movements sim
@@ -8755,7 +8941,7 @@ export async function repoCreateInventorySession(
       return existing.session;
     }
 
-    const sessionNo = await reserveInventorySessionNo(client);
+    const sessionNo = await reserveInventorySessionNoForScope(client, body);
     const ins = await client.query<{ id: string }>(
       `
         INSERT INTO public.stock_inventory_sessions (
@@ -8767,13 +8953,14 @@ export async function repoCreateInventorySession(
           scope_emplacement_id,
           scope_article_id,
           scope_article_category,
+          scope_article_prefix,
           blind_count,
           requires_second_count,
           correlation_id,
           created_by,
           updated_by
         )
-        VALUES ($1,'DRAFT',NULL,$2,$3::uuid,$4::bigint,$5::uuid,$6,$7,$8,$9::uuid,$10,$10)
+        VALUES ($1,'DRAFT',NULL,$2,$3::uuid,$4::bigint,$5::uuid,$6,$7,$8,$9,$10::uuid,$11,$11)
         RETURNING id::text AS id
       `,
       [
@@ -8783,6 +8970,7 @@ export async function repoCreateInventorySession(
         body.scope_emplacement_id ?? null,
         body.scope_article_id ?? null,
         body.scope_article_category ?? null,
+        body.scope_article_prefix ?? null,
         body.blind_count,
         body.requires_second_count,
         command.correlation_id,
@@ -8804,6 +8992,7 @@ export async function repoCreateInventorySession(
           emplacement_id: body.scope_emplacement_id ?? null,
           article_id: body.scope_article_id ?? null,
           article_category: body.scope_article_category ?? null,
+          article_prefix: body.scope_article_prefix ?? null,
         },
       },
     });
@@ -8858,6 +9047,7 @@ export async function repoStartInventorySession(
       scope_emplacement_id: number | null;
       scope_article_id: string | null;
       scope_article_category: string | null;
+      scope_article_prefix: string | null;
     }>(
       `
         SELECT
@@ -8867,7 +9057,8 @@ export async function repoStartInventorySession(
           scope_magasin_id::text AS scope_magasin_id,
           scope_emplacement_id::int AS scope_emplacement_id,
           scope_article_id::text AS scope_article_id,
-          scope_article_category
+          scope_article_category,
+          scope_article_prefix
         FROM public.stock_inventory_sessions
         WHERE id = $1::uuid
         FOR UPDATE
@@ -8921,7 +9112,9 @@ export async function repoStartInventorySession(
         SELECT
           $1::uuid,
           row_number() OVER (
-            ORDER BY article.code, magasin.id, emplacement.code, availability.lot_code NULLS FIRST
+            ORDER BY COALESCE(article_version.plan_reference, article.code),
+                     article_version.indice, magasin.id, emplacement.code,
+                     availability.lot_code NULLS FIRST
           )::int,
           availability.article_id,
           magasin.id,
@@ -8936,13 +9129,27 @@ export async function repoStartInventorySession(
         JOIN public.emplacements emplacement ON emplacement.location_id = availability.location_id
         JOIN public.magasins magasin ON magasin.id = emplacement.magasin_id
         JOIN public.units unit ON unit.id = availability.unit_id
+        LEFT JOIN public.pieces_techniques piece ON piece.id = article.piece_technique_id
+        LEFT JOIN LATERAL (
+          SELECT version.plan_reference, version.indice
+          FROM public.piece_technique_versions version
+          WHERE version.piece_technique_id = piece.id
+          ORDER BY (version.statut = 'APPLICABLE') DESC, version.is_current DESC,
+                   version.version_interne DESC, version.created_at DESC
+          LIMIT 1
+        ) article_version ON true
         WHERE availability.managed_in_stock = true
+          AND availability.qty_on_hand > 0
           AND magasin.is_active = true
           AND emplacement.is_active = true
           AND ($2::uuid IS NULL OR magasin.id = $2::uuid)
           AND ($3::bigint IS NULL OR emplacement.id = $3::bigint)
           AND ($4::uuid IS NULL OR article.id = $4::uuid)
           AND ($5::text IS NULL OR article.article_category::text = $5::text)
+          AND (
+            $6::text IS NULL
+            OR COALESCE(article_version.plan_reference, article.code) ILIKE $6::text || '%'
+          )
         RETURNING id::text AS id
       `,
       [
@@ -8951,6 +9158,7 @@ export async function repoStartInventorySession(
         row.scope_emplacement_id,
         row.scope_article_id,
         row.scope_article_category,
+        row.scope_article_prefix,
       ]
     );
     if (!inserted.rows.length) {
@@ -9015,6 +9223,9 @@ async function repoGetInventorySessionRow(id: string): Promise<StockInventorySes
         s.scope_emplacement_id::int AS scope_emplacement_id,
         s.scope_article_id::text AS scope_article_id,
         s.scope_article_category,
+        s.scope_article_prefix,
+        COALESCE(scope_magasin.code, scope_magasin.code_magasin)::text AS scope_magasin_code,
+        scope_emplacement.code::text AS scope_rayon_code,
         s.blind_count,
         s.requires_second_count,
         s.snapshot_at::text AS snapshot_at,
@@ -9029,13 +9240,25 @@ async function repoGetInventorySessionRow(id: string): Promise<StockInventorySes
         s.updated_at::text AS updated_at,
         s.created_at::text AS created_at,
         COALESCE(agg.adjustment_movements_count, 0)::int AS adjustment_movements_count,
-        last.last_adjustment_movement_id
+        last.last_adjustment_movement_id,
+        COALESCE(progress.lines_count, 0)::int AS lines_count,
+        COALESCE(progress.counted_lines_count, 0)::int AS counted_lines_count
       FROM public.stock_inventory_sessions s
+      LEFT JOIN public.magasins scope_magasin ON scope_magasin.id = s.scope_magasin_id
+      LEFT JOIN public.emplacements scope_emplacement ON scope_emplacement.id = s.scope_emplacement_id
       LEFT JOIN (
         SELECT session_id, COUNT(*)::int AS adjustment_movements_count
         FROM public.stock_inventory_session_movements
         GROUP BY session_id
       ) agg ON agg.session_id = s.id
+      LEFT JOIN (
+        SELECT snapshot.session_id,
+               COUNT(*)::int AS lines_count,
+               COUNT(DISTINCT event.snapshot_line_id)::int AS counted_lines_count
+        FROM public.stock_inventory_snapshot_lines snapshot
+        LEFT JOIN public.stock_inventory_count_events event ON event.snapshot_line_id = snapshot.id
+        GROUP BY snapshot.session_id
+      ) progress ON progress.session_id = s.id
       LEFT JOIN LATERAL (
         SELECT sim.stock_movement_id::text AS last_adjustment_movement_id
         FROM public.stock_inventory_session_movements sim
@@ -9099,6 +9322,9 @@ async function queryInventorySessionLines(
         snapshot.article_id::text AS article_id,
         article.code AS article_code,
         article.designation AS article_designation,
+        COALESCE(technical_version.plan_reference, latest_version.plan_reference) AS article_reference,
+        technical_version.id::text AS piece_technique_version_id,
+        technical_version.indice AS piece_technique_indice,
         snapshot.magasin_id::text AS magasin_id,
         COALESCE(magasin.code, magasin.code_magasin)::text AS magasin_code,
         COALESCE(magasin.name, magasin.libelle)::text AS magasin_name,
@@ -9107,6 +9333,9 @@ async function queryInventorySessionLines(
         emplacement.name AS emplacement_name,
         snapshot.lot_id::text AS lot_id,
         lot.lot_code AS lot_code,
+        COALESCE(traceability.of_references, ARRAY[]::text[]) AS of_references,
+        COALESCE(traceability.mp_references, ARRAY[]::text[]) AS mp_references,
+        COALESCE(traceability.tr_references, ARRAY[]::text[]) AS tr_references,
         latest_count.counted_qty::float8 AS counted_qty,
         CASE
           WHEN session.blind_count = true AND session.status = 'OPEN' THEN NULL
@@ -9128,6 +9357,46 @@ async function queryInventorySessionLines(
       JOIN public.magasins magasin ON magasin.id = snapshot.magasin_id
       JOIN public.emplacements emplacement ON emplacement.id = snapshot.emplacement_id
       LEFT JOIN public.lots lot ON lot.id = snapshot.lot_id
+      LEFT JOIN public.piece_technique_versions technical_version
+        ON technical_version.id = lot.piece_technique_version_id
+      LEFT JOIN LATERAL (
+        SELECT version.plan_reference
+        FROM public.piece_technique_versions version
+        WHERE version.piece_technique_id = article.piece_technique_id
+        ORDER BY (version.statut = 'APPLICABLE') DESC, version.is_current DESC,
+                 version.version_interne DESC, version.created_at DESC
+        LIMIT 1
+      ) latest_version ON true
+      LEFT JOIN LATERAL (
+        SELECT
+          ARRAY(
+            SELECT DISTINCT reference_value
+            FROM (
+              SELECT reference.reference_value
+              FROM public.stock_lot_trace_references reference
+              WHERE reference.lot_id = snapshot.lot_id AND reference.reference_type = 'OF'
+              UNION ALL
+              SELECT fabrication.numero
+              FROM public.of_output_lots output
+              JOIN public.ordres_fabrication fabrication ON fabrication.id = output.of_id
+              WHERE output.lot_id = snapshot.lot_id
+            ) values_of(reference_value)
+            WHERE reference_value IS NOT NULL AND btrim(reference_value) <> ''
+            ORDER BY reference_value
+          ) AS of_references,
+          ARRAY(
+            SELECT DISTINCT reference.reference_value
+            FROM public.stock_lot_trace_references reference
+            WHERE reference.lot_id = snapshot.lot_id AND reference.reference_type = 'MP_LOT'
+            ORDER BY reference.reference_value
+          ) AS mp_references,
+          ARRAY(
+            SELECT DISTINCT reference.reference_value
+            FROM public.stock_lot_trace_references reference
+            WHERE reference.lot_id = snapshot.lot_id AND reference.reference_type = 'TRAITEMENT_LOT'
+            ORDER BY reference.reference_value
+          ) AS tr_references
+      ) traceability ON snapshot.lot_id IS NOT NULL
       LEFT JOIN public.stock_inventory_lines materialized
         ON materialized.session_id = snapshot.session_id
        AND materialized.article_id = snapshot.article_id
@@ -9265,6 +9534,65 @@ export async function repoUpsertInventoryLine(
         422,
         "INVENTORY_REASON_REQUIRED",
         "A reason code is required for an inventory discrepancy"
+      );
+    }
+    const traceUpdates = [
+      ["OF", body.of_references] as const,
+      ["MP_LOT", body.mp_references] as const,
+      ["TRAITEMENT_LOT", body.tr_references] as const,
+    ].filter((entry): entry is readonly ["OF" | "MP_LOT" | "TRAITEMENT_LOT", string[]] => entry[1] !== undefined);
+    if (traceUpdates.length > 0 && !body.lot_id) {
+      throw new HttpError(
+        422,
+        "INVENTORY_LOT_REQUIRED_FOR_TRACEABILITY",
+        "Les références OF, MP et traitement nécessitent un lot."
+      );
+    }
+    if (traceUpdates.length > 0 && body.lot_id) {
+      const previous = await client.query<{ reference_type: string; reference_value: string }>(
+        `SELECT reference_type, reference_value
+         FROM public.stock_lot_trace_references
+         WHERE lot_id = $1::uuid
+           AND reference_type = ANY($2::text[])
+         ORDER BY reference_type, reference_value`,
+        [body.lot_id, traceUpdates.map(([type]) => type)]
+      );
+      for (const [referenceType, references] of traceUpdates) {
+        await client.query(
+          `DELETE FROM public.stock_lot_trace_references
+           WHERE lot_id = $1::uuid AND reference_type = $2`,
+          [body.lot_id, referenceType]
+        );
+        const normalizedReferences = [...new Set(references.map((reference) => reference.trim()).filter(Boolean))];
+        for (const reference of normalizedReferences) {
+          await client.query(
+            `INSERT INTO public.stock_lot_trace_references
+               (lot_id, reference_type, reference_value, created_by)
+             VALUES ($1::uuid,$2,$3,$4)
+             ON CONFLICT DO NOTHING`,
+            [body.lot_id, referenceType, reference, audit.user_id]
+          );
+        }
+      }
+      await client.query(
+        `INSERT INTO public.stock_lot_event_log (
+           lot_id, event_type, old_values, new_values,
+           actor_user_id, correlation_id
+         )
+         VALUES ($1::uuid,'INVENTORY_TRACEABILITY_CORRECTED',$2::jsonb,$3::jsonb,$4,$5::uuid)`,
+        [
+          body.lot_id,
+          JSON.stringify({ references: previous.rows, inventory_session_id: sessionId }),
+          JSON.stringify({
+            references: traceUpdates.map(([reference_type, references]) => ({
+              reference_type,
+              values: [...new Set(references.map((reference) => reference.trim()).filter(Boolean))],
+            })),
+            inventory_session_id: sessionId,
+          }),
+          audit.user_id,
+          command.correlation_id,
+        ]
       );
     }
     if (body.count_round === 2) {

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -9,7 +9,9 @@ export type Paginated<T> = {
 export type HistoricalStockImport = { article_id: string; lot_id: string; movement_id: string; stock_trace_code: string; qr_payload: string; replayed: boolean };
 export type ConsolidatedInventoryRow = {
   article_id: string; article_code: string; article_designation: string; old_material_definition: string | null; scope: "OLD" | "NEW";
+  article_reference: string | null; piece_indice: string | null; client_code: string | null;
   magasin_id: string; magasin_code: string; rayon_code: string; lot_id: string | null; lot_code: string | null;
+  of_references: string[]; mp_references: string[]; tr_references: string[];
   stock_trace_code: string | null; qr_payload: string | null; qty_initial: number | null; qty_total: number; qty_reserved: number; qty_available: number;
   updated_at: string;
 };
@@ -412,6 +414,9 @@ export type StockBalanceRow = {
   emplacement_name: string | null;
   lot_id: string | null;
   lot_code: string | null;
+  piece_technique_version_id: string | null;
+  piece_technique_indice: string | null;
+  piece_plan_reference: string | null;
   of_references: string[];
   mp_references: string[];
   tr_references: string[];
@@ -456,11 +461,16 @@ export type StockMovementListItem = {
   article_id: string;
   article_code: string;
   article_designation: string;
+  article_reference: string | null;
+  piece_technique_version_id: string | null;
+  piece_technique_indice: string | null;
+  direction: "IN" | "OUT" | "TRANSFER" | null;
   qty_total: number;
   effective_at: string;
   posted_at: string | null;
   source_document_type: string | null;
   source_document_id: string | null;
+  source_document_no: string | null;
   reason_code: string | null;
   correlation_id: string | null;
   reversal_of_id: string | null;
@@ -689,6 +699,9 @@ export type StockInventorySessionListItem = {
   scope_emplacement_id: number | null;
   scope_article_id: string | null;
   scope_article_category: ArticleCategory | null;
+  scope_article_prefix: string | null;
+  scope_magasin_code: string | null;
+  scope_rayon_code: string | null;
   blind_count: boolean;
   requires_second_count: boolean;
   snapshot_at: string | null;
@@ -704,6 +717,8 @@ export type StockInventorySessionListItem = {
   created_at: string;
   adjustment_movements_count: number;
   last_adjustment_movement_id: string | null;
+  lines_count: number;
+  counted_lines_count: number;
 };
 
 export type StockInventorySessionLine = {
@@ -714,6 +729,9 @@ export type StockInventorySessionLine = {
   article_id: string;
   article_code: string;
   article_designation: string;
+  article_reference: string | null;
+  piece_technique_version_id: string | null;
+  piece_technique_indice: string | null;
   magasin_id: string;
   magasin_code: string;
   magasin_name: string;
@@ -722,6 +740,9 @@ export type StockInventorySessionLine = {
   emplacement_name: string | null;
   lot_id: string | null;
   lot_code: string | null;
+  of_references: string[];
+  mp_references: string[];
+  tr_references: string[];
   counted_qty: number | null;
   qty_on_hand: number | null;
   delta_qty: number | null;

--- a/src/module/stock/validators/stock-225.validators.test.ts
+++ b/src/module/stock/validators/stock-225.validators.test.ts
@@ -205,6 +205,7 @@ describe("#225 stock validators", () => {
   }> = [
     { name: "magasin scope", body: { scope_magasin_id: UUID_A }, valid: true },
     { name: "article scope", body: { scope_article_id: UUID_A }, valid: true },
+    { name: "article reference prefix", body: { scope_article_prefix: "160" }, valid: true },
     { name: "category scope", body: { scope_article_category: "matiere" }, valid: true },
     {
       name: "emplacement with parent",
@@ -242,6 +243,26 @@ describe("#225 stock validators", () => {
     expect(
       upsertInventoryLineSchema.safeParse({
         body: { ...base, expected_session_version: 0 },
+      }).success
+    ).toBe(false);
+    expect(
+      upsertInventoryLineSchema.safeParse({
+        body: {
+          ...base,
+          lot_id: UUID_C,
+          of_references: ["OF-2026-001"],
+          mp_references: ["MP-7075-001"],
+          tr_references: ["TR-ANO-001"],
+        },
+      }).success
+    ).toBe(true);
+    expect(
+      upsertInventoryLineSchema.safeParse({
+        body: {
+          ...base,
+          lot_id: UUID_C,
+          of_references: ["1", "2", "3", "4", "5"],
+        },
       }).success
     ).toBe(false);
   });

--- a/src/module/stock/validators/stock.validators.ts
+++ b/src/module/stock/validators/stock.validators.ts
@@ -758,6 +758,8 @@ export const listBalancesQuerySchema = z.object({
   lot_id: uuid.optional(),
   lot_status: z.enum(["LIBERE", "EN_ATTENTE", "QUARANTAINE", "BLOQUE"]).optional(),
   only_available: z.preprocess(parseBoolean, z.boolean().optional()),
+  physical_state: z.enum(["present", "archived"]).optional(),
+  piece_technique_version_id: uuid.optional(),
   warehouse_id: uuid.optional(),
   location_id: uuid.optional(),
   page: z.coerce.number().int().min(1).optional().default(1),
@@ -832,6 +834,7 @@ export const listMovementsQuerySchema = z.object({
   movement_type: stockMovementTypeSchema.optional(),
   status: stockMovementStatusSchema.optional(),
   article_id: uuid.optional(),
+  piece_technique_version_id: uuid.optional(),
   from: z.string().trim().optional(),
   to: z.string().trim().optional(),
   page: z.coerce.number().int().min(1).optional().default(1),
@@ -994,6 +997,7 @@ export const createInventorySessionSchema = z.object({
       scope_emplacement_id: z.coerce.number().int().positive().optional().nullable(),
       scope_article_id: uuid.optional().nullable(),
       scope_article_category: articleCategorySchema.optional().nullable(),
+      scope_article_prefix: z.string().trim().min(1).max(120).optional().nullable(),
       blind_count: z.boolean().optional().default(false),
       requires_second_count: z.boolean().optional().default(false),
     })
@@ -1003,7 +1007,8 @@ export const createInventorySessionSchema = z.object({
         !body.scope_magasin_id &&
         !body.scope_emplacement_id &&
         !body.scope_article_id &&
-        !body.scope_article_category
+        !body.scope_article_category &&
+        !body.scope_article_prefix
       ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -1035,6 +1040,9 @@ export const upsertInventoryLineSchema = z.object({
       reason_code: z.string().trim().min(2).max(80).optional().nullable(),
       expected_session_version: z.coerce.number().int().positive(),
       note: z.string().trim().min(1).optional().nullable(),
+      of_references: z.array(z.string().trim().min(1).max(120)).max(4).optional(),
+      mp_references: z.array(z.string().trim().min(1).max(120)).max(4).optional(),
+      tr_references: z.array(z.string().trim().min(1).max(120)).max(4).optional(),
     })
     .strict(),
 });


### PR DESCRIPTION
Promotion de dev vers main du backend associé à la refonte, validée dans #689. Inclut une migration additive avec sauvegarde et validation avant application en production.

## Summary by Sourcery

Extend stock and inventory workflows with technical-version tracking, guided article-prefix scopes, richer traceability, and controlled correction safeguards.

New Features:
- Add revision-aware lot tracking and enforce technical-version compatibility when recording production receipts.
- Support guided inventory sessions scoped by article-reference prefix, with generated scope-aware identifiers and progress reporting.
- Expose technical-version metadata, stock physical-state filters, movement direction/source numbers, and lot traceability in stock and inventory views.
- Allow audited correction of OF, material-lot, and treatment-lot references during inventory counts.

Bug Fixes:
- Prevent production from being received into a lot associated with a different technical version.
- Backfill lot technical versions only when historical production links are unambiguous, leaving uncertain records unset.

Enhancements:
- Freeze the complete inventory scope, including article prefixes, after a session starts while preserving immutable completed sessions.
- Improve inventory line ordering and scope selection to prioritize applicable technical references and available stock.
- Add conservative rollback and read-only verification scripts for the additive database migration.

Deployment:
- Add an additive, idempotent production migration with guarded rollback and post-application verification checks.

Tests:
- Add contract coverage for reservation stock corrections and validation coverage for inventory prefixes and traceability references.