### PR TITLE
fix(db): autoriser le patch de rapprochement cible

### DIFF
--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -93,6 +93,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "6eed117fb4cd8f76fe178eea4bf9ba0c3083683dcf73075da3dab105d9f139d0",
   "20260901_stock_inventory_draft_adjustments.sql":
     "d1e06779acbf657dd68521762d45432a81f8aefdec870541bb38e4c9fab81117",
+  "20260902_customer_order_reconciliation_698.sql":
+    "df4b000e8db91dc7bf37fb0bb54b37a48cc1cc404427276faef409bd5c60d6c1",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";


### PR DESCRIPTION
## Objet
- enregistre le correctif SQL de rapprochement commande/devis dans la liste immuable
- permet un déploiement ciblé avec --only sans exécuter d'autres migrations

## Validation
- 21 tests du runner de migrations passent
- statut ciblé vérifié sur la base locale de test

Closes #698

## Summary by Sourcery

Enable targeted execution of the customer-order reconciliation database patch.

Bug Fixes:
- Allow targeted deployment of the customer-order reconciliation database patch without running unrelated migrations.

Enhancements:
- Register the customer-order reconciliation patch in the immutable patch list with its integrity checksum.