### PR TITLE
fix(deploy): rétablir le build Coolify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN printf '%s\n' \
       "https://dl-cdn.alpinelinux.org/alpine/v3.24/community" \
       > /etc/apk/repositories \
   && apk add --no-cache \
-    "curl=8.21.0-r0" \
+    "curl=8.22.0-r0" \
     "tini=0.19.0-r3" \
     "su-exec=0.3-r0" \
     "clamav=1.4.6-r0" \


### PR DESCRIPTION
## Correctif
- actualise le verrou Alpine de curl de 8.21.0-r0 vers 8.22.0-r0
- conserve tous les autres paquets runtime verrouillés

## Validation
- résolution simulée avec l'image Node et le digest exacts du Dockerfile
- les 26 paquets runtime, dont ClamAV, sont disponibles ensemble