### PR TITLE
feat(livraisons): finaliser le BL et sa traçabilité

### DIFF
--- a/src/__tests__/stock-delivery-repositories.pg.integration.test.ts
+++ b/src/__tests__/stock-delivery-repositories.pg.integration.test.ts
@@ -1012,9 +1012,10 @@ describePg("stock/delivery repositories — isolated PostgreSQL invariants", () 
       commande_id: number | null;
       affaire_id: number | null;
       adresse_livraison_id: string | null;
+      statut: string;
     }>(
       `SELECT client_id::text, commande_id::bigint::int, affaire_id::bigint::int,
-              adresse_livraison_id::text
+              adresse_livraison_id::text, statut
        FROM public.bon_livraison
        WHERE id = $1::uuid`,
       [result.id]
@@ -1033,6 +1034,7 @@ describePg("stock/delivery repositories — isolated PostgreSQL invariants", () 
         commande_id: null,
         affaire_id: null,
         adresse_livraison_id: ids.deliveryAddress,
+        statut: "READY",
       },
     ]);
     expect(lines.rows).toEqual([{ commande_ligne_id: 43 }, { commande_ligne_id: 45 }]);
@@ -1108,7 +1110,7 @@ describePg("stock/delivery repositories — isolated PostgreSQL invariants", () 
       [ids.reservation]
     );
     const preparedBlCount = await harnessPool.query<{ count: string }>(
-      `SELECT COUNT(*)::text AS count FROM public.bon_livraison WHERE statut = 'DRAFT'`
+      `SELECT COUNT(*)::text AS count FROM public.bon_livraison WHERE statut = 'READY'`
     );
     expect(preparedReservation.rows).toEqual([{ qty_prepared: 5, qty_consumed: 0 }]);
     expect(countValue(preparedBlCount.rows[0])).toBe(1);
