### PR TITLE
Release traçabilité BL et contrat entrée OLD

### DIFF
--- a/src/__tests__/stock-delivery-reservation.contract.test.ts
+++ b/src/__tests__/stock-delivery-reservation.contract.test.ts
@@ -139,6 +139,12 @@ describe("Commande → stock → OF receipt → delivery contracts", () => {
     expect(deliveryRepository).toMatch(/MP_SCAN_MISMATCH/);
     expect(deliveryRepository).toMatch(/TR_SCAN_MISMATCH/);
     expect(deliveryRepository).toMatch(/body\.of_number !== undefined && body\.of_number !== reservation\.of_numero/);
+    expect(deliveryRepository).toMatch(/stock_lot_trace_references/);
+    expect(deliveryRepository).toMatch(/reference_type = 'OF'/);
+    expect(deliveryRepository).toMatch(/reference_type = 'MP_LOT'/);
+    expect(deliveryRepository).toMatch(/reference_type = 'TRAITEMENT_LOT'/);
+    expect(deliveryRepository).toMatch(/public\.of_output_lots/);
+    expect(deliveryRepository).toMatch(/typeof snapshot\.of_number === "string"/);
     expect(deliveryRepository).toMatch(/requested_at = now\(\)/);
     expect(deliveryRepository).toMatch(/plan_reference/);
     expect(deliveryRepository).toMatch(/plan_index/);
@@ -147,6 +153,7 @@ describe("Commande → stock → OF receipt → delivery contracts", () => {
     expect(stockRepository).toMatch(/AS mp_references/);
     expect(stockRepository).toMatch(/AS tr_references/);
     expect(stockRepository).toMatch(/public\.of_output_lots/);
+    expect(stockRepository).toMatch(/lot_code: lotCode/);
     expect(livraisonRoutes).toMatch(/preparation-cart\/correct/);
     expect(livraisonRoutes).toMatch(/requireStockCorrectionPermission/);
     expect(livraisonRoutes).toMatch(/:id\/print-status/);

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -3520,9 +3520,9 @@ export async function repoListPreparationCart(filters: PreparationCartQueryDTO):
         e.id::bigint::int AS emplacement_id,
         e.code AS emplacement_code,
         r.of_id::bigint::int AS of_id,
-        ofa.numero AS of_numero,
-        l.mp_reference,
-        l.tr_reference,
+        COALESCE(NULLIF(ofa.numero, ''), lot_trace.of_reference) AS of_numero,
+        COALESCE(lot_trace.mp_reference, NULLIF(l.mp_reference, '')) AS mp_reference,
+        COALESCE(lot_trace.tr_reference, NULLIF(l.tr_reference, '')) AS tr_reference,
         v.created_at::text AS verified_at,
         v.snapshot AS verification_snapshot
       FROM public.stock_reservations r
@@ -3536,6 +3536,44 @@ export async function repoListPreparationCart(filters: PreparationCartQueryDTO):
       LEFT JOIN public.emplacements e ON e.location_id = r.location_id
       LEFT JOIN public.magasins m ON m.id = e.magasin_id
       LEFT JOIN public.ordres_fabrication ofa ON ofa.id = r.of_id
+      LEFT JOIN LATERAL (
+        SELECT
+          (
+            SELECT string_agg(reference_value, ' · ' ORDER BY reference_value)
+            FROM (
+              SELECT DISTINCT reference_value
+              FROM (
+                SELECT reference.reference_value
+                FROM public.stock_lot_trace_references reference
+                WHERE reference.lot_id = r.lot_id AND reference.reference_type = 'OF'
+                UNION ALL
+                SELECT fabrication.numero
+                FROM public.of_output_lots output
+                JOIN public.ordres_fabrication fabrication ON fabrication.id = output.of_id
+                WHERE output.lot_id = r.lot_id
+              ) values_of(reference_value)
+              WHERE reference_value IS NOT NULL AND btrim(reference_value) <> ''
+            ) distinct_of
+          ) AS of_reference,
+          (
+            SELECT string_agg(reference_value, ' · ' ORDER BY reference_value)
+            FROM (
+              SELECT DISTINCT reference.reference_value
+              FROM public.stock_lot_trace_references reference
+              WHERE reference.lot_id = r.lot_id AND reference.reference_type = 'MP_LOT'
+                AND btrim(reference.reference_value) <> ''
+            ) distinct_mp(reference_value)
+          ) AS mp_reference,
+          (
+            SELECT string_agg(reference_value, ' · ' ORDER BY reference_value)
+            FROM (
+              SELECT DISTINCT reference.reference_value
+              FROM public.stock_lot_trace_references reference
+              WHERE reference.lot_id = r.lot_id AND reference.reference_type = 'TRAITEMENT_LOT'
+                AND btrim(reference.reference_value) <> ''
+            ) distinct_tr(reference_value)
+          ) AS tr_reference
+      ) lot_trace ON r.lot_id IS NOT NULL
       LEFT JOIN LATERAL (
         SELECT pv.plan_reference
         FROM public.piece_technique_versions pv
@@ -3608,12 +3646,21 @@ export async function repoListPreparationCart(filters: PreparationCartQueryDTO):
         emplacement_id: row.emplacement_id === null ? null : Number(row.emplacement_id),
         emplacement_code: row.emplacement_code,
         of_id: row.of_id === null ? null : Number(row.of_id),
-        of_numero: row.of_numero,
+        of_numero:
+          typeof snapshot.of_number === "string" && snapshot.of_number.trim() !== ""
+            ? snapshot.of_number
+            : row.of_numero,
         // Before the first scan, expose the authoritative lot provenance.  A
         // later verification/correction snapshot is still preferred because it
         // is the immutable evidence used by the prepared BL.
-        mp_reference: typeof snapshot.mp_reference === "string" ? snapshot.mp_reference : row.mp_reference,
-        tr_reference: typeof snapshot.tr_reference === "string" ? snapshot.tr_reference : row.tr_reference,
+        mp_reference:
+          typeof snapshot.mp_reference === "string" && snapshot.mp_reference.trim() !== ""
+            ? snapshot.mp_reference
+            : row.mp_reference,
+        tr_reference:
+          typeof snapshot.tr_reference === "string" && snapshot.tr_reference.trim() !== ""
+            ? snapshot.tr_reference
+            : row.tr_reference,
         verified_qty: verifiedQty,
         verified_at: row.verified_at,
       }
@@ -3646,14 +3693,52 @@ export async function repoVerifyPreparationLot(
           (r.qty_reserved - r.qty_consumed - r.qty_prepared)::float8 AS qty_available,
           l.lot_code,
           l.id::text AS lot_id,
-          ofa.numero AS of_numero,
-          l.mp_reference,
-          l.tr_reference,
+          COALESCE(NULLIF(ofa.numero, ''), lot_trace.of_reference) AS of_numero,
+          COALESCE(lot_trace.mp_reference, NULLIF(l.mp_reference, '')) AS mp_reference,
+          COALESCE(lot_trace.tr_reference, NULLIF(l.tr_reference, '')) AS tr_reference,
           r.article_id::text AS article_id,
           r.source_scope
         FROM public.stock_reservations r
         JOIN public.lots l ON l.id = r.lot_id
         LEFT JOIN public.ordres_fabrication ofa ON ofa.id = r.of_id
+        LEFT JOIN LATERAL (
+          SELECT
+            (
+              SELECT string_agg(reference_value, ' · ' ORDER BY reference_value)
+              FROM (
+                SELECT DISTINCT reference_value
+                FROM (
+                  SELECT reference.reference_value
+                  FROM public.stock_lot_trace_references reference
+                  WHERE reference.lot_id = r.lot_id AND reference.reference_type = 'OF'
+                  UNION ALL
+                  SELECT fabrication.numero
+                  FROM public.of_output_lots output
+                  JOIN public.ordres_fabrication fabrication ON fabrication.id = output.of_id
+                  WHERE output.lot_id = r.lot_id
+                ) values_of(reference_value)
+                WHERE reference_value IS NOT NULL AND btrim(reference_value) <> ''
+              ) distinct_of
+            ) AS of_reference,
+            (
+              SELECT string_agg(reference_value, ' · ' ORDER BY reference_value)
+              FROM (
+                SELECT DISTINCT reference.reference_value
+                FROM public.stock_lot_trace_references reference
+                WHERE reference.lot_id = r.lot_id AND reference.reference_type = 'MP_LOT'
+                  AND btrim(reference.reference_value) <> ''
+              ) distinct_mp(reference_value)
+            ) AS mp_reference,
+            (
+              SELECT string_agg(reference_value, ' · ' ORDER BY reference_value)
+              FROM (
+                SELECT DISTINCT reference.reference_value
+                FROM public.stock_lot_trace_references reference
+                WHERE reference.lot_id = r.lot_id AND reference.reference_type = 'TRAITEMENT_LOT'
+                  AND btrim(reference.reference_value) <> ''
+              ) distinct_tr(reference_value)
+            ) AS tr_reference
+        ) lot_trace ON r.lot_id IS NOT NULL
         WHERE r.id = $1::uuid AND r.status = 'ACTIVE'
         FOR UPDATE OF r, l
       `,

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -6093,7 +6093,7 @@ export async function repoCreateHistoricalImport(body: HistoricalImportBodyDTO, 
     if (!movementId) throw new Error("Unable to post historical opening movement");
     await client.query(`INSERT INTO public.stock_movement_lines (movement_id,line_no,article_id,lot_id,qty,unite,dst_magasin_id,dst_emplacement_id,created_by,updated_by) VALUES ($1::uuid,1,$2::uuid,$3::uuid,$4,$5,$6::uuid,$7::bigint,$8,$8)`, [movementId, articleId, lotId, body.quantity, body.kind === "MP" ? body.unite ?? null : null, position.magasinId, position.emplacementId, audit.user_id]);
     await insertMovementEvent(client, { movement_id: movementId, event_type: "CREATED_POSTED", old_values: null, new_values: { status: "POSTED", source: "CERP_HISTORICAL_OPENING" }, user_id: audit.user_id });
-    const result: HistoricalStockImport = { article_id: articleId, lot_id: lotId, movement_id: movementId, stock_trace_code: trace, qr_payload: `CERP-STOCK:${trace}`, replayed: false };
+    const result: HistoricalStockImport = { article_id: articleId, lot_id: lotId, lot_code: lotCode, movement_id: movementId, stock_trace_code: trace, qr_payload: `CERP-STOCK:${trace}`, replayed: false };
     await insertAuditLog(client, audit, { action: "stock.historical-import.create", entity_type: "stock_movements", entity_id: movementId, details: { kind: body.kind, article_id: articleId, lot_id: lotId, stock_scope: "OLD" } });
     await completeStockCommand(client, { audit, command, command_type: "MOVEMENT_CREATE", resource_type: "stock_movement", resource_id: movementId, result_payload: result });
     await client.query("COMMIT");

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -6,7 +6,7 @@ export type Paginated<T> = {
   total: number;
 };
 
-export type HistoricalStockImport = { article_id: string; lot_id: string; movement_id: string; stock_trace_code: string; qr_payload: string; replayed: boolean };
+export type HistoricalStockImport = { article_id: string; lot_id: string; lot_code: string; movement_id: string; stock_trace_code: string; qr_payload: string; replayed: boolean };
 export type ConsolidatedInventoryRow = {
   article_id: string; article_code: string; article_designation: string; old_material_definition: string | null; scope: "OLD" | "NEW";
   article_reference: string | null; piece_indice: string | null; client_code: string | null;


### PR DESCRIPTION
Promotion validée de dev vers main après la PR #694.

La préparation BL retrouve la traçabilité canonique OF/MP/TR et l'entrée OLD retourne le numéro de lot destiné à l'impression locale. Aucun patch ni migration BDD.

Contrôles locaux : build, typage, tests de contrat et frontière de données.

## Summary by Sourcery

Restore authoritative lot traceability for delivery preparation and expose lot numbers from legacy stock imports.

New Features:
- Restore canonical OF, material-lot, and treatment-lot traceability when preparing delivery slips.
- Return the generated lot number in historical stock import responses for local printing.

Bug Fixes:
- Prefer verified traceability snapshots only when they contain meaningful values, preserving authoritative lot provenance otherwise.

Tests:
- Extend contract coverage for canonical lot traceability and historical-import lot numbers.