@@ -1116,7 +1118,6 @@ describePg("stock/delivery repositories — isolated PostgreSQL invariants", () 
     const preparation = successfulPreparation.value;
     const preview = await deliveryRepository.repoGetLivraisonPreparationPreview(preparation.id);
     if (!preview) throw new Error("Expected a preparation preview");
-    await harnessPool.query(`UPDATE public.bon_livraison SET statut = 'READY' WHERE id = $1::uuid`, [preparation.id]);
     await harnessPool.query(
       `INSERT INTO public.bon_livraison_pack_versions (bon_livraison_id, version, status) VALUES ($1::uuid, 1, 'GENERATED')`,
       [preparation.id]

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -676,6 +676,7 @@ type HeaderRow = {
   numero: string
   statut: BonLivraisonStatut
   client_id: string
+  client_code: string | null
   client_company_name: string
   commande_id: string | null
   commande_numero: string | null
@@ -720,6 +721,7 @@ async function getHeader(client: PoolClient, id: string, opts?: { forUpdate?: bo
       bl.numero,
       bl.statut,
       bl.client_id,
+      c.client_code,
       c.company_name AS client_company_name,
       bl.commande_id::text AS commande_id,
       cc.numero AS commande_numero,
@@ -847,7 +849,11 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
       id: headerRow.id,
       numero: headerRow.numero,
       statut: headerRow.statut,
-      client: { client_id: headerRow.client_id, company_name: headerRow.client_company_name },
+      client: {
+        client_id: headerRow.client_id,
+        client_code: headerRow.client_code,
+        company_name: headerRow.client_company_name,
+      },
       commande: headerRow.commande_id && headerRow.commande_numero ? { id: toInt(headerRow.commande_id, "bon_livraison.commande_id"), numero: headerRow.commande_numero } : null,
       commande_numeros: headerRow.commande_numeros,
       affaire: headerRow.affaire_id && headerRow.affaire_reference ? { id: toInt(headerRow.affaire_id, "bon_livraison.affaire_id"), reference: headerRow.affaire_reference } : null,
@@ -969,6 +975,18 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
       stock_batch_id: string | null
       reservation_id: string | null
       reservation_status: string | null
+      source_scope: "OLD" | "NEW"
+      commande_numero: string | null
+      affaire_reference: string | null
+      article_reference: string | null
+      article_indice: string | null
+      article_version: number | null
+      quantite_commandee: string | number | null
+      quantite_restante: string | number | null
+      of_numero: string | null
+      mp_reference: string | null
+      tr_reference: string | null
+      verified_at: string | null
       stock_movement_line_id: string | null
       quantite: string | number
       unite: string | null
@@ -1002,6 +1020,42 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
         a.stock_batch_id::text AS stock_batch_id,
         a.reservation_id::text AS reservation_id,
         reservation.status AS reservation_status,
+        CASE WHEN COALESCE(reservation.source_scope, lot.source_scope, 'NEW') = 'OLD' THEN 'OLD' ELSE 'NEW' END AS source_scope,
+        commande.numero AS commande_numero,
+        allocation_affaire.reference AS affaire_reference,
+        COALESCE(
+          NULLIF(technical_version.plan_reference, ''),
+          NULLIF(applicable_version.plan_reference, ''),
+          NULLIF(l.code_piece, '')
+        ) AS article_reference,
+        COALESCE(
+          NULLIF(technical_version.indice, ''),
+          NULLIF(applicable_version.indice, ''),
+          article.plan_index::text
+        ) AS article_indice,
+        COALESCE(technical_version.version_interne, applicable_version.version_interne)::int AS article_version,
+        commande_allocation.qty_ordered AS quantite_commandee,
+        CASE
+          WHEN delivery.statut IN ('DRAFT', 'READY')
+            THEN GREATEST(0, COALESCE(commande_allocation.qty_remaining, commande_allocation.qty_ordered, 0) - a.quantite)
+          ELSE GREATEST(0, COALESCE(commande_allocation.qty_remaining, 0))
+        END AS quantite_restante,
+        COALESCE(
+          NULLIF(a.verification_snapshot->>'of_number', ''),
+          NULLIF(fabrication.numero, ''),
+          lot_trace.of_reference
+        ) AS of_numero,
+        COALESCE(
+          NULLIF(a.verification_snapshot->>'mp_reference', ''),
+          lot_trace.mp_reference,
+          NULLIF(lot.mp_reference, '')
+        ) AS mp_reference,
+        COALESCE(
+          NULLIF(a.verification_snapshot->>'tr_reference', ''),
+          lot_trace.tr_reference,
+          NULLIF(lot.tr_reference, '')
+        ) AS tr_reference,
+        a.verified_at::text AS verified_at,
         a.stock_movement_line_id::text AS stock_movement_line_id,
         a.quantite,
         a.unite,
@@ -1017,10 +1071,72 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
         ub.surname AS updated_by_surname
       FROM public.bon_livraison_ligne_allocations a
       JOIN public.bon_livraison_ligne l ON l.id = a.bon_livraison_ligne_id
+      JOIN public.bon_livraison delivery ON delivery.id = l.bon_livraison_id
       LEFT JOIN public.lots lot ON lot.id = a.lot_id
+      LEFT JOIN public.articles article ON article.id = a.article_id
       LEFT JOIN public.magasins magasin ON magasin.id = a.magasin_id
       LEFT JOIN public.emplacements emplacement ON emplacement.id = a.emplacement_id
       LEFT JOIN public.stock_reservations reservation ON reservation.id = a.reservation_id
+      LEFT JOIN public.commande_ligne_affaire_allocation commande_allocation
+        ON commande_allocation.id = a.commande_ligne_affaire_allocation_id
+      LEFT JOIN public.commande_client commande ON commande.id = commande_allocation.commande_id
+      LEFT JOIN public.affaire allocation_affaire
+        ON allocation_affaire.id = commande_allocation.livraison_affaire_id
+      LEFT JOIN public.ordres_fabrication fabrication ON fabrication.id = reservation.of_id
+      LEFT JOIN public.piece_technique_versions technical_version
+        ON technical_version.id = lot.piece_technique_version_id
+      LEFT JOIN LATERAL (
+        SELECT version.plan_reference, version.indice, version.version_interne
+        FROM public.piece_technique_versions version
+        WHERE version.piece_technique_id = article.piece_technique_id
+        ORDER BY
+          version.is_current DESC,
+          (lower(version.statut) = 'applicable') DESC,
+          version.updated_at DESC,
+          version.created_at DESC,
+          version.id ASC
+        LIMIT 1
+      ) applicable_version ON true
+      LEFT JOIN LATERAL (
+        SELECT
+          (
+            SELECT string_agg(reference_value, ' · ' ORDER BY reference_value)
+            FROM (
+              SELECT DISTINCT reference_value
+              FROM (
+                SELECT reference.reference_value
+                FROM public.stock_lot_trace_references reference
+                WHERE reference.lot_id = a.lot_id AND reference.reference_type = 'OF'
+                UNION ALL
+                SELECT linked_of.numero
+                FROM public.of_output_lots output
+                JOIN public.ordres_fabrication linked_of ON linked_of.id = output.of_id
+                WHERE output.lot_id = a.lot_id
+              ) values_of(reference_value)
+              WHERE reference_value IS NOT NULL AND btrim(reference_value) <> ''
+            ) distinct_of
+          ) AS of_reference,
+          (
+            SELECT string_agg(reference_value, ' · ' ORDER BY reference_value)
+            FROM (
+              SELECT DISTINCT reference.reference_value
+              FROM public.stock_lot_trace_references reference
+              WHERE reference.lot_id = a.lot_id
+                AND reference.reference_type = 'MP_LOT'
+                AND btrim(reference.reference_value) <> ''
+            ) distinct_mp(reference_value)
+          ) AS mp_reference,
+          (
+            SELECT string_agg(reference_value, ' · ' ORDER BY reference_value)
+            FROM (
+              SELECT DISTINCT reference.reference_value
+              FROM public.stock_lot_trace_references reference
+              WHERE reference.lot_id = a.lot_id
+                AND reference.reference_type = 'TRAITEMENT_LOT'
+                AND btrim(reference.reference_value) <> ''
+            ) distinct_tr(reference_value)
+          ) AS tr_reference
+      ) lot_trace ON a.lot_id IS NOT NULL
       LEFT JOIN users cb ON cb.id = a.created_by
       LEFT JOIN users ub ON ub.id = a.updated_by
       WHERE l.bon_livraison_id = $1::uuid
@@ -1046,6 +1162,22 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
         stock_batch_id: r.stock_batch_id,
         reservation_id: r.reservation_id,
         reservation_status: r.reservation_status,
+        source_scope: r.source_scope,
+        commande_numero: r.commande_numero,
+        affaire_reference: r.affaire_reference,
+        article_reference: r.article_reference,
+        article_indice: r.article_indice,
+        article_version: r.article_version,
+        quantite_commandee: r.quantite_commandee === null
+          ? null
+          : toFloat(r.quantite_commandee, "bon_livraison_ligne_allocations.quantite_commandee"),
+        quantite_restante: r.quantite_restante === null
+          ? null
+          : toFloat(r.quantite_restante, "bon_livraison_ligne_allocations.quantite_restante"),
+        of_numero: r.of_numero,
+        mp_reference: r.mp_reference,
+        tr_reference: r.tr_reference,
+        verified_at: r.verified_at,
         stock_movement_line_id: r.stock_movement_line_id,
         quantite: toFloat(r.quantite, "bon_livraison_ligne_allocations.quantite"),
         unite: r.unite,
@@ -5055,8 +5187,17 @@ export async function repoCreateLivraisonFromReservations(params: {
       bon_livraison_id: bonLivraisonId,
       event_type: "CREATED_FROM_RESERVATIONS",
       user_id: userId,
-      new_values: { reservation_ids: ids, preview_hash: previewHash },
+      new_values: { reservation_ids: ids, preview_hash: previewHash, statut: "DRAFT" },
     })
+
+    // The preparation cart only accepts already-active command reservations
+    // whose physical lots were verified before this transaction. Reuse the
+    // canonical preparation command in the same transaction so the BL opens
+    // directly as READY without a misleading second "reserve stock" action.
+    // This also rebinds the existing reservations to their BL lines and keeps
+    // the usual PREPARATION_READY event/audit trail.
+    await prepareLivraisonInTransaction(db, bonLivraisonId, userId)
+
     const result = { id: bonLivraisonId, numero, shipping_version: 1, preview_hash: previewHash }
     await db.query(
       `

--- a/src/module/livraisons/types/livraisons.types.ts
+++ b/src/module/livraisons/types/livraisons.types.ts
@@ -31,6 +31,7 @@ export type UserLite = {
 
 export type ClientLite = {
   client_id: string
+  client_code?: string | null
   company_name: string
 }
 
@@ -131,6 +132,18 @@ export type BonLivraisonLigneAllocation = {
   stock_batch_id: string | null
   reservation_id: string | null
   reservation_status: string | null
+  source_scope: "OLD" | "NEW"
+  commande_numero: string | null
+  affaire_reference: string | null
+  article_reference: string | null
+  article_indice: string | null
+  article_version: number | null
+  quantite_commandee: number | null
+  quantite_restante: number | null
+  of_numero: string | null
+  mp_reference: string | null
+  tr_reference: string | null
+  verified_at: string | null
   stock_movement_line_id: string | null
   quantite: number
   unite: string | null

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -6588,8 +6588,9 @@ export async function repoListMovements(filters: ListMovementsQueryDTO): Promise
       a.code AS article_code,
       a.designation AS article_designation,
       COALESCE(technical_version.plan_reference, latest_version.plan_reference) AS article_reference,
-      technical_version.id::text AS piece_technique_version_id,
-      technical_version.indice AS piece_technique_indice,
+      COALESCE(technical_version.id, latest_version.id)::text AS piece_technique_version_id,
+      COALESCE(technical_version.indice, latest_version.indice) AS piece_technique_indice,
+      COALESCE(technical_version.version_interne, latest_version.version_interne)::int AS piece_technique_version,
       CASE
         WHEN m.movement_type::text = 'IN' THEN 'IN'
         WHEN m.movement_type::text IN ('OUT','SCRAP','DEPRECIATE') THEN 'OUT'
@@ -6629,7 +6630,7 @@ export async function repoListMovements(filters: ListMovementsQueryDTO): Promise
     LEFT JOIN public.piece_technique_versions technical_version
       ON technical_version.id = movement_version.version_id
     LEFT JOIN LATERAL (
-      SELECT version.plan_reference
+      SELECT version.id, version.plan_reference, version.indice, version.version_interne
       FROM public.piece_technique_versions version
       WHERE version.piece_technique_id = a.piece_technique_id
       ORDER BY (version.statut = 'APPLICABLE') DESC, version.is_current DESC,

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -464,6 +464,7 @@ export type StockMovementListItem = {
   article_reference: string | null;
   piece_technique_version_id: string | null;
   piece_technique_indice: string | null;
+  piece_technique_version: number | null;
   direction: "IN" | "OUT" | "TRANSFER" | null;
   qty_total: number;
   effective_at: string;


### PR DESCRIPTION
Closes #693

- valide directement les BL issus des réservations sans seconde réservation
- expose la traçabilité canonique OF/MP/TR et les références de commande/affaire/article par lot
- enrichit les mouvements stock avec la version technique

Validation : build et 5 201 tests passent ; 36 tests PostgreSQL dédiés restent volontairement ignorés sans base d’intégration locale. Aucun changement de schéma.

## Summary by Sourcery

Finalize delivery-note preparation by automatically validating eligible reservations and exposing complete traceability across deliveries and stock movements.

New Features:
- Expose canonical OF/MP/TR traceability and order, project, and article references on delivery-note allocations.
- Include technical article version information in stock movement listings.

Bug Fixes:
- Automatically transition delivery notes created from eligible reservations to READY without requiring a second reservation step.

Enhancements:
- Expose client codes and allocation verification and quantity details in delivery-note responses.

Tests:
- Update PostgreSQL integration expectations to reflect automatic READY delivery-note preparation.